### PR TITLE
Incident - Add status field to incident

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+
 	"github.com/google/go-querystring/query"
 )
 
@@ -39,6 +40,7 @@ type Incident struct {
 	EscalationPolicy     APIObject         `json:"escalation_policy,omitempty"`
 	Teams                []APIObject       `json:"teams,omitempty"`
 	Urgency              string            `json:"urgency,omitempty"`
+	Status               string            `json:"status,omitempty"`
 }
 
 // ListIncidentsResponse is the response structure when calling the ListIncident API endpoint.


### PR DESCRIPTION
This PR adds the field `"status"` to Incident, tested against a set of incidents.

Example response:
```json
{
 "type": "incident",
 "status": "resolved",
 "created_at": "2016-12-15T10:44:07Z",
  ...
}
```