### PR TITLE
Adding GetCurrentUser method

### DIFF
--- a/user.go
+++ b/user.go
@@ -77,6 +77,11 @@ type GetUserOptions struct {
 	Includes []string `url:"include,omitempty,brackets"`
 }
 
+// GetCurrentUserOptions is the data structure used when calling the GetCurrentUser API endpoint.
+type GetCurrentUserOptions struct {
+	Includes [] string `url:"include,omitempty,brackets"`
+}
+
 // ListUsers lists users of your PagerDuty account, optionally filtered by a search query.
 func (c *Client) ListUsers(o ListUsersOptions) (*ListUsersResponse, error) {
 	v, err := query.Values(o)
@@ -120,6 +125,16 @@ func (c *Client) UpdateUser(u User) (*User, error) {
 	v := make(map[string]User)
 	v["user"] = u
 	resp, err := c.put("/users/"+u.ID, v, nil)
+	return getUserFromResponse(c, resp, err)
+}
+
+// GetCurrentUser gets details about the authenticated user when using a user-level API key or OAuth token
+func (c *Client) GetCurrentUser(o GetCurrentUserOptions) (*User, error) {
+	v, err := query.Values(o)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.get("/users/me?" + v.Encode())
 	return getUserFromResponse(c, resp, err)
 }
 

--- a/user_test.go
+++ b/user_test.go
@@ -151,6 +151,35 @@ func TestUser_Update(t *testing.T) {
 	testEqual(t, want, res)
 }
 
+// Get Current User
+func TestUser_GetCurrent(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/me", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"user": {"id": "1", "email":"foo@bar.com"}}`))
+	})
+
+	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := GetCurrentUserOptions{
+		Includes: []string{},
+	}
+	res, err := client.GetCurrentUser(opts)
+
+	want := &User{
+		APIObject: APIObject{
+			ID: "1",
+		},
+		Email: "foo@bar.com",
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
 // List User Contactmethods
 func TestUser_ListContactMethods(t *testing.T) {
 	setup()


### PR DESCRIPTION
Hi there!

This is a simple PR adding a `GetCurrentUser` method to `users.go`, hitting the endpoint documented here:

https://api-reference.pagerduty.com/#!/Users/get_users_me

...which identifies the authenticated user when using an OAuth token or a user-level API key.