### PR TITLE
adding since and until to incident logentry options

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -349,6 +349,8 @@ type ListIncidentLogEntriesOptions struct {
 	Includes   []string `url:"include,omitempty,brackets"`
 	IsOverview bool     `url:"is_overview,omitempty"`
 	TimeZone   string   `url:"time_zone,omitempty"`
+	Since      string   `url:since,omitempty`
+	Until      string   `url:until,omitempty`
 }
 
 // ListIncidentLogEntries lists existing log entries for the specified incident.

--- a/incident_test.go
+++ b/incident_test.go
@@ -342,6 +342,46 @@ func TestIncident_ListLogEntries(t *testing.T) {
 	testEqual(t, want, res)
 }
 
+// ListIncidentLogEntriesSinceUntil
+func TestIncident_ListLogEntriesSinceUntil(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incidents/1/log_entries", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"log_entries": [{"id": "1","summary":"foo"}]}`))
+	})
+	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	id := "1"
+	var entriesOpts = ListIncidentLogEntriesOptions{
+		APIListObject: listObj,
+		Includes:      []string{},
+		IsOverview:    true,
+		TimeZone:      "UTC",
+		Since:         "2020-03-27T22:40:00-0700",
+		Until:         "2020-03-28T22:50:00-0700",
+	}
+	res, err := client.ListIncidentLogEntries(id, entriesOpts)
+
+	want := &ListIncidentLogEntriesResponse{
+		APIListObject: listObj,
+		LogEntries: []LogEntry{
+			{
+				APIObject: APIObject{
+					ID:      "1",
+					Summary: "foo",
+				},
+			},
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
 func TestIncident_ResponderRequest(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Adds support for the `ListIncidentLogEntries` function to handle two new options `Since` and `Until`. Also adds the `TestIncident_ListLogEntriesSinceUntil` test.

```
go test -v -run='TestIncident_ListLogEntries*'
=== RUN   TestIncident_ListLogEntries
--- PASS: TestIncident_ListLogEntries (0.00s)
=== RUN   TestIncident_ListLogEntriesSinceUntil
--- PASS: TestIncident_ListLogEntriesSinceUntil (0.00s)
PASS
ok  	github.com/PagerDuty/go-pagerduty	0.707s
```