### PR TITLE
service: do not omit support hours

### DIFF
--- a/service.go
+++ b/service.go
@@ -69,7 +69,7 @@ type Service struct {
 	EscalationPolicy       EscalationPolicy     `json:"escalation_policy,omitempty"`
 	Teams                  []Team               `json:"teams,omitempty"`
 	IncidentUrgencyRule    *IncidentUrgencyRule `json:"incident_urgency_rule,omitempty"`
-	SupportHours           *SupportHours        `json:"support_hours,omitempty"`
+	SupportHours           *SupportHours        `json:"support_hours"`
 	ScheduledActions       []ScheduledAction    `json:"scheduled_actions"`
 	AlertCreation          string               `json:"alert_creation,omitempty"`
 	AlertGrouping          string               `json:"alert_grouping,omitempty"`


### PR DESCRIPTION
CreateService() API contract has been randomly changed without a notice
to not accept the non-existence of the `support_hours` key. Creating a
service currently fails with:

```
Failed call API endpoint. HTTP response code: 400. Error: \u0026{2001 Invalid Input Provided [Support hours is required.]}
```

The API gladly accepts the same payload when `support_hours` is
_explicitly_ set to `null` in the resulting JSON.