### PR TITLE
Add support for v2 ManageEvent api call

### DIFF
--- a/event_v2.go
+++ b/event_v2.go
@@ -46,7 +46,7 @@ func ManageEvent(e V2Event) (*V2EventResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, _ := http.NewRequest("POST", eventEndPoint, bytes.NewBuffer(data))
+	req, _ := http.NewRequest("POST", v2eventEndPoint, bytes.NewBuffer(data))
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/event_v2.go
+++ b/event_v2.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -53,7 +54,11 @@ func ManageEvent(e V2Event) (*V2EventResponse, error) {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusAccepted {
-		return nil, fmt.Errorf("HTTP Status Code: %d", resp.StatusCode)
+		bytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("HTTP Status Code: %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("HTTP Status Code: %d, Message: %s", resp.StatusCode, string(bytes))
 	}
 	var eventResponse V2EventResponse
 	if err := json.NewDecoder(resp.Body).Decode(&eventResponse); err != nil {

--- a/event_v2.go
+++ b/event_v2.go
@@ -1,0 +1,63 @@
+package pagerduty
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Event includes the incident/alert details
+type V2Event struct {
+	RoutingKey string        `json:"routing_key"`
+	Action     string        `json:"event_action"`
+	DedupKey   string        `json:"dedup_key,omitempty"`
+	Images     []interface{} `json:"images,omitempty"`
+	Client     string        `json:"client,omitempty"`
+	ClientURL  string        `json:"client_url,omitempty"`
+	Payload    *V2Payload    `json:"payload,omitempty"`
+}
+
+// Payload represents the individual event details for an event
+type V2Payload struct {
+	Summary   string      `json:"summary"`
+	Source    string      `json:"source"`
+	Severity  string      `json:"severity"`
+	Timestamp string      `json:"timestamp,omitempty"`
+	Component string      `json:"component,omitempty"`
+	Group     string      `json:"group,omitempty"`
+	Class     string      `json:"class,omitempty"`
+	Details   interface{} `json:"custom_details,omitempty"`
+}
+
+// Response is the json response body for an event
+type V2EventResponse struct {
+	RoutingKey  string `json:"routing_key"`
+	DedupKey    string `json:"dedup_key"`
+	EventAction string `json:"event_action"`
+}
+
+const v2eventEndPoint = "https://events.pagerduty.com/v2/enqueue"
+
+// ManageEvent handles the trigger, acknowledge, and resolve methods for an event
+func ManageEvent(e V2Event) (*V2EventResponse, error) {
+	data, err := json.Marshal(e)
+	if err != nil {
+		return nil, err
+	}
+	req, _ := http.NewRequest("POST", eventEndPoint, bytes.NewBuffer(data))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		return nil, fmt.Errorf("HTTP Status Code: %d", resp.StatusCode)
+	}
+	var eventResponse V2EventResponse
+	if err := json.NewDecoder(resp.Body).Decode(&eventResponse); err != nil {
+		return nil, err
+	}
+	return &eventResponse, nil
+}


### PR DESCRIPTION
I took the liberty of adding the spike by @tmccleve from #83 to my fork in order to support creation of v2 API events. The code is almost identically to the v1 code that is already in the package apart from the JSON structures and the endpoint url.