### PR TITLE
service_dependency: fix (dis-)associate operations

### DIFF
--- a/service_dependency.go
+++ b/service_dependency.go
@@ -45,9 +45,7 @@ func (c *Client) ListTechnicalServiceDependencies(serviceID string) (*ListServic
 
 // AssociateServiceDependencies Create new dependencies between two services.
 func (c *Client) AssociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
-	data := make(map[string]*ListServiceDependencies)
-	data["relationships"] = dependencies
-	resp, err := c.post("/service_dependencies/associate", data, nil)
+	resp, err := c.post("/service_dependencies/associate", dependencies, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -57,9 +55,7 @@ func (c *Client) AssociateServiceDependencies(dependencies *ListServiceDependenc
 
 // DisassociateServiceDependencies Disassociate dependencies between two services.
 func (c *Client) DisassociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
-	data := make(map[string]*ListServiceDependencies)
-	data["relationships"] = dependencies
-	resp, err := c.post("/service_dependencies/disassociate", data, nil)
+	resp, err := c.post("/service_dependencies/disassociate", dependencies, nil)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Fix the (dis-)associate functions by not doing the hocus pocus with
`map[string]...`. `relationships` already exists due to the JSON tag in
the struct. Without this, the payload looks like:

```json
{"relationships": {"relationships": [...] } }
```

And PD API returns "invalid request". Tested locally that it works as
expected with these changes.