### PR TITLE
fix typo

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -48,7 +48,7 @@ type ListSchedulesOptions struct {
 
 type ListSchedulesResponse struct {
 	APIListObject
-	Schdules []Schedule
+	Schedules []Schedule
 }
 
 func (c *Client) ListSchedules(o ListSchedulesOptions) (*ListSchedulesResponse, error) {


### PR DESCRIPTION
Found while exploring the API. It took me a few minutes to notice the field name "Schdules" contained a typo.