### PR TITLE
Correct namespacing of Change Event resource

### DIFF
--- a/change_events.go
+++ b/change_events.go
@@ -6,28 +6,28 @@ import (
 	"errors"
 )
 
-const ChangeEventPath = "/v2/change/enqueue"
+const changeEventPath = "/v2/change/enqueue"
 
 // ChangeEvent represents a ChangeEvent's request parameters
 // https://developer.pagerduty.com/docs/events-api-v2/send-change-events/#parameters
 type ChangeEvent struct {
-	RoutingKey string  `json:"routing_key"`
-	Payload    Payload `json:"payload"`
-	Links      []Link  `json:"links"`
+	RoutingKey string             `json:"routing_key"`
+	Payload    ChangeEventPayload `json:"payload"`
+	Links      []ChangeEventLink  `json:"links"`
 }
 
-// Payload ChangeEvent Payload
+// ChangeEventPayload ChangeEvent ChangeEventPayload
 // https://developer.pagerduty.com/docs/events-api-v2/send-change-events/#example-request-payload
-type Payload struct {
+type ChangeEventPayload struct {
 	Source        string                 `json:"source"`
 	Summary       string                 `json:"summary"`
 	Timestamp     string                 `json:"timestamp"`
 	CustomDetails map[string]interface{} `json:"custom_details"`
 }
 
-// Link represents a single link in a ChangeEvent
+// ChangeEventLink represents a single link in a ChangeEvent
 // https://developer.pagerduty.com/docs/events-api-v2/send-change-events/#the-links-property
-type Link struct {
+type ChangeEventLink struct {
 	Href string `json:"href"`
 	Text string `json:"text"`
 }
@@ -57,7 +57,7 @@ func (c *Client) CreateChangeEvent(e ChangeEvent) (*ChangeEventResponse, error) 
 	resp, err := c.doWithEndpoint(
 		c.v2EventsAPIEndpoint,
 		"POST",
-		ChangeEventPath,
+		changeEventPath,
 		false,
 		bytes.NewBuffer(data),
 		&headers,

--- a/change_events_test.go
+++ b/change_events_test.go
@@ -41,13 +41,13 @@ func TestChangeEvent_Create(t *testing.T) {
 	eventDetails := map[string]interface{}{"DetailKey1": "DetailValue1", "DetailKey2": "DetailValue2"}
 	ce := ChangeEvent{
 		RoutingKey: "a0000000aa0000a0a000aa0a0a0aa000",
-		Payload: Payload{
+		Payload: ChangeEventPayload{
 			Source:        "Test runner",
 			Summary:       "Summary can't be blank",
 			Timestamp:     "2020-10-19T03:06:16.318Z",
 			CustomDetails: eventDetails,
 		},
-		Links: []Link{
+		Links: []ChangeEventLink{
 			{
 				Href: "https://acme.pagerduty.dev/build/2",
 				Text: "View more details in Acme!",
@@ -92,13 +92,13 @@ func TestChangeEvent_CreateWithPayloadVerification(t *testing.T) {
 	eventDetails := map[string]interface{}{"DetailKey1": "DetailValue1", "DetailKey2": "DetailValue2"}
 	ce := ChangeEvent{
 		RoutingKey: "a0000000aa0000a0a000aa0a0a0aa000",
-		Payload: Payload{
+		Payload: ChangeEventPayload{
 			Source:        "Test runner",
 			Summary:       "Summary can't be blank",
 			Timestamp:     "2020-10-19T03:06:16.318Z",
 			CustomDetails: eventDetails,
 		},
-		Links: []Link{
+		Links: []ChangeEventLink{
 			{
 				Href: "https://acme.pagerduty.dev/build/2",
 				Text: "View more details in Acme!",


### PR DESCRIPTION
In reviewing my previous implementation I noticed that some structs had more global namespaces that strictly necessary which can be non-intuitive when looking at the entire package in aggregate.  For example the exported Payload struct didn't make much sense in its stand alone form, so this have been updated to ChangeEventPayload as to avoid confusion and namespace collisions. Same applies to ChangeEvent links.