### PR TITLE
fix misspelling in trigger_summary_data's JSON key.

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -15,7 +15,7 @@ type IncidentDetail struct {
 	Service               string           `json:"service"`
 	AssignedToUser        *json.RawMessage `json:"assigned_to_user"`
 	AssignedTo            []string         `json:"assigned_to"`
-	TriggerSummaryData    *json.RawMessage `json:"trigger_summary_daya"`
+	TriggerSummaryData    *json.RawMessage `json:"trigger_summary_data"`
 	TriggerDeatilsHTMLUrl string           `json:"trigger_details_html_url"`
 }
 


### PR DESCRIPTION
This is a simple misspelling that I caught while reading the documentation.