### PR TITLE
Added missing slash to delete integration method url

### DIFF
--- a/service.go
+++ b/service.go
@@ -165,7 +165,7 @@ func (c *Client) UpdateIntegration(serviceID string, i Integration) (*Integratio
 
 // DeleteIntegration deletes an existing integration.
 func (c *Client) DeleteIntegration(serviceID string, integrationID string) error {
-	_, err := c.delete("/services/" + serviceID + "/integrations" + integrationID)
+	_, err := c.delete("/services/" + serviceID + "/integrations/" + integrationID)
 	return err
 }
 


### PR DESCRIPTION
Seems the `DeleteIntegration` method gives a 404 due to a missing slash before the integration ID query param. This patches that up.