### PR TITLE
Allow caller to specify a *http.Client

### DIFF
--- a/client.go
+++ b/client.go
@@ -45,12 +45,19 @@ type errorObject struct {
 // Client wraps http client
 type Client struct {
 	authToken string
+	client    *http.Client
 }
 
 // NewClient creates an API client
 func NewClient(authToken string) *Client {
+	return NewClientWithHTTPClient(authToken, http.DefaultClient)
+}
+
+// NewClientWithHTTPClient creates an API client with a specific *http.Client.
+func NewClientWithHTTPClient(authToken string, client *http.Client) *Client {
 	return &Client{
 		authToken: authToken,
+		client:    client,
 	}
 }
 
@@ -94,7 +101,7 @@ func (c *Client) do(method, path string, body io.Reader, headers *map[string]str
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Token token="+c.authToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.client.Do(req)
 	return c.checkResponse(resp, err)
 }
 

--- a/event.go
+++ b/event.go
@@ -28,15 +28,22 @@ type EventResponse struct {
 	IncidentKey string `json:"incident_key"`
 }
 
-// CreateEvent sends PagerDuty an event to report, acknowledge, or resolve a problem.
+// CreateEvent sends PagerDuty an event to report, acknowledge, or resolve a
+// problem using the http.DefaultClient.
 func CreateEvent(e Event) (*EventResponse, error) {
+	return CreateEventWithHTTPClient(e, http.DefaultClient)
+}
+
+// CreateEvent sends PagerDuty an event to report, acknowledge, or resolve a
+// problem using the provided *http.Client.
+func CreateEventWithHTTPClient(e Event, client *http.Client) (*EventResponse, error) {
 	data, err := json.Marshal(e)
 	if err != nil {
 		return nil, err
 	}
 	req, _ := http.NewRequest("POST", eventEndPoint, bytes.NewBuffer(data))
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow *http.Client to be injected so that go-pagerduty can be used in environments where the http.DefaultClient cannot be used (e.g. Google AppEngine standard environment)