### PR TITLE
Fix UpdateService

### DIFF
--- a/service.go
+++ b/service.go
@@ -128,7 +128,12 @@ func (c *Client) CreateService(s Service) (*Service, error) {
 
 // UpdateService updates an existing service.
 func (c *Client) UpdateService(s Service) (*Service, error) {
-	resp, err := c.put("/services/"+s.ID, s, nil)
+	body := struct {
+		Service `json:"service,omitempty"`
+	}{
+		s,
+	}
+	resp, err := c.put("/services/"+s.ID, body, nil)
 	return getServiceFromResponse(c, resp, err)
 }
 


### PR DESCRIPTION
Fixes https://github.com/PagerDuty/go-pagerduty/issues/188

JSON body must be nested under `service` key on service update to be recognized.