### PR TITLE
escalation_policy: support clearing teams from an existing escalation policy

### DIFF
--- a/escalation_policy.go
+++ b/escalation_policy.go
@@ -25,7 +25,7 @@ type EscalationPolicy struct {
 	EscalationRules []EscalationRule `json:"escalation_rules,omitempty"`
 	Services        []APIObject      `json:"services,omitempty"`
 	NumLoops        uint             `json:"num_loops,omitempty"`
-	Teams           []APIReference   `json:"teams,omitempty"`
+	Teams           []APIReference   `json:"teams"`
 	Description     string           `json:"description,omitempty"`
 	RepeatEnabled   bool             `json:"repeat_enabled,omitempty"`
 }


### PR DESCRIPTION
It's currently not possible to clear teams from an existing escalation policy.
This PR fixes that by sending an empty list instead of ignoring the field if it's not set.