### PR TITLE
Implement the Incident endpoint for ResponderRequest

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -380,4 +380,46 @@ type ListAlertResponse struct {
 	Alerts []Alert `json:"alerts,omitempty"`
 }
 
-/* TODO: Manage Alerts, Get Alert, Create Status Updates, Create Responder Request, */
+// CreateIncidentResponderRequestResponse
+type CreateIncidentResponderRequestResponse struct {
+	ResponderRequest ResponderRequest `json:"responder_request"`
+}
+
+// CreateIncidentResponderRequestOptions defines the input options for the Create Responder function.
+type CreateIncidentResponderRequestOptions struct {
+	From        string
+	Message     string
+	RequesterID string
+	Targets     []APIObject
+}
+
+// ResponderRequest contains the API structure for an incident responder request.
+type ResponderRequest struct {
+	Incident    Incident    `json:"incident"`
+	Requester   User        `json:"user,omitempty"`
+	RequestedAt string      `json:"request_at,omitempty"`
+	Message     string      `json:"message,omitempty"`
+	Targets     []APIObject `json:"responder_request_targets,omitempty"`
+}
+
+// CreateIncidentResponderRequest will submit a request to have a responder join an incident.
+func (c *Client) CreateIncidentResponderRequest(id string, o CreateIncidentResponderRequestOptions) (*CreateIncidentResponderRequestResponse, error) {
+	data := make(map[string]interface{})
+	headers := make(map[string]string)
+	headers["From"] = o.From
+
+	data["message"] = o.Message
+	data["request_id"] = o.RequesterID
+	data["responder_request_targets"] = o.Targets
+
+	resp, err := c.post("/incidents/"+id+"/responder_requests", data, &headers)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &CreateIncidentResponderRequestResponse{}
+	err = json.NewDecoder(resp.Body).Decode(result)
+	return result, err
+}
+
+/* TODO: Manage Alerts, Get Alert, Create Status Updates */

--- a/incident.go
+++ b/incident.go
@@ -380,44 +380,61 @@ type ListAlertResponse struct {
 	Alerts []Alert `json:"alerts,omitempty"`
 }
 
