### PR TITLE
[incidents] fix entries typo in a few places

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -148,13 +148,13 @@ func (c *Client) SnoozeIncident(id string, duration uint) error {
 	return err
 }
 
-// ListIncidentLogEntriesResponse is the response structure when calling the ListIncidentLogEntires API endpoint.
+// ListIncidentLogEntriesResponse is the response structure when calling the ListIncidentLogEntries API endpoint.
 type ListIncidentLogEntriesResponse struct {
 	APIListObject
-	LogEntires []LogEntry `json:"log_entries,omitempty"`
+	LogEntries []LogEntry `json:"log_entries,omitempty"`
 }
 
-// ListIncidentLogEntriesOptions is the structure used when passing parameters to the ListIncidentLogEntires API endpoint.
+// ListIncidentLogEntriesOptions is the structure used when passing parameters to the ListIncidentLogEntries API endpoint.
 type ListIncidentLogEntriesOptions struct {
 	APIListObject
 	Includes   []string `url:"include,omitempty,brackets"`
@@ -162,7 +162,7 @@ type ListIncidentLogEntriesOptions struct {
 	TimeZone   string   `url:"time_zone,omitempty"`
 }
 
-// ListIncidentLogEntries lists existing log entires for the specified incident.
+// ListIncidentLogEntries lists existing log entries for the specified incident.
 func (c *Client) ListIncidentLogEntries(id string, o ListIncidentLogEntriesOptions) (*ListIncidentLogEntriesResponse, error) {
 	v, err := query.Values(o)
 	if err != nil {


### PR DESCRIPTION
There are a few places where `entries` is spelled `entires` in various incidents functions.  This simply fixes those issues.