### PR TITLE
Adding metadata to services, which are present in V2 webhooks

### DIFF
--- a/service.go
+++ b/service.go
@@ -74,6 +74,7 @@ type Service struct {
 	AlertCreation          string               `json:"alert_creation,omitempty"`
 	AlertGrouping          string               `json:"alert_grouping,omitempty"`
 	AlertGroupingTimeout   *uint                `json:"alert_grouping_timeout,omitempty"`
+	Metadata               interface{}          `json:"metadata,omitempty"`
 }
 
 // ListServiceOptions is the data structure used when calling the ListServices API endpoint.


### PR DESCRIPTION
Metadata is present on Incidents *and* Services when you receive a webhook. Without this, you don't get the conference_url, etc for your service.