### PR TITLE
Couple of syntax and unmarshaling fixes. closes #232

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -392,8 +392,8 @@ type ListIncidentLogEntriesOptions struct {
 	Includes   []string `url:"include,omitempty,brackets"`
 	IsOverview bool     `url:"is_overview,omitempty"`
 	TimeZone   string   `url:"time_zone,omitempty"`
-	Since      string   `url:since,omitempty`
-	Until      string   `url:until,omitempty`
+	Since      string   `url:"since,omitempty"`
+	Until      string   `url:"until,omitempty"`
 }
 
 // ListIncidentLogEntries lists existing log entries for the specified incident.
@@ -439,19 +439,19 @@ type ResponderRequestTargets struct {
 
 // ResponderRequestOptions defines the input options for the Create Responder function.
 type ResponderRequestOptions struct {
-	From        string                   `json:"-"`
-	Message     string                   `json:"message"`
-	RequesterID string                   `json:"requester_id"`
-	Targets     []ResponderRequestTarget `json:"responder_request_targets"`
+	From        string                    `json:"-"`
+	Message     string                    `json:"message"`
+	RequesterID string                    `json:"requester_id"`
+	Targets     []ResponderRequestTargets `json:"responder_request_targets"`
 }
 
 // ResponderRequest contains the API structure for an incident responder request.
 type ResponderRequest struct {
-	Incident    Incident                `json:"incident"`
-	Requester   User                    `json:"requester,omitempty"`
-	RequestedAt string                  `json:"request_at,omitempty"`
-	Message     string                  `json:"message,omitempty"`
-	Targets     ResponderRequestTargets `json:"responder_request_targets"`
+	Incident    Incident                  `json:"incident"`
+	Requester   User                      `json:"requester,omitempty"`
+	RequestedAt string                    `json:"request_at,omitempty"`
+	Message     string                    `json:"message,omitempty"`
+	Targets     []ResponderRequestTargets `json:"responder_request_targets"`
 }
 
 // ResponderRequest will submit a request to have a responder join an incident.

--- a/incident_test.go
+++ b/incident_test.go
@@ -573,7 +573,7 @@ func TestIncident_ResponderRequest(t *testing.T) {
 		From:        from,
 		Message:     "help",
 		RequesterID: "PL1JMK5",
-		Targets:     []ResponderRequestTarget{r},
+		Targets:     []ResponderRequestTargets{{r}},
 	}
 
 	user := User{}
@@ -591,7 +591,7 @@ func TestIncident_ResponderRequest(t *testing.T) {
 			Incident:  Incident{},
 			Requester: user,
 			Message:   "Help",
-			Targets:   ResponderRequestTargets{target},
+			Targets:   []ResponderRequestTargets{{target}},
 		},
 	}
 	res, err := client.ResponderRequest(id, input)

--- a/webhook.go
+++ b/webhook.go
@@ -27,6 +27,7 @@ type IncidentDetails struct {
 	Urgency              string            `json:"urgency"`
 	ResolveReason        *string           `json:"resolve_reason"`
 	AlertCounts          AlertCounts       `json:"alert_counts"`
+	Alerts               []WebhookAlert    `json:"alerts"`
 	Metadata             interface{}       `json:"metadata"`
 	Description          string            `json:"description"`
 }
@@ -40,9 +41,14 @@ type WebhookPayloadMessages struct {
 type WebhookPayload struct {
 	ID         string          `json:"id"`
 	Event      string          `json:"event"`
-	CreatedOn  time.Time       `json:"created_on`
+	CreatedOn  time.Time       `json:"created_on"`
 	Incident   IncidentDetails `json:"incident"`
 	LogEntries []LogEntry      `json:"log_entries"`
+}
+
+// WebhookAlert describes the alert of the incident
+type WebhookAlert struct {
+	AlertKey string `json:"alert_key"`
 }
 
 // DecodeWebhook decodes a webhook from a response object.


### PR DESCRIPTION
This MR adds a field to the webhook struct, fixes struct tag syntax, and adjusts the payload for sending responder requests to match the documentation. Closes #232 