### PR TITLE
Add the ability to set urgency via the CreateIncident api call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 bin/*
 *.swp
 .idea
-go.mod
-go.sum

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 bin/*
 *.swp
+.idea
+go.mod
+go.sum

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 bin/*
 *.swp
-.idea

--- a/incident.go
+++ b/incident.go
@@ -102,6 +102,7 @@ type CreateIncidentOptions struct {
 	IncidentKey      string       `json:"incident_key"`
 	Body             APIDetails   `json:"body"`
 	EscalationPolicy APIReference `json:"escalation_policy"`
+	Urgency          string       `json:"urgency,omitempty"`
 }
 
 // CreateIncident creates an incident synchronously without a corresponding event from a monitoring service.


### PR DESCRIPTION
This PR adds the urgency field to CreateIncidentOptions struct, such that users can now specify urgency of "low" or "high" when creating an incident via the CreateIncident api. 