### PR TITLE
Make updates to Escalation Policies work

### DIFF
--- a/escalation_policy.go
+++ b/escalation_policy.go
@@ -90,7 +90,9 @@ func (c *Client) GetEscalationPolicy(id string, o *GetEscalationPolicyOptions) (
 
 // UpdateEscalationPolicy updates an existing escalation policy and its rules.
 func (c *Client) UpdateEscalationPolicy(id string, e *EscalationPolicy) (*EscalationPolicy, error) {
-	resp, err := c.put(escPath+"/"+id, e, nil)
+	data := make(map[string]EscalationPolicy)
+	data["escalation_policy"] = *e
+	resp, err := c.put(escPath+"/"+id, data, nil)
 	return getEscalationPolicyFromResponse(c, resp, err)
 }
 


### PR DESCRIPTION
Hi,
when trying to update an already existing escalation policy I noticed that no actual changes were made. I tried for example to change NumLoops (5 => 1) and no changes were registered.

With this change I got it to work, but maybe I missed something?