### PR TITLE
Add MergeIncidents (using Incident)

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -90,6 +90,17 @@ func (c *Client) ManageIncidents(from string, incidents []Incident) error {
 	return e
 }
 
+// MergeIncidents
+// Uses Incident to match ManageIncidents
+func (c *Client) MergeIncidents(from string, id string, incidents []Incident) error {
+	r := make(map[string][]Incident)
+	r["source_incidents"] = incidents
+	headers := make(map[string]string)
+	headers["From"] = from
+	_, e := c.put("/incidents/" + id + "/merge", r, &headers)
+	return e
+}
+
 // GetIncident shows detailed information about an incident.
 func (c *Client) GetIncident(id string) (*Incident, error) {
 	resp, err := c.get("/incidents/" + id)


### PR DESCRIPTION
Allows for merging of incidents as follows:

    incidents := make([]string, 3)
    incidents[0] = "PXXXXXX"
    incidents[1] = "PYYYYYY"
    incidents[2] = "PZZZZZZ"

    first := incidents[0]
    rest := incidents[1:]

    tomerge := make([]pagerduty.APIObject, 0)

    for i := range rest {
	    inc := pagerduty.Incident{
		APIObject: pagerduty.APIObject{
		    ID:   rest[i],
		    Type: "incident_reference",
		},
	    }
	    tomerge = append(tomerge, inc)
    }
    result := client.MergeIncidents(email, first, tomerge)

Note that this option (using `pagerduty.Incident` most closely matches the existing `ManageIncident`, but since Merge literally only requires the `id` and the `type` of "incident_reference" I've also got an [option 2 branch](https://github.com/atomicules/go-pagerduty/commit/216653aa2e12651f4d919afdff3e95a356a48b26) which uses `pagerduty.APIObject`; I personally think that option 2 is a bit cleaner for actual creation of "objects" for merging, but I guess doesn't sit as well with the existing `ManageIncidents` function.