### PR TITLE
Fixed invalid JSON descriptor for FirstTriggerLogEntry

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -36,7 +36,7 @@ type Incident struct {
 	Acknowledgements     []Acknowledgement `json:"acknowledgements,omitempty"`
 	LastStatusChangeAt   string            `json:"last_status_change_at,omitempty"`
 	LastStatusChangeBy   APIObject         `json:"last_status_change_by,omitempty"`
-	FirstTriggerLogEntry APIObject         `json:"last_trigger_log_entry,omitempty"`
+	FirstTriggerLogEntry APIObject         `json:"first_trigger_log_entry,omitempty"`
 	EscalationPolicy     APIObject         `json:"escalation_policy,omitempty"`
 	Teams                []APIObject       `json:"teams,omitempty"`
 	Urgency              string            `json:"urgency,omitempty"`


### PR DESCRIPTION
Previously the FirstTriggerLogEntry in the struct Incident used "last_trigger_log_entry" as it's underlying JSON description. However, the Pagerduty REST API will return "first_trigger_log_entry". This will cause the FirstTriggerLogEntry to always be empty.
This commit changes the JSON descriptor to "first_trigger_log_entry" and fixes the problem.