### PR TITLE
List team members, single page or all (with helper for auto-pagination)

### DIFF
--- a/client.go
+++ b/client.go
@@ -179,3 +179,38 @@ func (c *Client) getErrorFromResponse(resp *http.Response) (*errorObject, error)
 	}
 	return &s, nil
 }
+
+// responseHandler is capable of parsing a response. At a minimum it must
+// extract the page information for the current page. It can also execute
+// additional necessary handling; for example, if a closure, it has access
+// to the scope in which it was defined, and can be used to append data to
+// a specific slice. The responseHandler is responsible for closing the response.
+type responseHandler func(response *http.Response) (APIListObject, error)
+
+func (c *Client) pagedGet(basePath string, handler responseHandler) error {
+	// Indicates whether there are still additional pages associated with request.
+	var stillMore bool
+
+	// Offset to set for the next page request.
+	var nextOffset uint
+
+	// While there are more pages, keep adjusting the offset to get all results.
+	for stillMore, nextOffset = true, 0; stillMore; {
+		response, err := c.do("GET", fmt.Sprintf("%s?offset=%d", basePath, nextOffset), nil, nil)
+		if err != nil {
+			return err
+		}
+
+		// Call handler to extract page information and execute additional necessary handling.
+		pageInfo, err := handler(response)
+		if err != nil {
+			return err
+		}
+
+		// Bump the offset as necessary and set whether more results exist.
+		nextOffset = pageInfo.Offset + pageInfo.Limit
+		stillMore = pageInfo.More
+	}
+
+	return nil
+}

--- a/team.go
+++ b/team.go
@@ -104,3 +104,37 @@ func getTeamFromResponse(c *Client, resp *http.Response, err error) (*Team, erro
 	}
 	return &t, nil
 }
+
+// Member is a team member.
+type Member struct {
+	APIObject struct {
+		APIObject
+	} `json:"user"`
+	Role string `json:"role"`
+}
+
+// ListMembersOptions are the optional parameters for a members request.
+type ListMembersOptions struct {
+	APIListObject
+}
+
+// ListMembersResponse is the response from the members endpoint.
+type ListMembersResponse struct {
+	APIListObject
+	Members []Member `json:"members"`
+}
+
+// ListMembers gets the first page of users associated with the specified team.
+func (c *Client) ListMembers(teamID string, o ListMembersOptions) (*ListMembersResponse, error) {
+	v, err := query.Values(o)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.get("/teams/" + teamID + "/members?" + v.Encode())
+	if err != nil {
+		return nil, err
+	}
+	var result ListMembersResponse
+	return &result, c.decodeJSON(resp, &result)
+}

--- a/team_test.go
+++ b/team_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"text/template"
 )
@@ -356,11 +355,12 @@ func genRespPages(amount,
 }
 
 func TestListMembersSuccess(t *testing.T) {
+	setup()
+	defer teardown()
+
 	expectedNumResults := testMaxPageSize - 1
 	page := genRespPages(expectedNumResults, testMaxPageSize, genMembersRespPage, t)[0]
 
-	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
 	mux.HandleFunc("/teams/"+testValidTeamID+"/members", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, page)
 	})
