### PR TITLE
Add CreateIncident to API and cli

### DIFF
--- a/command/incident_create.go
+++ b/command/incident_create.go
@@ -39,11 +39,13 @@ func (c *IncidentCreate) Run(args []string) int {
 	var service string
 	var title string
 	var from string
+	var body string
 	flags := c.Meta.FlagSet("incident create")
 	flags.Usage = func() { fmt.Println(c.Help()) }
 	flags.StringVar(&service, "service", "", "service ID")
 	flags.StringVar(&title, "title", "", "incident title")
 	flags.StringVar(&from, "from", "", "user creating the ticket")
+	flags.StringVar(&body, "body", "", "detailed ticket description")
 
 	if err := flags.Parse(args); err != nil {
 		log.Error(err)
@@ -62,6 +64,12 @@ func (c *IncidentCreate) Run(args []string) int {
 			ID:   service,
 		},
 		Title: title,
+	}
+	if body != "" {
+		opts.Body = pagerduty.Body{
+			Type:    "incident_body",
+			Details: body,
+		}
 	}
 	if incident, err := client.CreateIncident(from, opts); err != nil {
 		log.Error(err)

--- a/command/incident_create.go
+++ b/command/incident_create.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	pagerduty "github.com/PagerDuty/go-pagerduty"
+	log "github.com/Sirupsen/logrus"
+	"github.com/mitchellh/cli"
+	"gopkg.in/yaml.v2"
+)
+
+// IncidentCreate holds the meta data
+type IncidentCreate struct {
+	Meta
+}
+
+// IncidentCreateCommand creates the struct
+func IncidentCreateCommand() (cli.Command, error) {
+	return &IncidentCreate{}, nil
+}
+
+// Help returns how to run the command
+func (c *IncidentCreate) Help() string {
+	helpText := `
+	pd incident create create incident
+
+	`
+	return strings.TrimSpace(helpText)
+}
+
+// Synopsis returns a summary of the command
+func (c *IncidentCreate) Synopsis() string {
+	return "Create incidents"
+}
+
+// Run runs the command
+func (c *IncidentCreate) Run(args []string) int {
+	var service string
+	var title string
+	var from string
+	flags := c.Meta.FlagSet("incident create")
+	flags.Usage = func() { fmt.Println(c.Help()) }
+	flags.StringVar(&service, "service", "", "service ID")
+	flags.StringVar(&title, "title", "", "incident title")
+	flags.StringVar(&from, "from", "", "user creating the ticket")
+
+	if err := flags.Parse(args); err != nil {
+		log.Error(err)
+		return -1
+	}
+
+	if err := c.Meta.Setup(); err != nil {
+		log.Error(err)
+		return -1
+	}
+
+	client := c.Meta.Client()
+	opts := pagerduty.CreateIncidentOptions{
+		Service: pagerduty.APIReference{
+			Type: "service",
+			ID:   service,
+		},
+		Title: title,
+	}
+	if incident, err := client.CreateIncident(from, opts); err != nil {
+		log.Error(err)
+		return -1
+	} else {
+		data, err := yaml.Marshal(incident)
+		if err != nil {
+			log.Error(err)
+			return -1
+		}
+		fmt.Println(string(data))
+
+	}
+	return 0
+}

--- a/command/main.go
+++ b/command/main.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/mitchellh/cli"
 	"os"
+
+	"github.com/mitchellh/cli"
 )
 
 const (

--- a/command/main.go
+++ b/command/main.go
@@ -27,6 +27,7 @@ func loadCommands() map[string]cli.CommandFactory {
 		"escalation-policy update": EscalationPolicyUpdateCommand,
 
 		"incident list":        IncidentListCommand,
+		"incident create":      IncidentCreateCommand,
 		"incident manage":      IncidentManageCommand,
 		"incident show":        IncidentShowCommand,
 		"incident note list":   IncidentNoteListCommand,

--- a/incident.go
+++ b/incident.go
@@ -54,6 +54,14 @@ type CreateIncidentOptions struct {
 	IncidentKey      string       `json:"incident_key,omitempty"`
 	EscalationPolicy APIObject    `json:"escalation_policy,omitempty"`
 	Assignments      []Assignment `json:"assignments,omitempty"`
+	Body             Body         `json:"body,omitempty"`
+}
+
+// Body is the detailed description for a ticket
+// To include, Type must be "incident_body"
+type Body struct {
+	Type    string `json:"type,omitempty"`
+	Details string `json:"details,omitempty"`
 }
 
 // CreateIncidentResponse  is the structure returned from a CreateIncident call.


### PR DESCRIPTION
There is error checking in CreateIncident that more aggressive than other functions, not sure if that should be removed for consistency.

CreateIncidentResponse is a new exported struct, but in CreateIncident, this code returns (*Incident, error), not sure if should make it non-exported, or have CreateIncident return it (although the client will only care about the Incident part of the response)