### PR TITLE
Add oncall details

### DIFF
--- a/event_v2.go
+++ b/event_v2.go
@@ -1,0 +1,63 @@
+package pagerduty
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Event includes the incident/alert details
+type V2Event struct {
+	RoutingKey string        `json:"routing_key"`
+	Action     string        `json:"event_action"`
+	DedupKey   string        `json:"dedup_key,omitempty"`
+	Images     []interface{} `json:"images,omitempty"`
+	Client     string        `json:"client,omitempty"`
+	ClientURL  string        `json:"client_url,omitempty"`
+	Payload    *V2Payload    `json:"payload,omitempty"`
+}
+
+// Payload represents the individual event details for an event
+type V2Payload struct {
+	Summary   string      `json:"summary"`
+	Source    string      `json:"source"`
+	Severity  string      `json:"severity"`
+	Timestamp string      `json:"timestamp,omitempty"`
+	Component string      `json:"component,omitempty"`
+	Group     string      `json:"group,omitempty"`
+	Class     string      `json:"class,omitempty"`
+	Details   interface{} `json:"custom_details,omitempty"`
+}
+
+// Response is the json response body for an event
+type V2EventResponse struct {
+	RoutingKey  string `json:"routing_key"`
+	DedupKey    string `json:"dedup_key"`
+	EventAction string `json:"event_action"`
+}
+
+const v2eventEndPoint = "https://events.pagerduty.com/v2/enqueue"
+
+// ManageEvent handles the trigger, acknowledge, and resolve methods for an event
+func ManageEvent(e V2Event) (*V2EventResponse, error) {
+	data, err := json.Marshal(e)
+	if err != nil {
+		return nil, err
+	}
+	req, _ := http.NewRequest("POST", eventEndPoint, bytes.NewBuffer(data))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		return nil, fmt.Errorf("HTTP Status Code: %d", resp.StatusCode)
+	}
+	var eventResponse V2EventResponse
+	if err := json.NewDecoder(resp.Body).Decode(&eventResponse); err != nil {
+		return nil, err
+	}
+	return &eventResponse, nil
+}

--- a/incident.go
+++ b/incident.go
@@ -1,6 +1,8 @@
 package pagerduty
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"github.com/google/go-querystring/query"
@@ -41,6 +43,12 @@ type Incident struct {
 	Teams                []APIObject       `json:"teams,omitempty"`
 	Urgency              string            `json:"urgency,omitempty"`
 	Status               string            `json:"status,omitempty"`
+}
+
+type CreateIncidentOptions struct {
+	APIObject
+	Title   string       `json:"title,omitempty"`
+	Service APIReference `json:"service,omitempty"`
 }
 
 // ListIncidentsResponse is the response structure when calling the ListIncident API endpoint.
@@ -130,6 +138,23 @@ func (c *Client) ListIncidentNotes(id string) ([]IncidentNote, error) {
 		return nil, fmt.Errorf("JSON response does not have notes field")
 	}
 	return notes, nil
+}
+
+// CreateIncident creates a new incident.
+func (c *Client) CreateIncident(from string, incident CreateIncidentOptions) error {
+	data := make(map[string]CreateIncidentOptions)
+	data["incident"] = incident
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.do("POST", "/incidents", bytes.NewBuffer(b), &map[string]string{
+		"From": from,
+	})
+
+	return err
 }
 
 // CreateIncidentNote creates a new note for the specified incident.

--- a/on_call.go
+++ b/on_call.go
@@ -6,12 +6,12 @@ import (
 
 // OnCall represents a contiguous unit of time for which a user will be on call for a given escalation policy and escalation rule.
 type OnCall struct {
-	User             APIObject `json:"user,omitempty"`
-	Schedule         APIObject `json:"schedule,omitempty"`
-	EscalationPolicy APIObject `json:"escalation_policy,omitempty"`
-	EscalationLevel  uint      `json:"escalation_level,omitempty"`
-	Start            string    `json:"start,omitempty"`
-	End              string    `json:"end,omitempty"`
+	User             User             `json:"user,omitempty"`
+	Schedule         Schedule         `json:"schedule,omitempty"`
+	EscalationPolicy EscalationPolicy `json:"escalation_policy,omitempty"`
+	EscalationLevel  uint             `json:"escalation_level,omitempty"`
+	Start            string           `json:"start,omitempty"`
+	End              string           `json:"end,omitempty"`
 }
 
 // ListOnCallsResponse is the data structure returned from calling the ListOnCalls API endpoint.


### PR DESCRIPTION
When you request additional details by setting `Includes` to `users,schedules`, you won't get access to the requested information because their mapped types are set to the basic `APIObject` and thus does not contain any data beyond an ID and a Summary, although the JSON response contains more details.