### PR TITLE
Modify ListOverrides and add ListOverridesResponse

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -163,6 +163,12 @@ type ListOverridesOptions struct {
 	Overflow bool   `url:"overflow,omitempty"`
 }
 
+// ListOverridesResponse is the data structure returned from calling the ListOverrides API endpoint.
+type ListOverridesResponse struct {
+	APIListObject
+	Overrides []Override `json:"overrides,omitempty"`
+}
+
 // Overrides are any schedule layers from the override layer.
 type Override struct {
 	ID    string    `json:"id,omitempty"`
@@ -172,7 +178,7 @@ type Override struct {
 }
 
 // ListOverrides lists overrides for a given time range.
-func (c *Client) ListOverrides(id string, o ListOverridesOptions) ([]Override, error) {
+func (c *Client) ListOverrides(id string, o ListOverridesOptions) (*ListOverridesResponse, error) {
 	v, err := query.Values(o)
 	if err != nil {
 		return nil, err
@@ -181,15 +187,8 @@ func (c *Client) ListOverrides(id string, o ListOverridesOptions) ([]Override, e
 	if err != nil {
 		return nil, err
 	}
-	var result map[string][]Override
-	if err := c.decodeJSON(resp, &result); err != nil {
-		return nil, err
-	}
-	overrides, ok := result["overrides"]
-	if !ok {
-		return nil, fmt.Errorf("JSON response does not have overrides field")
-	}
-	return overrides, nil
+	var result ListOverridesResponse
+	return &result, c.decodeJSON(resp, &result)
 }
 
 // CreateOverride creates an override for a specific user covering the specified time range.


### PR DESCRIPTION
I repeatedly encountered an error when using ListOverrides as the response from PagerDuty's API could not be correctly marshaled to `[]PagerDuty.Override`

This PR changes the behavior of ListOverrides so that it follows the pattern used by ListSchedules and as a result, allows proper operation of the endpoint.

This is a breaking change in as much as it changes the type returned by the method, but in my testing at least, the current implementation is broken itself.

Fixes #180 