### PR TITLE
Fix ruleset rule not respecting position "0"

### DIFF
--- a/ruleset.go
+++ b/ruleset.go
@@ -39,7 +39,7 @@ type ListRulesetsResponse struct {
 // RulesetRule represents a Ruleset rule
 type RulesetRule struct {
 	ID         string          `json:"id,omitempty"`
-	Position   int             `json:"position,omitempty"`
+	Position   *int            `json:"position,omitempty"`
 	Disabled   bool            `json:"disabled,omitempty"`
 	Conditions *RuleConditions `json:"conditions,omitempty"`
 	Actions    *RuleActions    `json:"actions,omitempty"`


### PR DESCRIPTION
During the JSON marshal of a `RulesetRule`, a `Position` with the value of `0` is considered empty and is not sent in the POST or PUT payload. Using a pointer allows the JSON marshal function to distinguish between an empty value and a default value.

I'm not sure how this change would be handled as it isn't really backwards compatible. Happy to hear any thoughts or opinions.