### PR TITLE
allow creating services with no scheduled actions

### DIFF
--- a/service.go
+++ b/service.go
@@ -70,7 +70,7 @@ type Service struct {
 	Teams                  []Team               `json:"teams,omitempty"`
 	IncidentUrgencyRule    *IncidentUrgencyRule `json:"incident_urgency_rule,omitempty"`
 	SupportHours           *SupportHours        `json:"support_hours,omitempty"`
-	ScheduledActions       []ScheduledAction    `json:"scheduled_actions,omitempty"`
+	ScheduledActions       []ScheduledAction    `json:"scheduled_actions"`
 	AlertCreation          string               `json:"alert_creation,omitempty"`
 	AlertGrouping          string               `json:"alert_grouping,omitempty"`
 	AlertGroupingTimeout   *uint                `json:"alert_grouping_timeout,omitempty"`


### PR DESCRIPTION
When using `use_support_hours` as the type for `incident_urgency_rule` you have to specify the `scheduled_actions` array as well.
The PagerDuty API allows this array to be empty, but an empty array will be omitted from the JSON.
This causes API errors when trying to create services that notify based on support hours but don't have any scheduled actions.