### PR TITLE
Add query to vendor

### DIFF
--- a/vendor.go
+++ b/vendor.go
@@ -30,6 +30,7 @@ type ListVendorResponse struct {
 // ListVendorOptions is the data structure used when calling the ListVendors API endpoint.
 type ListVendorOptions struct {
 	APIListObject
+	Query string `url:"query,omitempty"`
 }
 
 // ListVendors lists existing vendors.


### PR DESCRIPTION
This PR adds support for querying vendors.

This allows us to easier find vendors by name.

Example:
```go
client.ListVendors(&pagerduty.ListVendorOptions{
    Query: "Datadog",
}
```

Tested and seems to work quite well.