### PR TITLE
Remove duplicate "id" field from Incident struct

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -75,7 +75,6 @@ type Incident struct {
 	Priority             *Priority         `json:"priority,omitempty"`
 	Urgency              string            `json:"urgency,omitempty"`
 	Status               string            `json:"status,omitempty"`
-	Id                   string            `json:"id,omitempty"`
 	ResolveReason        ResolveReason     `json:"resolve_reason,omitempty"`
 	AlertCounts          AlertCounts       `json:"alert_counts,omitempty"`
 	Body                 IncidentBody      `json:"body,omitempty"`


### PR DESCRIPTION
When creating an incident using `CreateIncident`, it returns empty `ID` field of embedded `APIObject`. This is because there's a duplicate `Id` field that also maps to `"id"` json proprety.