### PR TITLE
Fixing Maintenance typo

### DIFF
--- a/command/maintenance_window_create.go
+++ b/command/maintenance_window_create.go
@@ -59,7 +59,7 @@ func (c *MaintenanceWindowCreate) Run(args []string) int {
 		return -1
 	}
 	log.Debugf("%#v", m)
-	if _, err := client.CreateMaintaienanceWindows(m); err != nil {
+	if _, err := client.CreateMaintenanceWindows(m); err != nil {
 		log.Error(err)
 		return -1
 	}

--- a/maintenance_window.go
+++ b/maintenance_window.go
@@ -48,8 +48,8 @@ func (c *Client) ListMaintenanceWindows(o ListMaintenanceWindowsOptions) (*ListM
 	return &result, c.decodeJSON(resp, &result)
 }
 
-// CreateMaintaienanceWindows creates a new maintenance window for the specified services.
-func (c *Client) CreateMaintaienanceWindows(m MaintenanceWindow) (*MaintenanceWindow, error) {
+// CreateMaintenanceWindows creates a new maintenance window for the specified services.
+func (c *Client) CreateMaintenanceWindows(m MaintenanceWindow) (*MaintenanceWindow, error) {
 	data := make(map[string]MaintenanceWindow)
 	data["maintenance_window"] = m
 	resp, err := c.post("/mainteance_windows", data)

--- a/maintenance_window.go
+++ b/maintenance_window.go
@@ -52,13 +52,13 @@ func (c *Client) ListMaintenanceWindows(o ListMaintenanceWindowsOptions) (*ListM
 func (c *Client) CreateMaintenanceWindows(m MaintenanceWindow) (*MaintenanceWindow, error) {
 	data := make(map[string]MaintenanceWindow)
 	data["maintenance_window"] = m
-	resp, err := c.post("/mainteance_windows", data)
+	resp, err := c.post("/maintenance_windows", data)
 	return getMaintenanceWindowFromResponse(c, resp, err)
 }
 
 // DeleteMaintenanceWindow deletes an existing maintenance window if it's in the future, or ends it if it's currently on-going.
 func (c *Client) DeleteMaintenanceWindow(id string) error {
-	_, err := c.delete("/mainteance_windows/" + id)
+	_, err := c.delete("/maintenance_windows/" + id)
 	return err
 }
 
@@ -73,7 +73,7 @@ func (c *Client) GetMaintenanceWindow(id string, o GetMaintenanceWindowOptions) 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/mainteance_windows/" + id + "?" + v.Encode())
+	resp, err := c.get("/maintenance_windows/" + id + "?" + v.Encode())
 	return getMaintenanceWindowFromResponse(c, resp, err)
 }
 


### PR DESCRIPTION
Was previously `CreateMaintaienanceWindows`, changed to `CreateMaintenanceWindows`, however this is a breaking API change if users are accessing the typo version.