### PR TITLE
Create Incident, List Priorities, and headers in POST method support

### DIFF
--- a/addon.go
+++ b/addon.go
@@ -2,8 +2,9 @@ package pagerduty
 
 import (
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"net/http"
+
+	"github.com/google/go-querystring/query"
 )
 
 // Addon is a third-party add-on to PagerDuty's UI.
@@ -46,7 +47,7 @@ func (c *Client) ListAddons(o ListAddonOptions) (*ListAddonResponse, error) {
 func (c *Client) InstallAddon(a Addon) (*Addon, error) {
 	data := make(map[string]Addon)
 	data["addon"] = a
-	resp, err := c.post("/addons", data)
+	resp, err := c.post("/addons", data, nil)
 	defer resp.Body.Close()
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -39,6 +39,11 @@ type APIReference struct {
 	Type string `json:"type,omitempty"`
 }
 
+type APIDetails struct {
+	Type    string `json:"type,omitempty"`
+	Details string `json:"details,omitempty"`
+}
+
 type errorObject struct {
 	Code    int         `json:"code,omitempty"`
 	Message string      `json:"message,omitempty"`
@@ -112,12 +117,12 @@ func (c *Client) put(path string, payload interface{}, headers *map[string]strin
 	return c.do("PUT", path, nil, headers)
 }
 
-func (c *Client) post(path string, payload interface{}) (*http.Response, error) {
+func (c *Client) post(path string, payload interface{}, headers *map[string]string) (*http.Response, error) {
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
 	}
-	return c.do("POST", path, bytes.NewBuffer(data), nil)
+	return c.do("POST", path, bytes.NewBuffer(data), headers)
 }
 
 func (c *Client) get(path string) (*http.Response, error) {

--- a/escalation_policy.go
+++ b/escalation_policy.go
@@ -74,7 +74,7 @@ func (c *Client) ListEscalationPolicies(o ListEscalationPoliciesOptions) (*ListE
 func (c *Client) CreateEscalationPolicy(e EscalationPolicy) (*EscalationPolicy, error) {
 	data := make(map[string]EscalationPolicy)
 	data["escalation_policy"] = e
-	resp, err := c.post(escPath, data)
+	resp, err := c.post(escPath, data, nil)
 	return getEscalationPolicyFromResponse(c, resp, err)
 }
 
@@ -112,7 +112,7 @@ func (c *Client) UpdateEscalationPolicy(id string, e *EscalationPolicy) (*Escala
 func (c *Client) CreateEscalationRule(escID string, e EscalationRule) (*EscalationRule, error) {
 	data := make(map[string]EscalationRule)
 	data["escalation_rule"] = e
-	resp, err := c.post(escPath+"/"+escID+"/escalation_rules", data)
+	resp, err := c.post(escPath+"/"+escID+"/escalation_rules", data, nil)
 	return getEscalationRuleFromResponse(c, resp, err)
 }
 

--- a/incident.go
+++ b/incident.go
@@ -86,8 +86,8 @@ type CreateIncident struct {
 	Incident CreateIncidentValue `json:"incident"`
 }
 
-// CreateIncidentResponse is returned from the API when creating a response.
-type CreateIncidentResponse struct {
+// createIncidentResponse is returned from the API when creating a response.
+type createIncidentResponse struct {
 	Incident Incident `json:incident`
 }
 
@@ -103,7 +103,7 @@ type CreateIncidentValue struct {
 }
 
 // CreateIncident creates an incident synchronously without a corresponding event from a monitoring service.
-func (c *Client) CreateIncidents(from string, i *CreateIncident) (*Incident, error) {
+func (c *Client) CreateIncident(from string, i *CreateIncident) (*Incident, error) {
 	headers := make(map[string]string)
 	headers["From"] = from
 	resp, e := c.post("/incidents", i, &headers)
@@ -111,7 +111,7 @@ func (c *Client) CreateIncidents(from string, i *CreateIncident) (*Incident, err
 		return nil, e
 	}
 
-	var ii CreateIncidentResponse
+	var ii createIncidentResponse
 	e = json.NewDecoder(resp.Body).Decode(&ii)
 	if e != nil {
 		return nil, e

--- a/incident.go
+++ b/incident.go
@@ -81,9 +81,14 @@ func (c *Client) ListIncidents(o ListIncidentsOptions) (*ListIncidentsResponse, 
 	return &result, c.decodeJSON(resp, &result)
 }
 
-//
+// CreateIncident is the structure POST'd to the incidents endpoint. It wraps a CreateIncidentValue
 type CreateIncident struct {
 	Incident CreateIncidentValue `json:"incident"`
+}
+
+// CreatedIncidentResponse is returned from the API when creating a response.
+type CreatedIncidentResponse struct {
+	Incident Incident `json:incident`
 }
 
 // CreateIncidentValue is the structure used when POSTing to the CreateIncident API endpoint.
@@ -106,13 +111,13 @@ func (c *Client) CreateIncidents(from string, i *CreateIncident) (*Incident, err
 		return nil, e
 	}
 
-	var ii Incident
+	var ii CreatedIncidentResponse
 	e = json.NewDecoder(resp.Body).Decode(&ii)
 	if e != nil {
 		return nil, e
 	}
 
-	return &ii, nil
+	return &ii.Incident, nil
 }
 
 // ManageIncidents acknowledges, resolves, escalates, or reassigns one or more incidents.

--- a/incident.go
+++ b/incident.go
@@ -83,7 +83,7 @@ func (c *Client) ListIncidents(o ListIncidentsOptions) (*ListIncidentsResponse, 
 
 // CreateIncident is the structure POST'd to the incidents endpoint. It wraps a CreateIncidentValue
 type CreateIncident struct {
-	Incident CreateIncidentValue `json:"incident"`
+	Incident CreateIncidentOptions `json:"incident"`
 }
 
 // createIncidentResponse is returned from the API when creating a response.
@@ -91,8 +91,8 @@ type createIncidentResponse struct {
 	Incident Incident `json:incident`
 }
 
-// CreateIncidentValue is the structure used when POSTing to the CreateIncident API endpoint.
-type CreateIncidentValue struct {
+// CreateIncidentOptions is the structure used when POSTing to the CreateIncident API endpoint.
+type CreateIncidentOptions struct {
 	Type             string       `json:"type"`
 	Title            string       `json:"title"`
 	Service          APIReference `json:"service"`

--- a/incident.go
+++ b/incident.go
@@ -101,7 +101,7 @@ type CreateIncident struct {
 }
 
 // CreateIncident creates an incident synchronously without a corresponding event from a monitoring service.
-func (c *Client) CreateIncidents(o CreateIncidentOptions, i CreateIncident) (Incident, error) {
+func (c *Client) CreateIncidents(o CreateIncidentOptions, i *CreateIncident) (*Incident, error) {
 	headers := make(map[string]string)
 	headers["From"] = o.From
 	resp, e := c.post("/incidents", i, &headers)
@@ -115,7 +115,7 @@ func (c *Client) CreateIncidents(o CreateIncidentOptions, i CreateIncident) (Inc
 		return nil, e
 	}
 
-	return ii, nil
+	return &ii, nil
 }
 
 // ManageIncidents acknowledges, resolves, escalates, or reassigns one or more incidents.
@@ -124,7 +124,7 @@ func (c *Client) ManageIncidents(from string, incidents []Incident) error {
 	headers := make(map[string]string)
 	headers["From"] = from
 	r["incidents"] = incidents
-	resp, e := c.put("/incidents", r, &headers)
+	_, e := c.put("/incidents", r, &headers)
 	return e
 }
 
@@ -174,7 +174,7 @@ func (c *Client) ListIncidentNotes(id string) ([]IncidentNote, error) {
 func (c *Client) CreateIncidentNote(id string, note IncidentNote) error {
 	data := make(map[string]IncidentNote)
 	data["note"] = note
-	_, err := c.post("/incidents/"+id+"/notes", data)
+	_, err := c.post("/incidents/"+id+"/notes", data, nil)
 	return err
 }
 
@@ -182,7 +182,7 @@ func (c *Client) CreateIncidentNote(id string, note IncidentNote) error {
 func (c *Client) SnoozeIncident(id string, duration uint) error {
 	data := make(map[string]uint)
 	data["duration"] = duration
-	_, err := c.post("/incidents/"+id+"/snooze", data)
+	_, err := c.post("/incidents/"+id+"/snooze", data, nil)
 	return err
 }
 

--- a/incident.go
+++ b/incident.go
@@ -81,17 +81,20 @@ func (c *Client) ListIncidents(o ListIncidentsOptions) (*ListIncidentsResponse, 
 	return &result, c.decodeJSON(resp, &result)
 }
 
-// CreateIncident is the structure used when POSTing to the CreateIncident API endpoint.
+//
 type CreateIncident struct {
-	Incident struct {
-		Type             string       `json:"type"`
-		Title            string       `json:"title"`
-		Service          APIReference `json:"service"`
-		Priority         APIReference `json:"priority"`
-		IncidentKey      string       `json:"incident_key"`
-		Body             APIDetails   `json:"details"`
-		EscalationPolicy APIReference `json:"escalation_policy"`
-	} `json:"incident"`
+	Incident CreateIncidentValue `json:"incident"`
+}
+
+// CreateIncidentValue is the structure used when POSTing to the CreateIncident API endpoint.
+type CreateIncidentValue struct {
+	Type             string       `json:"type"`
+	Title            string       `json:"title"`
+	Service          APIReference `json:"service"`
+	Priority         APIReference `json:"priority"`
+	IncidentKey      string       `json:"incident_key"`
+	Body             APIDetails   `json:"details"`
+	EscalationPolicy APIReference `json:"escalation_policy"`
 }
 
 // CreateIncident creates an incident synchronously without a corresponding event from a monitoring service.

--- a/incident.go
+++ b/incident.go
@@ -81,12 +81,6 @@ func (c *Client) ListIncidents(o ListIncidentsOptions) (*ListIncidentsResponse, 
 	return &result, c.decodeJSON(resp, &result)
 }
 
-// CreateIncidentOptions is the structure used when passing paremters to the CreateIncident API endpoint.
-type CreateIncidentOptions struct {
-	// From is a valid email address appended to a From header when POSTing to the CreateIncident API endpoint.
-	From string
-}
-
 // CreateIncident is the structure used when POSTing to the CreateIncident API endpoint.
 type CreateIncident struct {
 	Incident struct {
@@ -101,16 +95,16 @@ type CreateIncident struct {
 }
 
 // CreateIncident creates an incident synchronously without a corresponding event from a monitoring service.
-func (c *Client) CreateIncidents(o CreateIncidentOptions, i *CreateIncident) (*Incident, error) {
+func (c *Client) CreateIncidents(from string, i *CreateIncident) (*Incident, error) {
 	headers := make(map[string]string)
-	headers["From"] = o.From
+	headers["From"] = from
 	resp, e := c.post("/incidents", i, &headers)
 	if e != nil {
 		return nil, e
 	}
 
 	var ii Incident
-	e = json.NewDecoder(resp.Body).Decode(ii)
+	e = json.NewDecoder(resp.Body).Decode(&ii)
 	if e != nil {
 		return nil, e
 	}

--- a/incident.go
+++ b/incident.go
@@ -86,8 +86,8 @@ type CreateIncident struct {
 	Incident CreateIncidentValue `json:"incident"`
 }
 
-// CreatedIncidentResponse is returned from the API when creating a response.
-type CreatedIncidentResponse struct {
+// CreateIncidentResponse is returned from the API when creating a response.
+type CreateIncidentResponse struct {
 	Incident Incident `json:incident`
 }
 
@@ -98,7 +98,7 @@ type CreateIncidentValue struct {
 	Service          APIReference `json:"service"`
 	Priority         APIReference `json:"priority"`
 	IncidentKey      string       `json:"incident_key"`
-	Body             APIDetails   `json:"details"`
+	Body             APIDetails   `json:"body"`
 	EscalationPolicy APIReference `json:"escalation_policy"`
 }
 
@@ -111,7 +111,7 @@ func (c *Client) CreateIncidents(from string, i *CreateIncident) (*Incident, err
 		return nil, e
 	}
 
-	var ii CreatedIncidentResponse
+	var ii CreateIncidentResponse
 	e = json.NewDecoder(resp.Body).Decode(&ii)
 	if e != nil {
 		return nil, e

--- a/maintenance_window.go
+++ b/maintenance_window.go
@@ -2,8 +2,9 @@ package pagerduty
 
 import (
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"net/http"
+
+	"github.com/google/go-querystring/query"
 )
 
 // MaintenanceWindow is used to temporarily disable one or more services for a set period of time.
@@ -52,7 +53,7 @@ func (c *Client) ListMaintenanceWindows(o ListMaintenanceWindowsOptions) (*ListM
 func (c *Client) CreateMaintenanceWindows(m MaintenanceWindow) (*MaintenanceWindow, error) {
 	data := make(map[string]MaintenanceWindow)
 	data["maintenance_window"] = m
-	resp, err := c.post("/maintenance_windows", data)
+	resp, err := c.post("/maintenance_windows", data, nil)
 	return getMaintenanceWindowFromResponse(c, resp, err)
 }
 

--- a/priorites.go
+++ b/priorites.go
@@ -1,0 +1,33 @@
+package pagerduty
+
+import (
+	"encoding/json"
+)
+
+// PriorityProperty is a single priorty object returned from the Priorities endpoint
+type PriorityProperty struct {
+	APIObject
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type Priorities struct {
+	APIListObject
+	Priorities []PriorityProperty `json:"priorities"`
+}
+
+// ListPriorities lists existing priorities
+func (c *Client) ListPriorities() (*Priorities, error) {
+	resp, e := c.get("/priorites")
+	if e != nil {
+		return nil, e
+	}
+
+	var p Priorities
+	e = json.NewDecoder(resp.Body).Decode(&p)
+	if e != nil {
+		return nil, e
+	}
+
+	return &p, nil
+}

--- a/priorites.go
+++ b/priorites.go
@@ -18,7 +18,7 @@ type Priorities struct {
 
 // ListPriorities lists existing priorities
 func (c *Client) ListPriorities() (*Priorities, error) {
-	resp, e := c.get("/priorites")
+	resp, e := c.get("/priorities")
 	if e != nil {
 		return nil, e
 	}

--- a/schedule.go
+++ b/schedule.go
@@ -84,7 +84,7 @@ func (c *Client) ListSchedules(o ListSchedulesOptions) (*ListSchedulesResponse, 
 func (c *Client) CreateSchedule(s Schedule) (*Schedule, error) {
 	data := make(map[string]Schedule)
 	data["schedule"] = s
-	resp, err := c.post("/schedules", data)
+	resp, err := c.post("/schedules", data, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func (c *Client) PreviewSchedule(s Schedule, o PreviewScheduleOptions) error {
 	}
 	var data map[string]Schedule
 	data["schedule"] = s
-	_, e := c.post("/schedules/preview?"+v.Encode(), data)
+	_, e := c.post("/schedules/preview?"+v.Encode(), data, nil)
 	return e
 }
 
@@ -196,7 +196,7 @@ func (c *Client) ListOverrides(id string, o ListOverridesOptions) ([]Override, e
 func (c *Client) CreateOverride(id string, o Override) (*Override, error) {
 	data := make(map[string]Override)
 	data["override"] = o
-	resp, err := c.post("/schedules/"+id+"/overrides", data)
+	resp, err := c.post("/schedules/"+id+"/overrides", data, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/service.go
+++ b/service.go
@@ -120,7 +120,7 @@ func (c *Client) GetService(id string, o *GetServiceOptions) (*Service, error) {
 func (c *Client) CreateService(s Service) (*Service, error) {
 	data := make(map[string]Service)
 	data["service"] = s
-	resp, err := c.post("/services", data)
+	resp, err := c.post("/services", data, nil)
 	return getServiceFromResponse(c, resp, err)
 }
 
@@ -140,7 +140,7 @@ func (c *Client) DeleteService(id string) error {
 func (c *Client) CreateIntegration(id string, i Integration) (*Integration, error) {
 	data := make(map[string]Integration)
 	data["integration"] = i
-	resp, err := c.post("/services/"+id+"/integrations", data)
+	resp, err := c.post("/services/"+id+"/integrations", data, nil)
 	return getIntegrationFromResponse(c, resp, err)
 }
 

--- a/team.go
+++ b/team.go
@@ -2,8 +2,9 @@ package pagerduty
 
 import (
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"net/http"
+
+	"github.com/google/go-querystring/query"
 )
 
 // Team is a collection of users and escalation policies that represent a group of people within an organization.
@@ -42,7 +43,7 @@ func (c *Client) ListTeams(o ListTeamOptions) (*ListTeamResponse, error) {
 
 // CreateTeam creates a new team.
 func (c *Client) CreateTeam(t *Team) (*Team, error) {
-	resp, err := c.post("/teams", t)
+	resp, err := c.post("/teams", t, nil)
 	return getTeamFromResponse(c, resp, err)
 }
 

--- a/user.go
+++ b/user.go
@@ -2,8 +2,9 @@ package pagerduty
 
 import (
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"net/http"
+
+	"github.com/google/go-querystring/query"
 )
 
 // ContactMethod is a way of contacting the user.
@@ -79,7 +80,7 @@ func (c *Client) ListUsers(o ListUsersOptions) (*ListUsersResponse, error) {
 func (c *Client) CreateUser(u User) (*User, error) {
 	data := make(map[string]User)
 	data["user"] = u
-	resp, err := c.post("/users", data)
+	resp, err := c.post("/users", data, nil)
 	return getUserFromResponse(c, resp, err)
 }
 


### PR DESCRIPTION
Submitting this PR which adds support for POSTing (creating) an incident along with GETing (listing) priorities in the new priorities feature. Willing to change around any struct naming or json construction logic at request. 

Methods added:

client.CreateIncidents
client.ListPriorities 

PR also plumbed header support into POST method on the client. 