### PR TITLE
Update incident: fix FirstTriggerLogEntry type

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -69,7 +69,7 @@ type Incident struct {
 	Acknowledgements     []Acknowledgement `json:"acknowledgements,omitempty"`
 	LastStatusChangeAt   string            `json:"last_status_change_at,omitempty"`
 	LastStatusChangeBy   APIObject         `json:"last_status_change_by,omitempty"`
-	FirstTriggerLogEntry APIObject         `json:"first_trigger_log_entry,omitempty"`
+	FirstTriggerLogEntry LogEntry          `json:"first_trigger_log_entry,omitempty"`
 	EscalationPolicy     APIObject         `json:"escalation_policy,omitempty"`
 	Teams                []APIObject       `json:"teams,omitempty"`
 	Priority             *Priority         `json:"priority,omitempty"`


### PR DESCRIPTION
Use LogEntry type instead of APIObject for FirstTriggerLogEntry attribute in Incident