### PR TITLE
Schedule restriction - Add support for start_day_of_week

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -2,14 +2,16 @@ package pagerduty
 
 import (
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"net/http"
+
+	"github.com/google/go-querystring/query"
 )
 
 // Restriction limits on-call responsibility for a layer to certain times of the day or week.
 type Restriction struct {
 	Type            string `json:"type,omitempty"`
 	StartTimeOfDay  string `json:"start_time_of_day,omitempty"`
+	StartDayOfWeek  uint   `json:"start_day_of_week,omitempty"`
 	DurationSeconds uint   `json:"duration_seconds,omitempty"`
 }
 


### PR DESCRIPTION
Hi,

this adds support for `start_day_of_week`. 
Without `start_day_of_week` set, a restriction with type `weekly_restriction` will fail with:

```
Failed call API endpoint. HTTP response code: 400. Error: &{2001 Invalid Input Provided [Start day of week must be in 1, 2, 3, 4, 5, 6, 7, 1, 2, 3, 4, 5, 6, or 7.]}
```