@@ -388,12 +388,13 @@ func TestListMembersError(t *testing.T) {
 }
 
 func TestListAllMembersSuccessMultiplePages(t *testing.T) {
+	setup()
+	defer teardown()
+
 	expectedNumResults := testMaxPageSize*3 + 1
 	currentPage := 0
 	pages := genRespPages(expectedNumResults, testMaxPageSize, genMembersRespPage, t)
 
-	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
 	mux.HandleFunc("/teams/"+testValidTeamID+"/members", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, pages[currentPage])
 		currentPage++

--- a/team_test.go
+++ b/team_test.go
@@ -1,0 +1,165 @@
+package pagerduty
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"text/template"
+)
+
+func userID(offset, index int) int {
+	return offset + index
+}
+
+func lastIndex(length, index int) bool {
+	return length-1 == index
+}
+
+const membersResponseTemplate = `
+{
+    {{template "pageInfo" . }},
+    "members": [
+        {{- $length := len .roles -}}
+        {{- $offset := .offset -}}
+        {{- range $index, $role := .roles -}}
+        {
+            "user": {
+                "id": "ID{{userID $offset $index}}"
+            },
+            "role": "{{ $role }}"
+        }
+        {{- if not (lastIndex $length $index) }},
+        {{end -}}
+        {{- end }}
+    ]
+}
+`
+
+var memberPageTemplate = template.Must(pageTemplate.New("membersResponse").
+	Funcs(templateUtilityFuncs).
+	Parse(membersResponseTemplate))
+
+const (
+	testValidTeamID = "MYTEAM"
+	testAPIKey      = "MYKEY"
+	testBadURL      = "A-FAKE-URL"
+	testMaxPageSize = 3
+)
+
+var templateUtilityFuncs = template.FuncMap{
+	"lastIndex": lastIndex,
+	"userID":    userID,
+}
+
+var pageTemplate = template.Must(template.New("pageInfo").Parse(`
+    "more": {{- .more -}},
+    "limit": {{- .limit -}},
+    "offset": {{- .offset -}}
+`))
+
+type pageDetails struct {
+	lowNumber, highNumber, limit, offset int
+	more                                 bool
+}
+
+func genMembersRespPage(details pageDetails, t *testing.T) string {
+	if details.limit == 0 {
+		details.limit = 25 // Default to 25, PD's API default.
+	}
+
+	possibleRoles := []string{"manager", "responder", "observer"}
+	roles := make([]string, 0)
+	for ; details.lowNumber <= details.highNumber; details.lowNumber++ {
+		roles = append(roles, possibleRoles[details.lowNumber%len(possibleRoles)])
+	}
+
+	buffer := bytes.NewBufferString("")
+	err := memberPageTemplate.Execute(buffer, map[string]interface{}{
+		"roles":  roles,
+		"more":   details.more,
+		"limit":  details.limit,
+		"offset": details.offset,
+	})
+
+	if err != nil {
+		t.Fatalf("Failed to apply values to template: %v", err)
+	}
+
+	return string(buffer.String())
+}
+
+func genRespPages(amount,
+	maxPageSize int,
+	pageGenerator func(pageDetails, *testing.T) string,
+	t *testing.T) []string {
+
+	pages := make([]string, 0)
+
+	lowNumber := 1
+	offset := 0
+	more := true
+
+	for {
+		tempHighNumber := amount
+
+		if lowNumber+(maxPageSize-1) < amount {
+			// Still more pages to come, this page doesn't hit upper.
+			tempHighNumber = lowNumber + (maxPageSize - 1)
+		} else {
+			// Last page, with at least 1 user.
+			more = false
+		}
+
+		// Generate page using current lower and upper.
+		page := pageGenerator(pageDetails{
+			lowNumber:  lowNumber,
+			highNumber: tempHighNumber,
+			limit:      maxPageSize,
+			more:       more,
+			offset:     offset}, t)
+
+		pages = append(pages, page)
+
+		if !more {
+			// Hit the last page, stop.
+			return pages
+		}
+		// Move the offset and lower up to prepare for next page.
+		offset += maxPageSize
+		lowNumber += maxPageSize
+	}
+}
+
+func TestListMembersSuccess(t *testing.T) {
+	expectedNumResults := testMaxPageSize - 1
+	page := genRespPages(expectedNumResults, testMaxPageSize, genMembersRespPage, t)[0]
+
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	mux.HandleFunc("/teams/"+testValidTeamID+"/members", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, page)
+	})
+
+	api := &Client{apiEndpoint: server.URL, authToken: testAPIKey, HTTPClient: defaultHTTPClient}
+	members, err := api.ListMembers(testValidTeamID, ListMembersOptions{})
+	if err != nil {
+		t.Fatalf("Failed to get members: %v", err)
+	}
+
+	if len(members.Members) != expectedNumResults {
+		t.Fatalf("Expected %d team members, got: %v", expectedNumResults, err)
+	}
+}
+
+func TestListMembersError(t *testing.T) {
+	api := &Client{apiEndpoint: testBadURL, authToken: testAPIKey, HTTPClient: defaultHTTPClient}
+	members, err := api.ListMembers(testValidTeamID, ListMembersOptions{})
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
+	if members != nil {
+		t.Fatalf("Expected nil members response, got: %v", members)
+	}
+}


### PR DESCRIPTION
## What?

This PR adds:
* `ListMembers`: Method to get a single page from the `members` endpoint (`/teams/<ID>/members`).
* `pagedGet`: Helper for stepping through all available pages of a base endpoint `GET` request.
* `ListAllMembers`: Uses `pagedGet` to get _all_ members.

## Why?

Re. `ListMembers`: The `/teams/<ID>/members` endpoint is not currently accessible via the client package.
* This is helpful for retrieving team role information.

Re. `pagedGet` + `ListAllMembers`: All `List*` methods only return a single page of data.
* `pagedGet` allows one to make a single method call to get all members.
* This can be extended to the other `List*` methods to create `ListAll*`.