### PR TITLE
Use pointer to Priority so don't send an empty priority for incident

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -68,7 +68,7 @@ type Incident struct {
 	FirstTriggerLogEntry APIObject         `json:"first_trigger_log_entry,omitempty"`
 	EscalationPolicy     APIObject         `json:"escalation_policy,omitempty"`
 	Teams                []APIObject       `json:"teams,omitempty"`
-	Priority             Priority          `json:"priority,omitempty"`
+	Priority             *Priority         `json:"priority,omitempty"`
 	Urgency              string            `json:"urgency,omitempty"`
 	Status               string            `json:"status,omitempty"`
 	Id                   string            `json:"id,omitempty"`


### PR DESCRIPTION
Due to the changes to the Incident struct the library now inadvertently
sends an empty priority to the API (`"priority":{}`) and for
ManageIncidents this results in a response of:

    Priority id cannot be empty

To prevent sending an empty priority we can use a pointer to Priority.

Seems like a super simple fix for this - and as such I'm worried I've
missed something else.

Full discussion of this in this issue:

References: https://github.com/PagerDuty/go-pagerduty/issues/135