### PR TITLE
Get user's contact methods

### DIFF
--- a/user.go
+++ b/user.go
@@ -13,6 +13,9 @@ type ContactMethod struct {
 	Address        string
 	Type           string
 	SendShortEmail bool `json:"send_short_email"`
+	Summary        string
+	HTMLUrl        string `json:"hmtl_url"`
+	SendHTMLEmail  bool   `json:"send_html_email"`
 }
 
 // NotificationRule is a rule for notifying the user.
@@ -40,6 +43,12 @@ type User struct {
 	NotificationRules []NotificationRule `json:"notification_rules"`
 	JobTitle          string             `json:"job_title,omitempty"`
 	Teams             []Team
+}
+
+// ContactMethodResponse is the data structure returned from calling the GetUserContactMethod API endpoint.
+type ContactMethodResponse struct {
+	ContactMethods []ContactMethod `json:"contact_methods"`
+	Total          int
 }
 
 // ListUsersResponse is the data structure returned from calling the ListUsers API endpoint.
@@ -97,6 +106,17 @@ func (c *Client) GetUser(id string, o GetUserOptions) (*User, error) {
 	}
 	resp, err := c.get("/users/" + id + "?" + v.Encode())
 	return getUserFromResponse(c, resp, err)
+}
+
+// GetUserContactMethod fetches contact methods of the existing user.
+func (c *Client) GetUserContactMethod(id string) (*ContactMethodResponse, error) {
+	resp, err := c.get("/users/" + id + "/contact_methods")
+	if err != nil {
+		return nil, err
+	}
+
+	var result ContactMethodResponse
+	return &result, c.decodeJSON(resp, &result)
 }
 
 // UpdateUser updates an existing user.


### PR DESCRIPTION
The API call to get a user's contact method was missing.

The `GetUserContactMethod` added to `user.go` calls the following API call:

`GET	/users/{id}/contact_methods/{contact_method_id}`
[API Documentation ](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Users/get_users_id_contact_methods_contact_method_id)

Changes:
* Updated ContactMethod struct to include Summary, HTMLUrl, SendHTMLEmail.
* Added ContactMethodResponse struct to handle API response
* Added GetUserContactMethod method to retrieve a user's contact methods (by user id)