### PR TITLE
Remove subdomain argument from escalation_policy example.

### DIFF
--- a/examples/escalation_policies.go
+++ b/examples/escalation_policies.go
@@ -12,7 +12,7 @@ var (
 
 func main() {
 	var opts pagerduty.ListEscalationPoliciesOptions
-	client := pagerduty.NewClient(subdomain, authtoken)
+	client := pagerduty.NewClient(authtoken)
 	if eps, err := client.ListEscalationPolicies(opts); err != nil {
 		panic(err)
 	} else {


### PR DESCRIPTION
PR #19 removed the subdomain from pagerduty.NewClient. This example was
not changed and fails the build when running the build task of the
Makefile.