### PR TITLE
Remove duplicate license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ The PagerDuty API client also exposes its HTTP client as the `HTTPClient` field.
 If you need to use your own HTTP client, for doing things like defining your own
 transport settings, you can replace the default HTTP client with your own by
 simply by setting a new value in the `HTTPClient` field.
-## License
-[Apache License 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 
 ## Contributing
 


### PR DESCRIPTION
Hello,

README file contains 2 license links. This was a result of a bad conflict resolution in https://github.com/PagerDuty/go-pagerduty/commit/4a773b4fc79b8be782794697649db28ffda06fbc#diff-04c6e90faac2675aa89e2176d2eec7d8

Thanks.