### PR TITLE
Try out CircleCI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,11 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/golang:1.8.3
+    working_directory: /go/src/github.com/PagerDuty/go-pagerduty
+    steps:
+      - checkout
+      - run:
+          name: "Build"
+          command: make build


### PR DESCRIPTION
I noticed that some other PD projects are using CircleCI so I decided to see if I could get this one running as well.

The build times aren't crazy different from Travis but it's an improved. The last few Travis builds completed at just under 1 minute. The [CircleCI build](https://circleci.com/gh/felicianotech/go-pagerduty/2) I tried ran in 23 seconds.

If interested, this can be run alongside or instead of Travis. Any questions, optimizations needed, please let me know.