### PR TITLE
Correcting the responder requests to actually match the API

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -439,25 +439,30 @@ type ResponderRequestTargets struct {
 
 // ResponderRequestOptions defines the input options for the Create Responder function.
 type ResponderRequestOptions struct {
-	From        string                   `json:"-"`
-	Message     string                   `json:"message"`
-	RequesterID string                   `json:"requester_id"`
-	Targets     []ResponderRequestTarget `json:"responder_request_targets"`
+	From          string                    `json:"-"`
+	Message       string                    `json:"message"`
+	RequesterID   string                    `json:"requester_id"`
+	Targets       []ResponderRequestTarget  `json:"-"`
+	NestedTargets []ResponderRequestTargets `json:"responder_request_targets"`
 }
 
 // ResponderRequest contains the API structure for an incident responder request.
 type ResponderRequest struct {
-	Incident    Incident                `json:"incident"`
-	Requester   User                    `json:"requester,omitempty"`
-	RequestedAt string                  `json:"request_at,omitempty"`
-	Message     string                  `json:"message,omitempty"`
-	Targets     ResponderRequestTargets `json:"responder_request_targets"`
+	Incident    Incident                  `json:"incident"`
+	Requester   User                      `json:"requester,omitempty"`
+	RequestedAt string                    `json:"request_at,omitempty"`
+	Message     string                    `json:"message,omitempty"`
+	Targets     []ResponderRequestTargets `json:"responder_request_targets"`
 }
 
 // ResponderRequest will submit a request to have a responder join an incident.
 func (c *Client) ResponderRequest(id string, o ResponderRequestOptions) (*ResponderRequestResponse, error) {
 	headers := make(map[string]string)
 	headers["From"] = o.From
+
+	for _, v := range o.Targets {
+		o.NestedTargets = append(o.NestedTargets, ResponderRequestTargets{Target: v})
+	}
 
 	resp, err := c.post("/incidents/"+id+"/responder_requests", o, &headers)
 	if err != nil {

--- a/incident_test.go
+++ b/incident_test.go
@@ -540,25 +540,27 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	mux.HandleFunc("/incidents/"+id+"/responder_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		w.Write([]byte(`{
-	"responder_request": {
-		"requester": {
-			"id": "PL1JMK5",
-			"type": "user_reference"
-		},
-		"message": "Help",
-		"responder_request_targets": {
-			"responder_request_target": {
-				"id": "PJ25ZYX",
-				"type": "user_reference",
-				"incident_responders": {
-					"state": "pending",
-					"user": {
-						"id": "PJ25ZYX"
-					}
-				}
-			}
-		}
-	}
+  "responder_request": {
+    "requester": {
+      "id": "PL1JMK5",
+      "type": "user_reference"
+    },
+    "message": "Help",
+    "responder_request_targets": [
+      {
+        "responder_request_target": {
+          "id": "PJ25ZYX",
+          "type": "user_reference",
+          "incident_responders": {
+            "state": "pending",
+            "user": {
+              "id": "PJ25ZYX"
+            }
+          }
+        }
+      }
+    ]
+  }
 }`))
 
 	})
@@ -591,7 +593,7 @@ func TestIncident_ResponderRequest(t *testing.T) {
 			Incident:  Incident{},
 			Requester: user,
 			Message:   "Help",
-			Targets:   ResponderRequestTargets{target},
+			Targets:   []ResponderRequestTargets{{Target: target}},
 		},
 	}
 	res, err := client.ResponderRequest(id, input)


### PR DESCRIPTION
It looks like this never actually worked and it doesn't match the API.

A correct request:
```
{
  "requester_id": "PQKSYYY",
  "message": "Please help with issue",
  "responder_request_targets": [
    {
        "responder_request_target": {
            "id": "PQKSYYY",
          "type": "user_reference"
        }
    }
  ]
}
```

What it was generating as a request (which would result [unhelpfully] in just an undescriptive 404 error back from pagerduty):
```
{
     "requester_id": "PQKSYYY",
    "message": "Please join an existing incident to help",
    "responder_request_targets": [
        {
            "id": "PQKSYYY",
            "type": "user_reference"
        }
    ]
}
```

Also the response would generate this error as the response has an array of targets:
> json: cannot unmarshal array into Go struct field ResponderRequest.responder_request.responder_request_targets of type pagerduty.ResponderRequestTargets

Unfortunately, there didn't seem like a nice way to keep BC for this - that said, this never worked before anyway so I guess nobody is using it?

It appears the docs used to be wrong on this which is probably where it came from:
https://community.pagerduty.com/forum/t/create-responder-api-call-failing/226

It's worth noting the pagerduty API docs are also still wrong. The example is correct, but the schema is wrong: https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1incidents~1%7Bid%7D~1responder_requests/post

I have tested this fix locally with this code in a mock command and it works. I've tried to maintain BC also:
```
       if err := c.Meta.Setup(); err != nil {
		fmt.Println(err)
		return -1
	}
	client := c.Meta.Client()

	opts := pagerduty.ResponderRequestOptions{
		From: "XXXXX",
	}

	pid := "PPPSYYY"

	opts.Message = fmt.Sprintf("Please join an incident")
	opts.Targets = []pagerduty.ResponderRequestTarget{{APIObject: pagerduty.APIObject{ID: pid, Type: "user_reference"}}}
	opts.RequesterID = pid

	_, err := client.ResponderRequest("PPP1YYY", opts)
	fmt.Println(err)
```

I'd appreciate it if a tag could be done after merging this PR so I can pull the change down. Thanks!