### PR TITLE
Adding User-Agent Headers

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,33 +1,30 @@
-project_name: go-pagerduty
-release:
-  github:
-    owner: PagerDuty
-    name: go-pagerduty
-  draft: false
-  prerelease: true
-  name_template: "{{.ProjectName}}-v{{.Version}}"
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # you may remove this if you don't use vgo
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
 builds:
-- goos:
-  - linux
-  - darwin
-  - windows
-  goarch:
-  - amd64
-  - 386
-  main: ./command/*.go
-  binary: pd
-archive:
-  format: tar.gz
-  format_overrides:
-    - goos: windows
-      format: zip
-  replacements:
-    amd64: 64-bit
-    darwin: macOS
-    linux: Tux
-  name_template: "{{.Binary}}_{{.Version}}_{{.Os}}-{{.Arch}}"
-  files:
-    - LICENSE.txt
-    - README.md
-    - examples/*
-    - CHANGELOG.md
+- env:
+  - CGO_ENABLED=0
+- ldflags:
+  - -s -w -X pagerduty.Version={{.Version}}s
+archives:
+- replacements:
+    darwin: Darwin
+    linux: Linux
+    windows: Windows
+    386: i386
+    amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'

--- a/client.go
+++ b/client.go
@@ -140,6 +140,7 @@ func (c *Client) do(method, path string, body io.Reader, headers *map[string]str
 			req.Header.Set(k, v)
 		}
 	}
+	req.Header.Set("User-Agent", "go-pagerduty")
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Token token="+c.authToken)
 

--- a/client.go
+++ b/client.go
@@ -140,7 +140,7 @@ func (c *Client) do(method, path string, body io.Reader, headers *map[string]str
 			req.Header.Set(k, v)
 		}
 	}
-	req.Header.Set("User-Agent", "go-pagerduty")
+	req.Header.Set("User-Agent", "go-pagerduty/"+Version)
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Token token="+c.authToken)
 

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,5 @@
+package pagerduty
+
+const (
+	Version = "1.1.1"
+)

--- a/escalation_policy.go
+++ b/escalation_policy.go
@@ -21,22 +21,13 @@ type EscalationRule struct {
 // EscalationPolicy is a collection of escalation rules.
 type EscalationPolicy struct {
 	APIObject
-	Name            string                   `json:"name,omitempty"`
-	EscalationRules []EscalationRule         `json:"escalation_rules,omitempty"`
-	Services        []APIObject              `json:"services,omitempty"`
-	NumLoops        uint                     `json:"num_loops,omitempty"`
-	Teams           []APIReference           `json:"teams"`
-	OnCall          []EscalationPolicyOnCall `json:"on_call"`
-	Description     string                   `json:"description,omitempty"`
-	RepeatEnabled   bool                     `json:"repeat_enabled,omitempty"`
-}
-
-//
-type EscalationPolicyOnCall struct {
-	Level uint   `json:"level"`
-	Start string `json:"start,omitempty"`
-	End   string `json:"end,omitempty"`
-	User  User   `json:"user,omitempty"`
+	Name            string           `json:"name,omitempty"`
+	EscalationRules []EscalationRule `json:"escalation_rules,omitempty"`
+	Services        []APIObject      `json:"services,omitempty"`
+	NumLoops        uint             `json:"num_loops,omitempty"`
+	Teams           []APIReference   `json:"teams"`
+	Description     string           `json:"description,omitempty"`
+	RepeatEnabled   bool             `json:"repeat_enabled,omitempty"`
 }
 
 // ListEscalationPoliciesResponse is the data structure returned from calling the ListEscalationPolicies API endpoint.

--- a/event_v2.go
+++ b/event_v2.go
@@ -48,7 +48,7 @@ func ManageEvent(e V2Event) (*V2EventResponse, error) {
 		return nil, err
 	}
 	req, _ := http.NewRequest("POST", v2eventEndPoint, bytes.NewBuffer(data))
-	req.Header.Set("User-Agent", "go-pagerduty")
+	req.Header.Set("User-Agent", "go-pagerduty/"+Version)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/event_v2.go
+++ b/event_v2.go
@@ -48,6 +48,7 @@ func ManageEvent(e V2Event) (*V2EventResponse, error) {
 		return nil, err
 	}
 	req, _ := http.NewRequest("POST", v2eventEndPoint, bytes.NewBuffer(data))
+	req.Header.Set("User-Agent", "go-pagerduty")
 	req.Header.Set("Content-Type", "application/json")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
Adding User-Agent header to calls so that we understand how often the library is used. Also, rolling back #183. We don't want to be supporting undocumented features in this library. And, there are no immediate plans to document `oncall` for the escalation_policy endpoint. 