### PR TITLE
Add src to cd $GOPATH instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ API represented by their own sub commands. For an exhaustive list of sub-command
 
 __Install:__
 ```
-cd $GOPATH/github.com/PagerDuty/go-pagerduty
+cd $GOPATH/src/github.com/PagerDuty/go-pagerduty
 go build -o $GOPATH/bin/pd command/*
 ```
 


### PR DESCRIPTION
I believe go expects the directory layout to be $GOPATH/src

https://github.com/golang/go/wiki/GOPATH