### PR TITLE
Work around the LogEntry.Channel field being not well defined.

### DIFF
--- a/log_entry.go
+++ b/log_entry.go
@@ -10,9 +10,14 @@ import (
 type Agent APIObject
 
 // Channel is the means by which the action was carried out.
-type Channel struct {
-	Type string
-}
+//type Channel struct {
+//	Type string
+//}
+
+// Channel is not well defined and uses a variadic type.
+// Making this an interface map makes it possible for the client ot interpret
+// the results instead of eating them.
+type Channel map[string]interface{}
 
 // Context are to be included with the trigger such as links to graphs or images.
 type Context struct {


### PR DESCRIPTION
In order to get access to the event details you need to look into the contents of the channel field. The current go implementation loses all that data because it's "Channel" type only includes the "Type" field. By making this an interface we can walk the dictionary and access the details. I'm not sure if this is the best solution, but I feel it's better than preventing access entirely...

Note: APIs that return different types in the same field make working with them in statically typed languages painful. Maybe you can provide some feedback to the API developers while they are still undecided on the structure of this field.