### PR TITLE
Add oncall details

### DIFF
--- a/on_call.go
+++ b/on_call.go
@@ -6,12 +6,12 @@ import (
 
 // OnCall represents a contiguous unit of time for which a user will be on call for a given escalation policy and escalation rule.
 type OnCall struct {
-	User             APIObject `json:"user,omitempty"`
-	Schedule         APIObject `json:"schedule,omitempty"`
-	EscalationPolicy APIObject `json:"escalation_policy,omitempty"`
-	EscalationLevel  uint      `json:"escalation_level,omitempty"`
-	Start            string    `json:"start,omitempty"`
-	End              string    `json:"end,omitempty"`
+	User             User             `json:"user,omitempty"`
+	Schedule         Schedule         `json:"schedule,omitempty"`
+	EscalationPolicy EscalationPolicy `json:"escalation_policy,omitempty"`
+	EscalationLevel  uint             `json:"escalation_level,omitempty"`
+	Start            string           `json:"start,omitempty"`
+	End              string           `json:"end,omitempty"`
 }
 
 // ListOnCallsResponse is the data structure returned from calling the ListOnCalls API endpoint.


### PR DESCRIPTION
When you request additional details by setting `Includes` to `users,schedules`, you won't get access to the requested information because their mapped types are set to the basic `APIObject` and thus does not contain any data beyond an ID and a Summary, although the JSON response contains more details.