### PR TITLE
adding Raw to LogEntry.Channel object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/*
 *.swp
 pd
 vendor/
+.vscode/

--- a/log_entry.go
+++ b/log_entry.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/google/go-querystring/query"
@@ -12,6 +13,7 @@ type Agent APIObject
 // Channel is the means by which the action was carried out.
 type Channel struct {
 	Type string
+	Raw  map[string]interface{}
 }
 
 // Context are to be included with the trigger such as links to graphs or images.
@@ -45,7 +47,7 @@ type ListLogEntryResponse struct {
 // ListLogEntriesOptions is the data structure used when calling the ListLogEntry API endpoint.
 type ListLogEntriesOptions struct {
 	APIListObject
-	TimeZone   string   `url:"time_zone"`
+	TimeZone   string   `url:"time_zone,omitempty"`
 	Since      string   `url:"since,omitempty"`
 	Until      string   `url:"until,omitempty"`
 	IsOverview bool     `url:"is_overview,omitempty"`
@@ -63,7 +65,20 @@ func (c *Client) ListLogEntries(o ListLogEntriesOptions) (*ListLogEntryResponse,
 		return nil, err
 	}
 	var result ListLogEntryResponse
-	return &result, c.decodeJSON(resp, &result)
+	if err := c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+	// setting Channel.Raw to provide access to each of the channel fields objects
+	for _, le := range result.LogEntries {
+		les, err := json.Marshal(le)
+		if err != nil {
+			return nil, err
+		}
+		if err := le.Channel.UnmarshalJSON([]byte(les)); err != nil {
+			return nil, err
+		}
+	}
+	return &result, err
 }
 
 // GetLogEntryOptions is the data structure used when calling the GetLogEntry API endpoint.
@@ -83,12 +98,39 @@ func (c *Client) GetLogEntry(id string, o GetLogEntryOptions) (*LogEntry, error)
 		return nil, err
 	}
 	var result map[string]LogEntry
+
 	if err := c.decodeJSON(resp, &result); err != nil {
 		return nil, err
 	}
+
 	le, ok := result["log_entry"]
 	if !ok {
 		return nil, fmt.Errorf("JSON response does not have log_entry field")
 	}
+
+	// setting Channel.Raw to provide access to each of the channel object fields
+	les, err := json.Marshal(result)
+	if err != nil {
+		return nil, err
+	}
+	if err := le.Channel.UnmarshalJSON([]byte(les)); err != nil {
+		return nil, err
+	}
 	return &le, nil
+}
+
+// UnmarshalJSON Expands the LogEntry.Channel object to parse out a raw value
+func (c *Channel) UnmarshalJSON(b []byte) error {
+	var raw map[string]interface{}
+
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	ct, ok := raw["type"]
+	if ok {
+		c.Type = ct.(string)
+		c.Raw = raw
+	}
+
+	return nil
 }

--- a/log_entry.go
+++ b/log_entry.go
@@ -68,16 +68,6 @@ func (c *Client) ListLogEntries(o ListLogEntriesOptions) (*ListLogEntryResponse,
 	if err := c.decodeJSON(resp, &result); err != nil {
 		return nil, err
 	}
-	// setting Channel.Raw to provide access to each of the channel fields objects
-	for _, le := range result.LogEntries {
-		les, err := json.Marshal(le)
-		if err != nil {
-			return nil, err
-		}
-		if err := le.Channel.UnmarshalJSON([]byte(les)); err != nil {
-			return nil, err
-		}
-	}
 	return &result, err
 }
 
@@ -106,15 +96,6 @@ func (c *Client) GetLogEntry(id string, o GetLogEntryOptions) (*LogEntry, error)
 	le, ok := result["log_entry"]
 	if !ok {
 		return nil, fmt.Errorf("JSON response does not have log_entry field")
-	}
-
-	// setting Channel.Raw to provide access to each of the channel object fields
-	les, err := json.Marshal(result)
-	if err != nil {
-		return nil, err
-	}
-	if err := le.Channel.UnmarshalJSON([]byte(les)); err != nil {
-		return nil, err
 	}
 	return &le, nil
 }


### PR DESCRIPTION
Adding a `Raw` field to the `LogEntry.Channel` object so that all the channel fields can be accessed.  The fields that Raw expose may be undocumented by PagerDuty and thus may change, so it should be understood that it's an object that is a "use at your own risk" kind of object. 

Adding the `Raw` field also allows for the existing `Channel.Type` to remain intact in case someone is currently using it. 