### PR TITLE
Skip JSON encoding if no payload was given

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,11 +59,15 @@ func (c *Client) delete(path string) (*http.Response, error) {
 }
 
 func (c *Client) put(path string, payload interface{}, headers *map[string]string) (*http.Response, error) {
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return nil, err
+
+	if payload != nil {
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		return c.do("PUT", path, bytes.NewBuffer(data), headers)
 	}
-	return c.do("PUT", path, bytes.NewBuffer(data), headers)
+	return c.do("PUT", path, nil, headers)
 }
 
 func (c *Client) post(path string, payload interface{}) (*http.Response, error) {


### PR DESCRIPTION
This solves the issue when calling `AddUserToTeam()`, 
but there might be a better/cleaner way of solving this.

The API response (if successful returns 204) and no payload is necessary when calling `PUT	/teams/{id}/users/{user_id}`.

https://v2.developer.pagerduty.com/v2/page/api-reference#!/Teams/put_teams_id_users_user_id

