### PR TITLE
Allow package consumers to provide their own HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ func main() {
 }
 ```
 
+The PagerDuty API client also exposes its HTTP client as the `HTTPClient` field.
+If you need to use your own HTTP client, for doing things like defining your own
+transport settings, you can replace the default HTTP client with your own by
+simply by setting a new value in the `HTTPClient` field.
+
 ## License
 [Apache 2](http://www.apache.org/licenses/LICENSE-2.0)
 

--- a/client.go
+++ b/client.go
@@ -5,7 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"runtime"
+	"time"
 )
 
 const (
@@ -42,15 +45,54 @@ type errorObject struct {
 	Errors  interface{} `json:"errors,omitempty"`
 }
 
+func newDefaultHTTPClient() *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			MaxIdleConns:          10,
+			IdleConnTimeout:       60 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+			MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
+		},
+	}
+}
+
+// HTTPClient is an interface which declares the functionality we need from an
+// HTTP client. This is to allow consumers to provide their own HTTP client as
+// needed, without restricting them to only using *http.Client.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// defaultHTTPClient is our own default HTTP client. We use this, instead of
+// http.DefaultClient, to avoid other packages tweaks to http.DefaultClient
+// causing issues with our HTTP calls. This also allows us to tweak the
+// transport values to be more resilient without making changes to the
+// http.DefaultClient.
+//
+// Keep this unexported so consumers of the package can't make changes to it.
+var defaultHTTPClient HTTPClient = newDefaultHTTPClient()
+
 // Client wraps http client
 type Client struct {
 	authToken string
+
+	// HTTPClient is the HTTP client used for making requests against the
+	// PagerDuty API. You can use either *http.Client here, or your own
+	// implementation.
+	HTTPClient HTTPClient
 }
 
 // NewClient creates an API client
 func NewClient(authToken string) *Client {
 	return &Client{
-		authToken: authToken,
+		authToken:  authToken,
+		HTTPClient: defaultHTTPClient,
 	}
 }
 
@@ -94,7 +136,7 @@ func (c *Client) do(method, path string, body io.Reader, headers *map[string]str
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Token token="+c.authToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.HTTPClient.Do(req)
 	return c.checkResponse(resp, err)
 }
 

--- a/event.go
+++ b/event.go
@@ -28,15 +28,25 @@ type EventResponse struct {
 	IncidentKey string `json:"incident_key"`
 }
 
-// CreateEvent sends PagerDuty an event to report, acknowledge, or resolve a problem.
+// CreateEvent sends PagerDuty an event to trigger, acknowledge, or resolve a
+// problem. If you need to provide a custom HTTP client, please use
+// CreateEventWithHTTPClient.
 func CreateEvent(e Event) (*EventResponse, error) {
+	return CreateEventWithHTTPClient(e, defaultHTTPClient)
+}
+
+// CreateEventWithHTTPClient sends PagerDuty an event to trigger, acknowledge,
+// or resolve a problem. This function accepts a custom HTTP Client, if the
+// default one used by this package doesn't fit your needs. If you don't need a
+// custom HTTP client, please use CreateEvent instead.
+func CreateEventWithHTTPClient(e Event, client HTTPClient) (*EventResponse, error) {
 	data, err := json.Marshal(e)
 	if err != nil {
 		return nil, err
 	}
 	req, _ := http.NewRequest("POST", eventEndPoint, bytes.NewBuffer(data))
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This updates the package to no longer make use of the `http.DefaultClient`, and
to instead use a package-local default client as well as to provide consumers
the ability to provide their own client in the time of need.

The reason for moving away from the `http.DefaultClient` is for two reasons:

1. It prevents other packages from being able to impact this one by making
   changes to the `http.DefaultClient`.

2. The isolation should help make this package more resilient, as we can tweak
   the client's transport settings to provide defaults appropriate for PagerDuty
   usage.

The package-local default client is not directly exposed, so as to hopefully
avoid people making out-of-band changes to its config and to instead provide
their own client.

This also supports the ability for consumers to provide their own HTTP client,
in the situation where the default client doesn't have the settings they need.
The ability to provide this client was done using an interface, `HTTPClient`, so
that consumers aren't forced to make use of `*http.Client` if they don't want
to.

Fixes #110

Signed-off-by: Tim Heckman <t@heckman.io>