### PR TITLE
Update ListOverrides to function as ListSchedules does

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -181,6 +181,7 @@ func (c *Client) ListOverrides(id string, o ListOverridesOptions) ([]Override, e
 	if err != nil {
 		return nil, err
 	}
+	fmt.Printf("%+v", resp)
 	var result map[string][]Override
 	if err := c.decodeJSON(resp, &result); err != nil {
 		return nil, err


### PR DESCRIPTION
I repeatedly encountered an error when using ListOverrides as the response from PagerDuty's API could not be correctly marshaled to `[]PagerDuty.Override`

This PR changes the behavior of `ListOverrides` so that it follows the pattern used by `ListSchedules` and as a result, allows proper operation of the endpoint.

This is a breaking change in as much as it changes the type returned by the method, but in my testing at least, the current implementation is broken itself.

Fixes #180 