### PR TITLE
Fix misspelling in User struct and add JSON tags

### DIFF
--- a/user.go
+++ b/user.go
@@ -28,7 +28,6 @@ type NotificationRule struct {
 // User is a member of a PagerDuty account that has the ability to interact with incidents and other data on the account.
 type User struct {
 	APIObject
-	ID                string `json:"id"`
 	Name              string `json:"name"`
 	Email             string `json:"email"`
 	Timezone          string `json:"timezone,omitempty"`

--- a/user.go
+++ b/user.go
@@ -28,17 +28,18 @@ type NotificationRule struct {
 // User is a member of a PagerDuty account that has the ability to interact with incidents and other data on the account.
 type User struct {
 	APIObject
-	Name              string
-	Email             string
-	Timezone          string
-	Color             string
-	Role              string
-	AvatarURL         string `json:"avatar_url"`
-	Description       string
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	Email             string `json:"email"`
+	Timezone          string `json:"timezone,omitempty"`
+	Color             string `json:"color,omitempty"`
+	Role              string `json:"role,omitempty"`
+	AvatarURL         string `json:"avatar_url,omitempty"`
+	Description       string `json:"description,omitempty"`
 	InvitationSent    bool
 	ContactMethods    []ContactMethod    `json:"contact_methods"`
 	NotificationRules []NotificationRule `json:"notification_rules"`
-	JobTitle          string             `json:"jon_title"`
+	JobTitle          string             `json:"job_title,omitempty"`
 	Teams             []Team
 }
 


### PR DESCRIPTION
Hi,
I'm using this library in a Terraform provider and noticed that I can't really create a user with the current `User` struct.

I modified the `User` struct like this to get it to work. 

**Please note that I'm very new to Go and my code might have faults in it, 
but at least I got it to work with this change.**