### PR TITLE
Adding proper types for Links and Images

### DIFF
--- a/event_v2.go
+++ b/event_v2.go
@@ -10,14 +10,27 @@ import (
 
 // Event includes the incident/alert details
 type V2Event struct {
-	RoutingKey string        `json:"routing_key"`
-	Action     string        `json:"event_action"`
-	DedupKey   string        `json:"dedup_key,omitempty"`
-	Images     []interface{} `json:"images,omitempty"`
-	Links      []interface{} `json:"links,omitempty"`
-	Client     string        `json:"client,omitempty"`
-	ClientURL  string        `json:"client_url,omitempty"`
-	Payload    *V2Payload    `json:"payload,omitempty"`
+	RoutingKey string         `json:"routing_key"`
+	Action     string         `json:"event_action"`
+	DedupKey   string         `json:"dedup_key,omitempty"`
+	Images     []V2EventImage `json:"images,omitempty"`
+	Links      []V2EventLink  `json:"links,omitempty"`
+	Client     string         `json:"client,omitempty"`
+	ClientURL  string         `json:"client_url,omitempty"`
+	Payload    *V2Payload     `json:"payload,omitempty"`
+}
+
+// EventLink is a link to be included on an event
+type V2EventLink struct {
+	Href string `json:"href"`
+	Text string `json:"text"`
+}
+
+// EventImage is an image to be included, with an optional link and alt text
+type V2EventImage struct {
+	Src  string `json:"src"`
+	Href string `json:"href,omitempty"`
+	Alt  string `json:"alt,omitempty"`
 }
 
 // Payload represents the individual event details for an event


### PR DESCRIPTION
I think this is correct? It should make code easier to write instead of writing something like 

```
Links: []interface{}{
			map[string]string{
				"href": "https://link.to.thing/thing",
				"text": "Link",
			},
		},
```