-// CreateIncidentResponderRequestResponse
-type CreateIncidentResponderRequestResponse struct {
+// IncidentResponders contains details about responders to an incident.
+type IncidentResponders struct {
+	State       string    `json:"state"`
+	User        APIObject `json:"user"`
+	Incident    APIObject `json:"incident"`
+	UpdatedAt   string    `json:"updated_at"`
+	Message     string    `json:"message"`
+	Requester   APIObject `json:"requester"`
+	RequestedAt string    `json:"requested_at"`
+}
+
+// ResponderRequestResponse
+type ResponderRequestResponse struct {
 	ResponderRequest ResponderRequest `json:"responder_request"`
 }
 
-// CreateIncidentResponderRequestOptions defines the input options for the Create Responder function.
-type CreateIncidentResponderRequestOptions struct {
-	From        string
-	Message     string
-	RequesterID string
-	Targets     []APIObject
+// ResponderRequestTarget specifies an individual target for the responder request.
+type ResponderRequestTarget struct {
+	APIObject
+	Responders IncidentResponders `json:"incident_responders"`
+}
+
+// ResponderRequestTargets is a wrapper for a ResponderRequestTarget.
+type ResponderRequestTargets struct {
+	Target ResponderRequestTarget `json:"responder_request_target"`
+}
+
+// ResponderRequestOptions defines the input options for the Create Responder function.
+type ResponderRequestOptions struct {
+	From        string                   `json:"-"`
+	Message     string                   `json:"message"`
+	RequesterID string                   `json:"request_id"`
+	Targets     []ResponderRequestTarget `json:"responder_request_targets"`
 }
 
 // ResponderRequest contains the API structure for an incident responder request.
 type ResponderRequest struct {
-	Incident    Incident    `json:"incident"`
-	Requester   User        `json:"user,omitempty"`
-	RequestedAt string      `json:"request_at,omitempty"`
-	Message     string      `json:"message,omitempty"`
-	Targets     []APIObject `json:"responder_request_targets,omitempty"`
+	Incident    Incident                `json:"incident"`
+	Requester   User                    `json:"requester,omitempty"`
+	RequestedAt string                  `json:"request_at,omitempty"`
+	Message     string                  `json:"message,omitempty"`
+	Targets     ResponderRequestTargets `json:"responder_request_targets"`
 }
 
-// CreateIncidentResponderRequest will submit a request to have a responder join an incident.
-func (c *Client) CreateIncidentResponderRequest(id string, o CreateIncidentResponderRequestOptions) (*CreateIncidentResponderRequestResponse, error) {
-	data := make(map[string]interface{})
+// ResponderRequest will submit a request to have a responder join an incident.
+func (c *Client) ResponderRequest(id string, o ResponderRequestOptions) (*ResponderRequestResponse, error) {
 	headers := make(map[string]string)
 	headers["From"] = o.From
 
-	data["message"] = o.Message
-	data["request_id"] = o.RequesterID
-	data["responder_request_targets"] = o.Targets
-
-	resp, err := c.post("/incidents/"+id+"/responder_requests", data, &headers)
+	resp, err := c.post("/incidents/"+id+"/responder_requests", o, &headers)
 	if err != nil {
 		return nil, err
 	}
 
-	result := &CreateIncidentResponderRequestResponse{}
+	result := &ResponderRequestResponse{}
 	err = json.NewDecoder(resp.Body).Decode(result)
 	return result, err
 }

--- a/incident_test.go
+++ b/incident_test.go
@@ -341,3 +341,38 @@ func TestIncident_ListLogEntries(t *testing.T) {
 	}
 	testEqual(t, want, res)
 }
+
+func TestIncident_ResponderRequest(t *testing.T) {
+	setup()
+	defer teardown()
+
+	id := "1"
+	mux.HandleFunc("/incidents/"+id+"/responder_requests", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Write([]byte(`{"requester_id": "PL1JMK5", "message": "Help", "responder_request_targets": [{"responder_request_target":{"id":"PJ25ZYX","type":"user_reference"}}]}`))
+	})
+	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	from := "foo@bar.com"
+
+	input := CreateIncidentResponderRequestOptions{
+		From:        from,
+		Message:     "help",
+		RequesterID: "PL1JMK5",
+		Targets: []APIObject{
+			APIObject{ID: "PJ25ZYX", Type: "user_reference"},
+		},
+	}
+
+	want := &CreateIncidentResponderRequestResponse{
+		ResponderRequest: ResponderRequest{
+			Incident:  Incident{},
+			Requester: User{},
+		},
+	}
+	res, err := client.CreateIncidentResponderRequest(id, input)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}

--- a/incident_test.go
+++ b/incident_test.go
@@ -349,27 +349,62 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	id := "1"
 	mux.HandleFunc("/incidents/"+id+"/responder_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"requester_id": "PL1JMK5", "message": "Help", "responder_request_targets": [{"responder_request_target":{"id":"PJ25ZYX","type":"user_reference"}}]}`))
+		w.Write([]byte(`{
+	"responder_request": {
+		"requester": {
+			"id": "PL1JMK5",
+			"type": "user_reference"
+		},
+		"message": "Help",
+		"responder_request_targets": {
+			"responder_request_target": {
+				"id": "PJ25ZYX",
+				"type": "user_reference",
+				"incident_responders": {
+					"state": "pending",
+					"user": {
+						"id": "PJ25ZYX"
+					}
+				}
+			}
+		}
+	}
+}`))
+
 	})
 	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	from := "foo@bar.com"
 
-	input := CreateIncidentResponderRequestOptions{
+	r := ResponderRequestTarget{}
+	r.ID = "PJ25ZYX"
+	r.Type = "user_reference"
+
+	input := ResponderRequestOptions{
 		From:        from,
 		Message:     "help",
 		RequesterID: "PL1JMK5",
-		Targets: []APIObject{
-			APIObject{ID: "PJ25ZYX", Type: "user_reference"},
-		},
+		Targets:     []ResponderRequestTarget{r},
 	}
 
-	want := &CreateIncidentResponderRequestResponse{
+	user := User{}
+	user.ID = "PL1JMK5"
+	user.Type = "user_reference"
+
+	target := ResponderRequestTarget{}
+	target.ID = "PJ25ZYX"
+	target.Type = "user_reference"
+	target.Responders.State = "pending"
+	target.Responders.User.ID = "PJ25ZYX"
+
+	want := &ResponderRequestResponse{
 		ResponderRequest: ResponderRequest{
 			Incident:  Incident{},
-			Requester: User{},
+			Requester: user,
+			Message:   "Help",
+			Targets:   ResponderRequestTargets{target},
 		},
 	}
-	res, err := client.CreateIncidentResponderRequest(id, input)
+	res, err := client.ResponderRequest(id, input)
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Was hoping to use this functionality, but it lacks in the API here, so adding it in. Based on [the docs](https://api-reference.pagerduty.com/#!/Incidents/post_incidents_id_responder_requests) this looks to be correct?

I wasn't entirely sure about the test case either, whether there is a way to provide better response content from the API (or have it generated).