### PR TITLE
Augment Channel for other possible fields

### DIFF
--- a/log_entry.go
+++ b/log_entry.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+
 	"github.com/google/go-querystring/query"
 )
 
@@ -10,7 +11,10 @@ type Agent APIObject
 
 // Channel is the means by which the action was carried out.
 type Channel struct {
-	Type string
+	Type    string
+	Details string
+	Subject string
+	Summary string
 }
 
 // LogEntry is a list of all of the events that happened to an incident.


### PR DESCRIPTION
Hi!

We've found ourselves really wanting the "Details" from the channel field within the first trigger log entry, and noticed that the struct in this library doesn't include it as a field. I'm hoping we can augment that struct so we can access it within our project. The commit contains a bit more context as well.

I couldn't find much documentation about channels, so I don't know if this will cause any bad effects, but it _appears_ to me that these four fields are consistent.

Apologies for the little whitespace change; I can recommit without if need be. My go linting tool does that automatically.

Thanks for reviewing!
