### PR TITLE
Add instructions for actually being able to install the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ authtoken: fooBar
 `pd` command provides a single entrypoint for all the API endpoints, with individual
 API represented by their own sub commands. For an exhaustive list of sub-commands, try:
 
+__Install:__
+```
+cd $GOPATH/github.com/PagerDuty/go-pagerduty
+go build -o $GOPATH/bin/pd command/*
+```
+
 ```
 pd --help
 ```


### PR DESCRIPTION
Happy to move these somewhere else but this is the only way you are going to be able to run:

```
pd --help
```

This isn't made obvious to anyone hoping to use it.