### PR TITLE
Add support for incident creation

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -1,6 +1,8 @@
 package pagerduty
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 
 	"github.com/google/go-querystring/query"
@@ -41,6 +43,12 @@ type Incident struct {
 	Teams                []APIObject       `json:"teams,omitempty"`
 	Urgency              string            `json:"urgency,omitempty"`
 	Status               string            `json:"status,omitempty"`
+}
+
+type CreateIncidentOptions struct {
+	APIObject
+	Title   string       `json:"title,omitempty"`
+	Service APIReference `json:"service,omitempty"`
 }
 
 // ListIncidentsResponse is the response structure when calling the ListIncident API endpoint.
@@ -130,6 +138,23 @@ func (c *Client) ListIncidentNotes(id string) ([]IncidentNote, error) {
 		return nil, fmt.Errorf("JSON response does not have notes field")
 	}
 	return notes, nil
+}
+
+// CreateIncident creates a new incident.
+func (c *Client) CreateIncident(from string, incident CreateIncidentOptions) error {
+	data := make(map[string]CreateIncidentOptions)
+	data["incident"] = incident
+
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.do("POST", "/incidents", bytes.NewBuffer(b), &map[string]string{
+		"From": from,
+	})
+
+	return err
 }
 
 // CreateIncidentNote creates a new note for the specified incident.

--- a/incident.go
+++ b/incident.go
@@ -47,8 +47,11 @@ type Incident struct {
 
 type CreateIncidentOptions struct {
 	APIObject
-	Title   string       `json:"title,omitempty"`
-	Service APIReference `json:"service,omitempty"`
+	Title            string       `json:"title,omitempty"`
+	Service          APIReference `json:"service,omitempty"`
+	IncidentKey      string       `json:"incident_key,omitempty"`
+	EscalationPolicy APIObject    `json:"escalation_policy,omitempty"`
+	Assignments      []Assignment `json:"assignments,omitempty"`
 }
 
 // ListIncidentsResponse is the response structure when calling the ListIncident API endpoint.


### PR DESCRIPTION
The current version of the client does not allow creation of incidents for services. This PR changes that.