### PR TITLE
Add team_ids[] query string arg

### DIFF
--- a/client.go
+++ b/client.go
@@ -23,8 +23,8 @@ type APIObject struct {
 type APIListObject struct {
 	Limit  uint `url:"limit,omitempty"`
 	Offset uint `url:"offset,omitempty"`
-	More   bool
-	Total  uint
+	More   bool `url:"more,omitempty"`
+	Total  uint `url:"total,omitempty"`
 }
 
 // Client wraps http client

--- a/user.go
+++ b/user.go
@@ -47,6 +47,7 @@ type ListUsersResponse struct {
 type ListUserOptions struct {
 	APIListObject
 	Query    string   `url:"query,omitempty"`
+	TeamIDs  []string `url:"team_ids,omitempty,brackets"`
 	Includes []string `url:"include,omitempty,brackets"`
 }
 


### PR DESCRIPTION
I added the field in the ListUserOptions struct that produces the team_ids[] query string param. I also cleaned up the APIListObject struct adding a field tag to make the resultant query string params conform to other qs params (i.e. lowercase and omitempty).