### PR TITLE
Fix inconsistency with some REST Options objects passed by reference …

### DIFF
--- a/escalation_policy.go
+++ b/escalation_policy.go
@@ -90,7 +90,7 @@ type GetEscalationPolicyOptions struct {
 }
 
 // GetEscalationPolicy gets information about an existing escalation policy and its rules.
-func (c *Client) GetEscalationPolicy(id string, o *GetEscalationPolicyOptions) (*EscalationPolicy, error) {
+func (c *Client) GetEscalationPolicy(id string, o GetEscalationPolicyOptions) (*EscalationPolicy, error) {
 	v, err := query.Values(o)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ func (c *Client) CreateEscalationRule(escID string, e EscalationRule) (*Escalati
 }
 
 // GetEscalationRule gets information about an existing escalation rule.
-func (c *Client) GetEscalationRule(escID string, id string, o *GetEscalationRuleOptions) (*EscalationRule, error) {
+func (c *Client) GetEscalationRule(escID string, id string, o GetEscalationRuleOptions) (*EscalationRule, error) {
 	v, err := query.Values(o)
 	if err != nil {
 		return nil, err

--- a/service.go
+++ b/service.go
@@ -109,7 +109,7 @@ type GetServiceOptions struct {
 }
 
 // GetService gets details about an existing service.
-func (c *Client) GetService(id string, o *GetServiceOptions) (*Service, error) {
+func (c *Client) GetService(id string, o GetServiceOptions) (*Service, error) {
 	v, err := query.Values(o)
 	resp, err := c.get("/services/" + id + "?" + v.Encode())
 	return getServiceFromResponse(c, resp, err)


### PR DESCRIPTION
…instead of by value.

All other method signatures for requests pass the *Options* object by value and not by reference. This PR updates three outlier function signatures for consistency with the rest of the library.