### PR TITLE
Fix logentry.channel json marshaling/unmarshaling

### DIFF
--- a/log_entry.go
+++ b/log_entry.go
@@ -115,7 +115,6 @@ func (c *Channel) UnmarshalJSON(b []byte) error {
 	ct, ok := raw["type"]
 	if ok {
 		c.Type = ct.(string)
-		delete(raw, "type")
 		c.Raw = raw
 	}
 
@@ -126,16 +125,10 @@ func (c *Channel) UnmarshalJSON(b []byte) error {
 func (c *Channel) MarshalJSON() ([]byte, error) {
 	raw := map[string]interface{}{}
 	if c != nil && c.Type != "" {
-		raw["type"] = c.Type
 		for k, v := range c.Raw {
 			raw[k] = v
 		}
 	}
 
-	b, err := json.Marshal(raw)
-	if err != nil {
-		return nil, err
-	}
-
-	return b, nil
+	return json.Marshal(raw)
 }

--- a/log_entry.go
+++ b/log_entry.go
@@ -40,7 +40,7 @@ type CommonLogEntryField struct {
 // LogEntry is a list of all of the events that happened to an incident.
 type LogEntry struct {
 	CommonLogEntryField
-	Incident Incident
+	Incident Incident `json:"incident"`
 }
 
 // ListLogEntryResponse is the response data when calling the ListLogEntry API endpoint.
@@ -115,8 +115,27 @@ func (c *Channel) UnmarshalJSON(b []byte) error {
 	ct, ok := raw["type"]
 	if ok {
 		c.Type = ct.(string)
+		delete(raw, "type")
 		c.Raw = raw
 	}
 
 	return nil
+}
+
+// MarshalJSON Expands the LogEntry.Channel object to correctly marshal it back
+func (c *Channel) MarshalJSON() ([]byte, error) {
+	raw := map[string]interface{}{}
+	if c != nil && c.Type != "" {
+		raw["type"] = c.Type
+		for k, v := range c.Raw {
+			raw[k] = v
+		}
+	}
+
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
 }

--- a/log_entry_test.go
+++ b/log_entry_test.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 )
@@ -71,4 +72,51 @@ func TestLogEntry_Get(t *testing.T) {
 		t.Fatal(err)
 	}
 	testEqual(t, want, res)
+}
+
+func TestChannel_MarhalUnmarshal(t *testing.T) {
+	logEntryRaw := []byte(`{
+		"id": "1",
+		"type": "trigger_log_entry",
+		"summary": "foo",
+		"channel": {
+			"type": "web_trigger",
+			"summary": "My new incident",
+			"details_omitted": false
+		}
+	}`)
+	want := &LogEntry{
+		CommonLogEntryField: CommonLogEntryField{
+			APIObject: APIObject{
+				ID:      "1",
+				Type:    "trigger_log_entry",
+				Summary: "foo",
+			},
+			Channel: Channel{
+				Type: "web_trigger",
+				Raw: map[string]interface{}{
+					"summary":         "My new incident",
+					"details_omitted": false,
+				},
+			},
+		},
+	}
+
+	logEntry := &LogEntry{}
+	if err := json.Unmarshal(logEntryRaw, logEntry); err != nil {
+		t.Fatal(err)
+	}
+
+	testEqual(t, want, logEntry)
+
+	newLogEntryRaw, err := json.Marshal(logEntry)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	newLogEntry := &LogEntry{}
+	if err := json.Unmarshal(newLogEntryRaw, newLogEntry); err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, newLogEntry)
 }

--- a/log_entry_test.go
+++ b/log_entry_test.go
@@ -95,6 +95,7 @@ func TestChannel_MarhalUnmarshal(t *testing.T) {
 			Channel: Channel{
 				Type: "web_trigger",
 				Raw: map[string]interface{}{
+					"type":            "web_trigger",
 					"summary":         "My new incident",
 					"details_omitted": false,
 				},


### PR DESCRIPTION
Hello.

I've faced an issue when unmarshalling and marshalling back of LogEntry lead to results that differ from initial.

First of all just because of absent json tags, so it lead to `"Type"` instead of `"type"`, so the next unmarshaling was broken.
Also "fixing" tags leads to nested object and
```json
{
    ...
    "channel": {
	    "type": "web_trigger",
	    "summary": "My new incident",
	    "details_omitted": false
    }
}
```

transforms to
```json
{
    ...
    "channel": {
	    "type": "web_trigger",
            "raw": {
	        "summary": "My new incident",
	        "details_omitted": false
            }
    }
}
```

So this PR will fix this, however it require Channel type changes.

Looking forward for your feedback.