### PR TITLE
Correct JSON payload format for CreateIncident call

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -135,6 +135,8 @@ type CreateIncidentOptions struct {
 func (c *Client) CreateIncident(from string, o *CreateIncidentOptions) (*Incident, error) {
 	headers := make(map[string]string)
 	headers["From"] = from
+	data := make(map[string]*CreateIncidentOptions)
+	data["incident"] = o
 	resp, e := c.post("/incidents", o, &headers)
 	if e != nil {
 		return nil, e

--- a/incident.go
+++ b/incident.go
@@ -137,7 +137,7 @@ func (c *Client) CreateIncident(from string, o *CreateIncidentOptions) (*Inciden
 	headers["From"] = from
 	data := make(map[string]*CreateIncidentOptions)
 	data["incident"] = o
-	resp, e := c.post("/incidents", o, &headers)
+	resp, e := c.post("/incidents", data, &headers)
 	if e != nil {
 		return nil, e
 	}


### PR DESCRIPTION
Fixes https://github.com/PagerDuty/go-pagerduty/issues/165

Unlike other areas of the library the `CreateIncident` function failed to nest the options for the call in a top level `incident` JSON property.

This caused all calls to this function to fail API validation regardless of if they are structured correctly.