### PR TITLE
fix creating services that don't use support hours

### DIFF
--- a/service.go
+++ b/service.go
@@ -69,7 +69,7 @@ type Service struct {
 	EscalationPolicy        EscalationPolicy         `json:"escalation_policy,omitempty"`
 	Teams                   []Team                   `json:"teams,omitempty"`
 	IncidentUrgencyRule     *IncidentUrgencyRule     `json:"incident_urgency_rule,omitempty"`
-	SupportHours            *SupportHours            `json:"support_hours,omitempty"`
+	SupportHours            *SupportHours            `json:"support_hours"`
 	ScheduledActions        []ScheduledAction        `json:"scheduled_actions"`
 	AlertCreation           string                   `json:"alert_creation,omitempty"`
 	AlertGrouping           string                   `json:"alert_grouping,omitempty"`


### PR DESCRIPTION
It appears that when creating a service with `scheduled_actions`: `null`, the API requires that `support_hours` is also set to `null`.
Without this change the API returns an error: `HTTP response code: 400. Error: &{2001 Invalid Input Provided [Support hours is required.]}`