### PR TITLE
Add Teams to Schedule

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -44,6 +44,7 @@ type Schedule struct {
 	Description         string          `json:"description,omitempty"`
 	EscalationPolicies  []APIObject     `json:"escalation_policies,omitempty"`
 	Users               []APIObject     `json:"users,omitempty"`
+	Teams               []APIReference  `json:"teams,omitempty"`
 	ScheduleLayers      []ScheduleLayer `json:"schedule_layers,omitempty"`
 	OverrideSubschedule ScheduleLayer   `json:"override_subschedule,omitempty"`
 	FinalSchedule       ScheduleLayer   `json:"final_schedule,omitempty"`


### PR DESCRIPTION
Nor the API docs, nor the current code says so, but Schedule can take a
team (or more than one). Add this by using an APIReference slice.

Signed-off-by: Miek Gieben <miek@miek.nl>