### PR TITLE
Fix JSON decode (errorObject)

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,9 +37,9 @@ type APIReference struct {
 }
 
 type errorObject struct {
-	Code   int      `json:"code,omitempty"`
-	Mesage string   `json:"message,omitempty"`
-	Errors []string `json:"errors,omitempty"`
+	Code    int         `json:"code,omitempty"`
+	Message string      `json:"message,omitempty"`
+	Errors  interface{} `json:"errors,omitempty"`
 }
 
 // Client wraps http client


### PR DESCRIPTION
This PR aims to solve the following error when trying to decode the JSON response:

Current:
```bash
Response did not contain formatted error: Could not decode JSON response: json: cannot unmarshal object into Go struct field errorObject.errors of type []string. HTTP response code: 400. Raw response: &{Status:400 Bad Request StatusCode:400 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Date:[Mon, 30 Jan 2017 19:08:00 GMT] Content-Type:[application/json; charset=utf-8] Access-Control-Allow-Headers:[Authorization, Content-Type] X-Ua-Compatible:[IE=Edge,chrome=1] Connection:[keep-alive] Access-Control-Allow-Origin:[*] Access-Control-Max-Age:[1728000] Cache-Control:[no-cache] X-Request-Id:[acde0a61602cd216ae1c1d66831bf0ed] Server:[nginx] Status:[400 Bad Request] Access-Control-Allow-Methods:[GET, POST, PUT, DELETE, OPTIONS]] Body:0xc42018e480 ContentLength:-1 TransferEncoding:[chunked] Close:false Uncompressed:false Trailer:map[] Request:0xc4204f8100 TLS:0xc42009c370}
```

After:
```bash
Failed call API endpoint. HTTP response code: 400. Error: &{3001 Invalid Schedule map[rotation_layers.weekly_restrictions.duration_seconds:[Please use a shorter duration or just turn the recurrence off.]]}
```

Without this, one would have to actually call the API manually or via the API reference to figure out what the actual error was, this can hopefully solve most error cases. 

Since API errors might come back a bit different (see below) I changed `Errors` to `interface{}` to prevent JSON decode errors. Also fixed a typo in `errorObject`.

Example error responses:
```json
{
  "error": {
  "message": "Invalid Schedule",
  "code": 3001,
  "errors": {
    "rotation_layers.weekly_restrictions.duration_seconds": [
      "Please use a shorter duration or just turn the recurrence off."
    ]
  }
}
```

```json
{
  "error": {
    "message": "Invalid Input Provided",
    "code": 2001,
    "errors": [
      "Time zone must be a valid time zone string."
    ]
  }
}
```