### PR TITLE
Prepare internals for exposing context.Context in exported API

### DIFF
--- a/ability.go
+++ b/ability.go
@@ -1,5 +1,7 @@
 package pagerduty
 
+import "context"
+
 // ListAbilityResponse is the response when calling the ListAbility API endpoint.
 type ListAbilityResponse struct {
 	Abilities []string `json:"abilities"`
@@ -7,7 +9,7 @@ type ListAbilityResponse struct {
 
 // ListAbilities lists all abilities on your account.
 func (c *Client) ListAbilities() (*ListAbilityResponse, error) {
-	resp, err := c.get("/abilities")
+	resp, err := c.get(context.TODO(), "/abilities")
 	if err != nil {
 		return nil, err
 	}
@@ -17,6 +19,6 @@ func (c *Client) ListAbilities() (*ListAbilityResponse, error) {
 
 // TestAbility Check if your account has the given ability.
 func (c *Client) TestAbility(ability string) error {
-	_, err := c.get("/abilities/" + ability)
+	_, err := c.get(context.TODO(), "/abilities/"+ability)
 	return err
 }

--- a/addon.go
+++ b/addon.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -35,7 +36,7 @@ func (c *Client) ListAddons(o ListAddonOptions) (*ListAddonResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/addons?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/addons?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +48,8 @@ func (c *Client) ListAddons(o ListAddonOptions) (*ListAddonResponse, error) {
 func (c *Client) InstallAddon(a Addon) (*Addon, error) {
 	data := make(map[string]Addon)
 	data["addon"] = a
-	resp, err := c.post("/addons", data, nil)
-	defer resp.Body.Close()
+	resp, err := c.post(context.TODO(), "/addons", data, nil)
+	defer resp.Body.Close() // TODO(theckman): validate that this is safe
 	if err != nil {
 		return nil, err
 	}
@@ -60,13 +61,13 @@ func (c *Client) InstallAddon(a Addon) (*Addon, error) {
 
 // DeleteAddon deletes an add-on from your account.
 func (c *Client) DeleteAddon(id string) error {
-	_, err := c.delete("/addons/" + id)
+	_, err := c.delete(context.TODO(), "/addons/"+id)
 	return err
 }
 
 // GetAddon gets details about an existing add-on.
 func (c *Client) GetAddon(id string) (*Addon, error) {
-	resp, err := c.get("/addons/" + id)
+	resp, err := c.get(context.TODO(), "/addons/"+id)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +78,7 @@ func (c *Client) GetAddon(id string) (*Addon, error) {
 func (c *Client) UpdateAddon(id string, a Addon) (*Addon, error) {
 	v := make(map[string]Addon)
 	v["addon"] = a
-	resp, err := c.put("/addons/"+id, v, nil)
+	resp, err := c.put(context.TODO(), "/addons/"+id, v, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/business_service.go
+++ b/business_service.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -75,7 +76,7 @@ func (c *Client) ListBusinessServices(o ListBusinessServiceOptions) (*ListBusine
 	}
 
 	// Make call to get all pages associated with the base endpoint.
-	if err := c.pagedGet("/business_services"+queryParms.Encode(), responseHandler); err != nil {
+	if err := c.pagedGet(context.TODO(), "/business_services"+queryParms.Encode(), responseHandler); err != nil {
 		return nil, err
 	}
 	businessServiceResponse.BusinessServices = businessServices
@@ -87,19 +88,19 @@ func (c *Client) ListBusinessServices(o ListBusinessServiceOptions) (*ListBusine
 func (c *Client) CreateBusinessService(b *BusinessService) (*BusinessService, *http.Response, error) {
 	data := make(map[string]*BusinessService)
 	data["business_service"] = b
-	resp, err := c.post("/business_services", data, nil)
+	resp, err := c.post(context.TODO(), "/business_services", data, nil)
 	return getBusinessServiceFromResponse(c, resp, err)
 }
 
 // GetBusinessService gets details about a business service.
 func (c *Client) GetBusinessService(ID string) (*BusinessService, *http.Response, error) {
-	resp, err := c.get("/business_services/" + ID)
+	resp, err := c.get(context.TODO(), "/business_services/"+ID)
 	return getBusinessServiceFromResponse(c, resp, err)
 }
 
 // DeleteBusinessService deletes a business_service.
 func (c *Client) DeleteBusinessService(ID string) error {
-	_, err := c.delete("/business_services/" + ID)
+	_, err := c.delete(context.TODO(), "/business_services/"+ID)
 	return err
 }
 
@@ -109,7 +110,7 @@ func (c *Client) UpdateBusinessService(b *BusinessService) (*BusinessService, *h
 	id := b.ID
 	b.ID = ""
 	v["business_service"] = b
-	resp, err := c.put("/business_services/"+id, v, nil)
+	resp, err := c.put(context.TODO(), "/business_services/"+id, v, nil)
 	return getBusinessServiceFromResponse(c, resp, err)
 }
 

--- a/change_events.go
+++ b/change_events.go
@@ -2,8 +2,10 @@ package pagerduty
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 )
 
 const changeEventPath = "/v2/change/enqueue"
@@ -55,8 +57,9 @@ func (c *Client) CreateChangeEvent(e ChangeEvent) (*ChangeEventResponse, error) 
 	}
 
 	resp, err := c.doWithEndpoint(
+		context.TODO(),
 		c.v2EventsAPIEndpoint,
-		"POST",
+		http.MethodPost,
 		changeEventPath,
 		false,
 		bytes.NewBuffer(data),

--- a/escalation_policy.go
+++ b/escalation_policy.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -62,7 +63,7 @@ func (c *Client) ListEscalationPolicies(o ListEscalationPoliciesOptions) (*ListE
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get(escPath + "?" + v.Encode())
+	resp, err := c.get(context.TODO(), escPath+"?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -74,13 +75,13 @@ func (c *Client) ListEscalationPolicies(o ListEscalationPoliciesOptions) (*ListE
 func (c *Client) CreateEscalationPolicy(e EscalationPolicy) (*EscalationPolicy, error) {
 	data := make(map[string]EscalationPolicy)
 	data["escalation_policy"] = e
-	resp, err := c.post(escPath, data, nil)
+	resp, err := c.post(context.TODO(), escPath, data, nil)
 	return getEscalationPolicyFromResponse(c, resp, err)
 }
 
 // DeleteEscalationPolicy deletes an existing escalation policy and rules.
 func (c *Client) DeleteEscalationPolicy(id string) error {
-	_, err := c.delete(escPath + "/" + id)
+	_, err := c.delete(context.TODO(), escPath+"/"+id)
 	return err
 }
 
@@ -95,7 +96,7 @@ func (c *Client) GetEscalationPolicy(id string, o *GetEscalationPolicyOptions) (
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get(escPath + "/" + id + "?" + v.Encode())
+	resp, err := c.get(context.TODO(), escPath+"/"+id+"?"+v.Encode())
 	return getEscalationPolicyFromResponse(c, resp, err)
 }
 
@@ -103,7 +104,7 @@ func (c *Client) GetEscalationPolicy(id string, o *GetEscalationPolicyOptions) (
 func (c *Client) UpdateEscalationPolicy(id string, e *EscalationPolicy) (*EscalationPolicy, error) {
 	data := make(map[string]EscalationPolicy)
 	data["escalation_policy"] = *e
-	resp, err := c.put(escPath+"/"+id, data, nil)
+	resp, err := c.put(context.TODO(), escPath+"/"+id, data, nil)
 	return getEscalationPolicyFromResponse(c, resp, err)
 }
 
@@ -112,7 +113,7 @@ func (c *Client) UpdateEscalationPolicy(id string, e *EscalationPolicy) (*Escala
 func (c *Client) CreateEscalationRule(escID string, e EscalationRule) (*EscalationRule, error) {
 	data := make(map[string]EscalationRule)
 	data["escalation_rule"] = e
-	resp, err := c.post(escPath+"/"+escID+"/escalation_rules", data, nil)
+	resp, err := c.post(context.TODO(), escPath+"/"+escID+"/escalation_rules", data, nil)
 	return getEscalationRuleFromResponse(c, resp, err)
 }
 
@@ -122,13 +123,13 @@ func (c *Client) GetEscalationRule(escID string, id string, o *GetEscalationRule
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get(escPath + "/" + escID + "/escalation_rules/" + id + "?" + v.Encode())
+	resp, err := c.get(context.TODO(), escPath+"/"+escID+"/escalation_rules/"+id+"?"+v.Encode())
 	return getEscalationRuleFromResponse(c, resp, err)
 }
 
 // DeleteEscalationRule deletes an existing escalation rule.
 func (c *Client) DeleteEscalationRule(escID string, id string) error {
-	_, err := c.delete(escPath + "/" + escID + "/escalation_rules/" + id)
+	_, err := c.delete(context.TODO(), escPath+"/"+escID+"/escalation_rules/"+id)
 	return err
 }
 
@@ -136,13 +137,13 @@ func (c *Client) DeleteEscalationRule(escID string, id string) error {
 func (c *Client) UpdateEscalationRule(escID string, id string, e *EscalationRule) (*EscalationRule, error) {
 	data := make(map[string]EscalationRule)
 	data["escalation_rule"] = *e
-	resp, err := c.put(escPath+"/"+escID+"/escalation_rules/"+id, data, nil)
+	resp, err := c.put(context.TODO(), escPath+"/"+escID+"/escalation_rules/"+id, data, nil)
 	return getEscalationRuleFromResponse(c, resp, err)
 }
 
 // ListEscalationRules lists all of the escalation rules for an existing escalation policy.
 func (c *Client) ListEscalationRules(escID string) (*ListEscalationRulesResponse, error) {
-	resp, err := c.get(escPath + "/" + escID + "/escalation_rules")
+	resp, err := c.get(context.TODO(), escPath+"/"+escID+"/escalation_rules")
 	if err != nil {
 		return nil, err
 	}

--- a/event_v2.go
+++ b/event_v2.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -48,9 +49,16 @@ func ManageEvent(e V2Event) (*V2EventResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, _ := http.NewRequest("POST", v2eventEndPoint, bytes.NewBuffer(data))
+
+	req, err := http.NewRequestWithContext(context.TODO(), http.MethodPost, v2eventEndPoint, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
 	req.Header.Set("User-Agent", "go-pagerduty/"+Version)
 	req.Header.Set("Content-Type", "application/json")
+
+	// TODO(theckman): switch to a package-local default client
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -78,7 +86,8 @@ func (c *Client) ManageEvent(e *V2Event) (*V2EventResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.doWithEndpoint(c.v2EventsAPIEndpoint, "POST", "/v2/enqueue", false, bytes.NewBuffer(data), &headers)
+
+	resp, err := c.doWithEndpoint(context.TODO(), c.v2EventsAPIEndpoint, http.MethodPost, "/v2/enqueue", false, bytes.NewBuffer(data), &headers)
 	if err != nil {
 		return nil, err
 	}

--- a/extension.go
+++ b/extension.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -34,7 +35,7 @@ func (c *Client) ListExtensions(o ListExtensionOptions) (*ListExtensionResponse,
 		return nil, err
 	}
 
-	resp, err := c.get("/extensions?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/extensions?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -45,22 +46,22 @@ func (c *Client) ListExtensions(o ListExtensionOptions) (*ListExtensionResponse,
 }
 
 func (c *Client) CreateExtension(e *Extension) (*Extension, error) {
-	resp, err := c.post("/extensions", e, nil)
+	resp, err := c.post(context.TODO(), "/extensions", e, nil)
 	return getExtensionFromResponse(c, resp, err)
 }
 
 func (c *Client) DeleteExtension(id string) error {
-	_, err := c.delete("/extensions/" + id)
+	_, err := c.delete(context.TODO(), "/extensions/"+id)
 	return err
 }
 
 func (c *Client) GetExtension(id string) (*Extension, error) {
-	resp, err := c.get("/extensions/" + id)
+	resp, err := c.get(context.TODO(), "/extensions/"+id)
 	return getExtensionFromResponse(c, resp, err)
 }
 
 func (c *Client) UpdateExtension(id string, e *Extension) (*Extension, error) {
-	resp, err := c.put("/extensions/"+id, e, nil)
+	resp, err := c.put(context.TODO(), "/extensions/"+id, e, nil)
 	return getExtensionFromResponse(c, resp, err)
 }
 

--- a/extension_schema.go
+++ b/extension_schema.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -35,7 +36,7 @@ func (c *Client) ListExtensionSchemas(o ListExtensionSchemaOptions) (*ListExtens
 		return nil, err
 	}
 
-	resp, err := c.get("/extension_schemas?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/extension_schemas?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +47,7 @@ func (c *Client) ListExtensionSchemas(o ListExtensionSchemaOptions) (*ListExtens
 }
 
 func (c *Client) GetExtensionSchema(id string) (*ExtensionSchema, error) {
-	resp, err := c.get("/extension_schemas/" + id)
+	resp, err := c.get(context.TODO(), "/extension_schemas/"+id)
 	return getExtensionSchemaFromResponse(c, resp, err)
 }
 

--- a/incident.go
+++ b/incident.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -125,7 +126,7 @@ func (c *Client) ListIncidents(o ListIncidentsOptions) (*ListIncidentsResponse, 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/incidents?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/incidents?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +173,7 @@ func (c *Client) CreateIncident(from string, o *CreateIncidentOptions) (*Inciden
 	headers["From"] = from
 	data := make(map[string]*CreateIncidentOptions)
 	data["incident"] = o
-	resp, e := c.post("/incidents", data, &headers)
+	resp, e := c.post(context.TODO(), "/incidents", data, &headers)
 	if e != nil {
 		return nil, e
 	}
@@ -193,7 +194,7 @@ func (c *Client) ManageIncidents(from string, incidents []ManageIncidentsOptions
 	headers["From"] = from
 	data["incidents"] = incidents
 
-	resp, err := c.put("/incidents", data, &headers)
+	resp, err := c.put(context.TODO(), "/incidents", data, &headers)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +209,7 @@ func (c *Client) MergeIncidents(from string, id string, sourceIncidents []MergeI
 	headers := make(map[string]string)
 	headers["From"] = from
 
-	resp, err := c.put("/incidents/"+id+"/merge", r, &headers)
+	resp, err := c.put(context.TODO(), "/incidents/"+id+"/merge", r, &headers)
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +219,7 @@ func (c *Client) MergeIncidents(from string, id string, sourceIncidents []MergeI
 
 // GetIncident shows detailed information about an incident.
 func (c *Client) GetIncident(id string) (*Incident, error) {
-	resp, err := c.get("/incidents/" + id)
+	resp, err := c.get(context.TODO(), "/incidents/"+id)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +249,7 @@ type CreateIncidentNoteResponse struct {
 
 // ListIncidentNotes lists existing notes for the specified incident.
 func (c *Client) ListIncidentNotes(id string) ([]IncidentNote, error) {
-	resp, err := c.get("/incidents/" + id + "/notes")
+	resp, err := c.get(context.TODO(), "/incidents/"+id+"/notes")
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +313,7 @@ func (c *Client) ListIncidentAlertsWithOpts(id string, o ListIncidentAlertsOptio
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/incidents/" + id + "/alerts?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/incidents/"+id+"/alerts?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -328,7 +329,7 @@ func (c *Client) CreateIncidentNoteWithResponse(id string, note IncidentNote) (*
 	headers["From"] = note.User.Summary
 
 	data["note"] = note
-	resp, err := c.post("/incidents/"+id+"/notes", data, &headers)
+	resp, err := c.post(context.TODO(), "/incidents/"+id+"/notes", data, &headers)
 	if err != nil {
 		return nil, err
 	}
@@ -348,9 +349,8 @@ func (c *Client) CreateIncidentNote(id string, note IncidentNote) error {
 	data := make(map[string]IncidentNote)
 	headers := make(map[string]string)
 	headers["From"] = note.User.Summary
-
 	data["note"] = note
-	_, err := c.post("/incidents/"+id+"/notes", data, &headers)
+	_, err := c.post(context.TODO(), "/incidents/"+id+"/notes", data, &headers)
 	return err
 }
 
@@ -358,7 +358,7 @@ func (c *Client) CreateIncidentNote(id string, note IncidentNote) error {
 func (c *Client) SnoozeIncidentWithResponse(id string, duration uint) (*Incident, error) {
 	data := make(map[string]uint)
 	data["duration"] = duration
-	resp, err := c.post("/incidents/"+id+"/snooze", data, nil)
+	resp, err := c.post(context.TODO(), "/incidents/"+id+"/snooze", data, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +376,7 @@ func (c *Client) SnoozeIncidentWithResponse(id string, duration uint) (*Incident
 func (c *Client) SnoozeIncident(id string, duration uint) error {
 	data := make(map[string]uint)
 	data["duration"] = duration
-	_, err := c.post("/incidents/"+id+"/snooze", data, nil)
+	_, err := c.post(context.TODO(), "/incidents/"+id+"/snooze", data, nil)
 	return err
 }
 
@@ -402,7 +402,7 @@ func (c *Client) ListIncidentLogEntries(id string, o ListIncidentLogEntriesOptio
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/incidents/" + id + "/log_entries?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/incidents/"+id+"/log_entries?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -459,7 +459,7 @@ func (c *Client) ResponderRequest(id string, o ResponderRequestOptions) (*Respon
 	headers := make(map[string]string)
 	headers["From"] = o.From
 
-	resp, err := c.post("/incidents/"+id+"/responder_requests", o, &headers)
+	resp, err := c.post(context.TODO(), "/incidents/"+id+"/responder_requests", o, &headers)
 	if err != nil {
 		return nil, err
 	}
@@ -471,7 +471,7 @@ func (c *Client) ResponderRequest(id string, o ResponderRequestOptions) (*Respon
 
 // GetIncidentAlert
 func (c *Client) GetIncidentAlert(incidentID, alertID string) (*IncidentAlertResponse, *http.Response, error) {
-	resp, err := c.get("/incidents/" + incidentID + "/alerts/" + alertID)
+	resp, err := c.get(context.TODO(), "/incidents/"+incidentID+"/alerts/"+alertID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -485,7 +485,7 @@ func (c *Client) GetIncidentAlert(incidentID, alertID string) (*IncidentAlertRes
 func (c *Client) ManageIncidentAlerts(incidentID string, alerts *IncidentAlertList) (*ListAlertsResponse, *http.Response, error) {
 	headers := make(map[string]string)
 
-	resp, err := c.put("/incidents/"+incidentID+"/alerts/", alerts, &headers)
+	resp, err := c.put(context.TODO(), "/incidents/"+incidentID+"/alerts/", alerts, &headers)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/log_entry.go
+++ b/log_entry.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -65,7 +66,7 @@ func (c *Client) ListLogEntries(o ListLogEntriesOptions) (*ListLogEntryResponse,
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/log_entries?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/log_entries?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -88,12 +89,12 @@ func (c *Client) GetLogEntry(id string, o GetLogEntryOptions) (*LogEntry, error)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/log_entries/" + id + "?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/log_entries/"+id+"?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
-	var result map[string]LogEntry
 
+	var result map[string]LogEntry
 	if err := c.decodeJSON(resp, &result); err != nil {
 		return nil, err
 	}
@@ -108,7 +109,6 @@ func (c *Client) GetLogEntry(id string, o GetLogEntryOptions) (*LogEntry, error)
 // UnmarshalJSON Expands the LogEntry.Channel object to parse out a raw value
 func (c *Channel) UnmarshalJSON(b []byte) error {
 	var raw map[string]interface{}
-
 	if err := json.Unmarshal(b, &raw); err != nil {
 		return err
 	}

--- a/maintenance_window.go
+++ b/maintenance_window.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -41,7 +42,7 @@ func (c *Client) ListMaintenanceWindows(o ListMaintenanceWindowsOptions) (*ListM
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/maintenance_windows?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/maintenance_windows?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +59,7 @@ func (c *Client) CreateMaintenanceWindow(from string, o MaintenanceWindow) (*Mai
 	if from != "" {
 		headers["From"] = from
 	}
-	resp, err := c.post("/maintenance_windows", data, &headers)
+	resp, err := c.post(context.TODO(), "/maintenance_windows", data, &headers)
 	return getMaintenanceWindowFromResponse(c, resp, err)
 }
 
@@ -70,7 +71,7 @@ func (c *Client) CreateMaintenanceWindows(o MaintenanceWindow) (*MaintenanceWind
 
 // DeleteMaintenanceWindow deletes an existing maintenance window if it's in the future, or ends it if it's currently on-going.
 func (c *Client) DeleteMaintenanceWindow(id string) error {
-	_, err := c.delete("/maintenance_windows/" + id)
+	_, err := c.delete(context.TODO(), "/maintenance_windows/"+id)
 	return err
 }
 
@@ -85,13 +86,13 @@ func (c *Client) GetMaintenanceWindow(id string, o GetMaintenanceWindowOptions) 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/maintenance_windows/" + id + "?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/maintenance_windows/"+id+"?"+v.Encode())
 	return getMaintenanceWindowFromResponse(c, resp, err)
 }
 
 // UpdateMaintenanceWindow updates an existing maintenance window.
 func (c *Client) UpdateMaintenanceWindow(m MaintenanceWindow) (*MaintenanceWindow, error) {
-	resp, err := c.put("/maintenance_windows/"+m.ID, m, nil)
+	resp, err := c.put(context.TODO(), "/maintenance_windows/"+m.ID, m, nil)
 	return getMaintenanceWindowFromResponse(c, resp, err)
 }
 

--- a/notification.go
+++ b/notification.go
@@ -1,6 +1,8 @@
 package pagerduty
 
 import (
+	"context"
+
 	"github.com/google/go-querystring/query"
 )
 
@@ -35,7 +37,7 @@ func (c *Client) ListNotifications(o ListNotificationOptions) (*ListNotification
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/notifications?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/notifications?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}

--- a/on_call.go
+++ b/on_call.go
@@ -1,6 +1,8 @@
 package pagerduty
 
 import (
+	"context"
+
 	"github.com/google/go-querystring/query"
 )
 
@@ -39,7 +41,7 @@ func (c *Client) ListOnCalls(o ListOnCallOptions) (*ListOnCallsResponse, error) 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/oncalls?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/oncalls?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}

--- a/priorites.go
+++ b/priorites.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"encoding/json"
 )
 
@@ -18,15 +19,17 @@ type Priorities struct {
 
 // ListPriorities lists existing priorities
 func (c *Client) ListPriorities() (*Priorities, error) {
-	resp, e := c.get("/priorities")
-	if e != nil {
-		return nil, e
+	resp, err := c.get(context.TODO(), "/priorities")
+	if err != nil {
+		return nil, err
 	}
 
+	// TODO(theckman): make sure we close the resp.Body here
+
 	var p Priorities
-	e = json.NewDecoder(resp.Body).Decode(&p)
-	if e != nil {
-		return nil, e
+	err = json.NewDecoder(resp.Body).Decode(&p)
+	if err != nil {
+		return nil, err
 	}
 
 	return &p, nil

--- a/ruleset.go
+++ b/ruleset.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 )
@@ -157,7 +158,7 @@ func (c *Client) ListRulesets() (*ListRulesetsResponse, error) {
 	}
 
 	// Make call to get all pages associated with the base endpoint.
-	if err := c.pagedGet("/rulesets/", responseHandler); err != nil {
+	if err := c.pagedGet(context.TODO(), "/rulesets/", responseHandler); err != nil {
 		return nil, err
 	}
 	rulesetResponse.Rulesets = rulesets
@@ -169,19 +170,19 @@ func (c *Client) ListRulesets() (*ListRulesetsResponse, error) {
 func (c *Client) CreateRuleset(r *Ruleset) (*Ruleset, *http.Response, error) {
 	data := make(map[string]*Ruleset)
 	data["ruleset"] = r
-	resp, err := c.post("/rulesets", data, nil)
+	resp, err := c.post(context.TODO(), "/rulesets", data, nil)
 	return getRulesetFromResponse(c, resp, err)
 }
 
 // DeleteRuleset deletes a ruleset.
 func (c *Client) DeleteRuleset(id string) error {
-	_, err := c.delete("/rulesets/" + id)
+	_, err := c.delete(context.TODO(), "/rulesets/"+id)
 	return err
 }
 
 // GetRuleset gets details about a ruleset.
 func (c *Client) GetRuleset(id string) (*Ruleset, *http.Response, error) {
-	resp, err := c.get("/rulesets/" + id)
+	resp, err := c.get(context.TODO(), "/rulesets/"+id)
 	return getRulesetFromResponse(c, resp, err)
 }
 
@@ -189,7 +190,7 @@ func (c *Client) GetRuleset(id string) (*Ruleset, *http.Response, error) {
 func (c *Client) UpdateRuleset(r *Ruleset) (*Ruleset, *http.Response, error) {
 	v := make(map[string]*Ruleset)
 	v["ruleset"] = r
-	resp, err := c.put("/rulesets/"+r.ID, v, nil)
+	resp, err := c.put(context.TODO(), "/rulesets/"+r.ID, v, nil)
 	return getRulesetFromResponse(c, resp, err)
 }
 
@@ -234,7 +235,7 @@ func (c *Client) ListRulesetRules(rulesetID string) (*ListRulesetRulesResponse, 
 	}
 
 	// Make call to get all pages associated with the base endpoint.
-	if err := c.pagedGet("/rulesets/"+rulesetID+"/rules", responseHandler); err != nil {
+	if err := c.pagedGet(context.TODO(), "/rulesets/"+rulesetID+"/rules", responseHandler); err != nil {
 		return nil, err
 	}
 	rulesResponse.Rules = rules
@@ -244,13 +245,13 @@ func (c *Client) ListRulesetRules(rulesetID string) (*ListRulesetRulesResponse, 
 
 // GetRulesetRule gets an event rule
 func (c *Client) GetRulesetRule(rulesetID, ruleID string) (*RulesetRule, *http.Response, error) {
-	resp, err := c.get("/rulesets/" + rulesetID + "/rules/" + ruleID)
+	resp, err := c.get(context.TODO(), "/rulesets/"+rulesetID+"/rules/"+ruleID)
 	return getRuleFromResponse(c, resp, err)
 }
 
 // DeleteRulesetRule deletes a rule.
 func (c *Client) DeleteRulesetRule(rulesetID, ruleID string) error {
-	_, err := c.delete("/rulesets/" + rulesetID + "/rules/" + ruleID)
+	_, err := c.delete(context.TODO(), "/rulesets/"+rulesetID+"/rules/"+ruleID)
 	return err
 }
 
@@ -258,7 +259,7 @@ func (c *Client) DeleteRulesetRule(rulesetID, ruleID string) error {
 func (c *Client) CreateRulesetRule(rulesetID string, rule *RulesetRule) (*RulesetRule, *http.Response, error) {
 	data := make(map[string]*RulesetRule)
 	data["rule"] = rule
-	resp, err := c.post("/rulesets/"+rulesetID+"/rules/", data, nil)
+	resp, err := c.post(context.TODO(), "/rulesets/"+rulesetID+"/rules/", data, nil)
 	return getRuleFromResponse(c, resp, err)
 }
 
@@ -266,7 +267,7 @@ func (c *Client) CreateRulesetRule(rulesetID string, rule *RulesetRule) (*Rulese
 func (c *Client) UpdateRulesetRule(rulesetID, ruleID string, r *RulesetRule) (*RulesetRule, *http.Response, error) {
 	v := make(map[string]*RulesetRule)
 	v["rule"] = r
-	resp, err := c.put("/rulesets/"+rulesetID+"/rules/"+ruleID, v, nil)
+	resp, err := c.put(context.TODO(), "/rulesets/"+rulesetID+"/rules/"+ruleID, v, nil)
 	return getRuleFromResponse(c, resp, err)
 }
 

--- a/schedule.go
+++ b/schedule.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -73,7 +74,7 @@ func (c *Client) ListSchedules(o ListSchedulesOptions) (*ListSchedulesResponse, 
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/schedules?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/schedules?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +86,7 @@ func (c *Client) ListSchedules(o ListSchedulesOptions) (*ListSchedulesResponse, 
 func (c *Client) CreateSchedule(s Schedule) (*Schedule, error) {
 	data := make(map[string]Schedule)
 	data["schedule"] = s
-	resp, err := c.post("/schedules", data, nil)
+	resp, err := c.post(context.TODO(), "/schedules", data, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -108,13 +109,13 @@ func (c *Client) PreviewSchedule(s Schedule, o PreviewScheduleOptions) error {
 	}
 	var data map[string]Schedule
 	data["schedule"] = s
-	_, e := c.post("/schedules/preview?"+v.Encode(), data, nil)
-	return e
+	_, err = c.post(context.TODO(), "/schedules/preview?"+v.Encode(), data, nil)
+	return err
 }
 
 // DeleteSchedule deletes an on-call schedule.
 func (c *Client) DeleteSchedule(id string) error {
-	_, err := c.delete("/schedules/" + id)
+	_, err := c.delete(context.TODO(), "/schedules/"+id)
 	return err
 }
 
@@ -132,7 +133,7 @@ func (c *Client) GetSchedule(id string, o GetScheduleOptions) (*Schedule, error)
 	if err != nil {
 		return nil, fmt.Errorf("Could not parse values for query: %v", err)
 	}
-	resp, err := c.get("/schedules/" + id + "?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/schedules/"+id+"?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +149,7 @@ type UpdateScheduleOptions struct {
 func (c *Client) UpdateSchedule(id string, s Schedule) (*Schedule, error) {
 	v := make(map[string]Schedule)
 	v["schedule"] = s
-	resp, err := c.put("/schedules/"+id, v, nil)
+	resp, err := c.put(context.TODO(), "/schedules/"+id, v, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +185,7 @@ func (c *Client) ListOverrides(id string, o ListOverridesOptions) (*ListOverride
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/schedules/" + id + "/overrides?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/schedules/"+id+"/overrides?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +197,7 @@ func (c *Client) ListOverrides(id string, o ListOverridesOptions) (*ListOverride
 func (c *Client) CreateOverride(id string, o Override) (*Override, error) {
 	data := make(map[string]Override)
 	data["override"] = o
-	resp, err := c.post("/schedules/"+id+"/overrides", data, nil)
+	resp, err := c.post(context.TODO(), "/schedules/"+id+"/overrides", data, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -205,7 +206,7 @@ func (c *Client) CreateOverride(id string, o Override) (*Override, error) {
 
 // DeleteOverride removes an override.
 func (c *Client) DeleteOverride(scheduleID, overrideID string) error {
-	_, err := c.delete("/schedules/" + scheduleID + "/overrides/" + overrideID)
+	_, err := c.delete(context.TODO(), "/schedules/"+scheduleID+"/overrides/"+overrideID)
 	return err
 }
 
@@ -222,7 +223,7 @@ func (c *Client) ListOnCallUsers(id string, o ListOnCallUsersOptions) ([]User, e
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/schedules/" + id + "/users?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/schedules/"+id+"/users?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}

--- a/service.go
+++ b/service.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -112,7 +113,7 @@ func (c *Client) ListServices(o ListServiceOptions) (*ListServiceResponse, error
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/services?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/services?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +129,7 @@ type GetServiceOptions struct {
 // GetService gets details about an existing service.
 func (c *Client) GetService(id string, o *GetServiceOptions) (*Service, error) {
 	v, err := query.Values(o)
-	resp, err := c.get("/services/" + id + "?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/services/"+id+"?"+v.Encode())
 	return getServiceFromResponse(c, resp, err)
 }
 
@@ -136,7 +137,7 @@ func (c *Client) GetService(id string, o *GetServiceOptions) (*Service, error) {
 func (c *Client) CreateService(s Service) (*Service, error) {
 	data := make(map[string]Service)
 	data["service"] = s
-	resp, err := c.post("/services", data, nil)
+	resp, err := c.post(context.TODO(), "/services", data, nil)
 	return getServiceFromResponse(c, resp, err)
 }
 
@@ -147,13 +148,13 @@ func (c *Client) UpdateService(s Service) (*Service, error) {
 	}{
 		s,
 	}
-	resp, err := c.put("/services/"+s.ID, body, nil)
+	resp, err := c.put(context.TODO(), "/services/"+s.ID, body, nil)
 	return getServiceFromResponse(c, resp, err)
 }
 
 // DeleteService deletes an existing service.
 func (c *Client) DeleteService(id string) error {
-	_, err := c.delete("/services/" + id)
+	_, err := c.delete(context.TODO(), "/services/"+id)
 	return err
 }
 
@@ -161,7 +162,7 @@ func (c *Client) DeleteService(id string) error {
 func (c *Client) CreateIntegration(id string, i Integration) (*Integration, error) {
 	data := make(map[string]Integration)
 	data["integration"] = i
-	resp, err := c.post("/services/"+id+"/integrations", data, nil)
+	resp, err := c.post(context.TODO(), "/services/"+id+"/integrations", data, nil)
 	return getIntegrationFromResponse(c, resp, err)
 }
 
@@ -176,19 +177,19 @@ func (c *Client) GetIntegration(serviceID, integrationID string, o GetIntegratio
 	if queryErr != nil {
 		return nil, queryErr
 	}
-	resp, err := c.get("/services/" + serviceID + "/integrations/" + integrationID + "?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/services/"+serviceID+"/integrations/"+integrationID+"?"+v.Encode())
 	return getIntegrationFromResponse(c, resp, err)
 }
 
 // UpdateIntegration updates an integration belonging to a service.
 func (c *Client) UpdateIntegration(serviceID string, i Integration) (*Integration, error) {
-	resp, err := c.put("/services/"+serviceID+"/integrations/"+i.ID, i, nil)
+	resp, err := c.put(context.TODO(), "/services/"+serviceID+"/integrations/"+i.ID, i, nil)
 	return getIntegrationFromResponse(c, resp, err)
 }
 
 // DeleteIntegration deletes an existing integration.
 func (c *Client) DeleteIntegration(serviceID string, integrationID string) error {
-	_, err := c.delete("/services/" + serviceID + "/integrations/" + integrationID)
+	_, err := c.delete(context.TODO(), "/services/"+serviceID+"/integrations/"+integrationID)
 	return err
 }
 

--- a/service_dependency.go
+++ b/service_dependency.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"net/http"
 )
 
@@ -25,7 +26,7 @@ type ListServiceDependencies struct {
 
 // ListBusinessServiceDependencies lists dependencies of a business service.
 func (c *Client) ListBusinessServiceDependencies(businessServiceID string) (*ListServiceDependencies, *http.Response, error) {
-	resp, err := c.get("/service_dependencies/business_services/" + businessServiceID)
+	resp, err := c.get(context.TODO(), "/service_dependencies/business_services/"+businessServiceID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -35,7 +36,7 @@ func (c *Client) ListBusinessServiceDependencies(businessServiceID string) (*Lis
 
 // ListTechnicalServiceDependencies lists dependencies of a technical service.
 func (c *Client) ListTechnicalServiceDependencies(serviceID string) (*ListServiceDependencies, *http.Response, error) {
-	resp, err := c.get("/service_dependencies/technical_services/" + serviceID)
+	resp, err := c.get(context.TODO(), "/service_dependencies/technical_services/"+serviceID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -45,7 +46,7 @@ func (c *Client) ListTechnicalServiceDependencies(serviceID string) (*ListServic
 
 // AssociateServiceDependencies Create new dependencies between two services.
 func (c *Client) AssociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
-	resp, err := c.post("/service_dependencies/associate", dependencies, nil)
+	resp, err := c.post(context.TODO(), "/service_dependencies/associate", dependencies, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -55,7 +56,7 @@ func (c *Client) AssociateServiceDependencies(dependencies *ListServiceDependenc
 
 // DisassociateServiceDependencies Disassociate dependencies between two services.
 func (c *Client) DisassociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
-	resp, err := c.post("/service_dependencies/disassociate", dependencies, nil)
+	resp, err := c.post(context.TODO(), "/service_dependencies/disassociate", dependencies, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/team.go
+++ b/team.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -33,7 +34,7 @@ func (c *Client) ListTeams(o ListTeamOptions) (*ListTeamResponse, error) {
 		return nil, err
 	}
 
-	resp, err := c.get("/teams?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/teams?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -43,49 +44,49 @@ func (c *Client) ListTeams(o ListTeamOptions) (*ListTeamResponse, error) {
 
 // CreateTeam creates a new team.
 func (c *Client) CreateTeam(t *Team) (*Team, error) {
-	resp, err := c.post("/teams", t, nil)
+	resp, err := c.post(context.TODO(), "/teams", t, nil)
 	return getTeamFromResponse(c, resp, err)
 }
 
 // DeleteTeam removes an existing team.
 func (c *Client) DeleteTeam(id string) error {
-	_, err := c.delete("/teams/" + id)
+	_, err := c.delete(context.TODO(), "/teams/"+id)
 	return err
 }
 
 // GetTeam gets details about an existing team.
 func (c *Client) GetTeam(id string) (*Team, error) {
-	resp, err := c.get("/teams/" + id)
+	resp, err := c.get(context.TODO(), "/teams/"+id)
 	return getTeamFromResponse(c, resp, err)
 }
 
 // UpdateTeam updates an existing team.
 func (c *Client) UpdateTeam(id string, t *Team) (*Team, error) {
-	resp, err := c.put("/teams/"+id, t, nil)
+	resp, err := c.put(context.TODO(), "/teams/"+id, t, nil)
 	return getTeamFromResponse(c, resp, err)
 }
 
 // RemoveEscalationPolicyFromTeam removes an escalation policy from a team.
 func (c *Client) RemoveEscalationPolicyFromTeam(teamID, epID string) error {
-	_, err := c.delete("/teams/" + teamID + "/escalation_policies/" + epID)
+	_, err := c.delete(context.TODO(), "/teams/"+teamID+"/escalation_policies/"+epID)
 	return err
 }
 
 // AddEscalationPolicyToTeam adds an escalation policy to a team.
 func (c *Client) AddEscalationPolicyToTeam(teamID, epID string) error {
-	_, err := c.put("/teams/"+teamID+"/escalation_policies/"+epID, nil, nil)
+	_, err := c.put(context.TODO(), "/teams/"+teamID+"/escalation_policies/"+epID, nil, nil)
 	return err
 }
 
 // RemoveUserFromTeam removes a user from a team.
 func (c *Client) RemoveUserFromTeam(teamID, userID string) error {
-	_, err := c.delete("/teams/" + teamID + "/users/" + userID)
+	_, err := c.delete(context.TODO(), "/teams/"+teamID+"/users/"+userID)
 	return err
 }
 
 // AddUserToTeam adds a user to a team.
 func (c *Client) AddUserToTeam(teamID, userID string) error {
-	_, err := c.put("/teams/"+teamID+"/users/"+userID, nil, nil)
+	_, err := c.put(context.TODO(), "/teams/"+teamID+"/users/"+userID, nil, nil)
 	return err
 }
 
@@ -131,7 +132,7 @@ func (c *Client) ListMembers(teamID string, o ListMembersOptions) (*ListMembersR
 		return nil, err
 	}
 
-	resp, err := c.get("/teams/" + teamID + "/members?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/teams/"+teamID+"/members?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +164,7 @@ func (c *Client) ListAllMembers(teamID string) ([]Member, error) {
 	}
 
 	// Make call to get all pages associated with the base endpoint.
-	if err := c.pagedGet("/teams/"+teamID+"/members", responseHandler); err != nil {
+	if err := c.pagedGet(context.TODO(), "/teams/"+teamID+"/members", responseHandler); err != nil {
 		return nil, err
 	}
 

--- a/user.go
+++ b/user.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -94,7 +95,7 @@ func (c *Client) ListUsers(o ListUsersOptions) (*ListUsersResponse, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/users?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/users?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -106,13 +107,13 @@ func (c *Client) ListUsers(o ListUsersOptions) (*ListUsersResponse, error) {
 func (c *Client) CreateUser(u User) (*User, error) {
 	data := make(map[string]User)
 	data["user"] = u
-	resp, err := c.post("/users", data, nil)
+	resp, err := c.post(context.TODO(), "/users", data, nil)
 	return getUserFromResponse(c, resp, err)
 }
 
 // DeleteUser deletes a user.
 func (c *Client) DeleteUser(id string) error {
-	_, err := c.delete("/users/" + id)
+	_, err := c.delete(context.TODO(), "/users/"+id)
 	return err
 }
 
@@ -122,7 +123,7 @@ func (c *Client) GetUser(id string, o GetUserOptions) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/users/" + id + "?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/users/"+id+"?"+v.Encode())
 	return getUserFromResponse(c, resp, err)
 }
 
@@ -130,7 +131,7 @@ func (c *Client) GetUser(id string, o GetUserOptions) (*User, error) {
 func (c *Client) UpdateUser(u User) (*User, error) {
 	v := make(map[string]User)
 	v["user"] = u
-	resp, err := c.put("/users/"+u.ID, v, nil)
+	resp, err := c.put(context.TODO(), "/users/"+u.ID, v, nil)
 	return getUserFromResponse(c, resp, err)
 }
 
@@ -140,7 +141,7 @@ func (c *Client) GetCurrentUser(o GetCurrentUserOptions) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.get("/users/me?" + v.Encode())
+	resp, err := c.get(context.TODO(), "/users/me?"+v.Encode())
 	return getUserFromResponse(c, resp, err)
 }
 
@@ -162,7 +163,7 @@ func getUserFromResponse(c *Client, resp *http.Response, err error) (*User, erro
 
 // ListUserContactMethods fetches contact methods of the existing user.
 func (c *Client) ListUserContactMethods(userID string) (*ListContactMethodsResponse, error) {
-	resp, err := c.get("/users/" + userID + "/contact_methods")
+	resp, err := c.get(context.TODO(), "/users/"+userID+"/contact_methods")
 	if err != nil {
 		return nil, err
 	}
@@ -172,13 +173,13 @@ func (c *Client) ListUserContactMethods(userID string) (*ListContactMethodsRespo
 
 // GetUserContactMethod gets details about a contact method.
 func (c *Client) GetUserContactMethod(userID, contactMethodID string) (*ContactMethod, error) {
-	resp, err := c.get("/users/" + userID + "/contact_methods/" + contactMethodID)
+	resp, err := c.get(context.TODO(), "/users/"+userID+"/contact_methods/"+contactMethodID)
 	return getContactMethodFromResponse(c, resp, err)
 }
 
 // DeleteUserContactMethod deletes a user.
 func (c *Client) DeleteUserContactMethod(userID, contactMethodID string) error {
-	_, err := c.delete("/users/" + userID + "/contact_methods/" + contactMethodID)
+	_, err := c.delete(context.TODO(), "/users/"+userID+"/contact_methods/"+contactMethodID)
 	return err
 }
 
@@ -186,7 +187,7 @@ func (c *Client) DeleteUserContactMethod(userID, contactMethodID string) error {
 func (c *Client) CreateUserContactMethod(userID string, cm ContactMethod) (*ContactMethod, error) {
 	data := make(map[string]ContactMethod)
 	data["contact_method"] = cm
-	resp, err := c.post("/users/"+userID+"/contact_methods", data, nil)
+	resp, err := c.post(context.TODO(), "/users/"+userID+"/contact_methods", data, nil)
 	return getContactMethodFromResponse(c, resp, err)
 }
 
@@ -194,7 +195,7 @@ func (c *Client) CreateUserContactMethod(userID string, cm ContactMethod) (*Cont
 func (c *Client) UpdateUserContactMethod(userID string, cm ContactMethod) (*ContactMethod, error) {
 	v := make(map[string]ContactMethod)
 	v["contact_method"] = cm
-	resp, err := c.put("/users/"+userID+"/contact_methods/"+cm.ID, v, nil)
+	resp, err := c.put(context.TODO(), "/users/"+userID+"/contact_methods/"+cm.ID, v, nil)
 	return getContactMethodFromResponse(c, resp, err)
 }
 
@@ -216,7 +217,7 @@ func getContactMethodFromResponse(c *Client, resp *http.Response, err error) (*C
 
 // GetUserNotificationRule gets details about a notification rule.
 func (c *Client) GetUserNotificationRule(userID, ruleID string) (*NotificationRule, error) {
-	resp, err := c.get("/users/" + userID + "/notification_rules/" + ruleID)
+	resp, err := c.get(context.TODO(), "/users/"+userID+"/notification_rules/"+ruleID)
 	return getUserNotificationRuleFromResponse(c, resp, err)
 }
 
@@ -224,7 +225,7 @@ func (c *Client) GetUserNotificationRule(userID, ruleID string) (*NotificationRu
 func (c *Client) CreateUserNotificationRule(userID string, rule NotificationRule) (*NotificationRule, error) {
 	data := make(map[string]NotificationRule)
 	data["notification_rule"] = rule
-	resp, err := c.post("/users/"+userID+"/notification_rules", data, nil)
+	resp, err := c.post(context.TODO(), "/users/"+userID+"/notification_rules", data, nil)
 	return getUserNotificationRuleFromResponse(c, resp, err)
 }
 
@@ -232,19 +233,19 @@ func (c *Client) CreateUserNotificationRule(userID string, rule NotificationRule
 func (c *Client) UpdateUserNotificationRule(userID string, rule NotificationRule) (*NotificationRule, error) {
 	data := make(map[string]NotificationRule)
 	data["notification_rule"] = rule
-	resp, err := c.put("/users/"+userID+"/notification_rules/"+rule.ID, data, nil)
+	resp, err := c.put(context.TODO(), "/users/"+userID+"/notification_rules/"+rule.ID, data, nil)
 	return getUserNotificationRuleFromResponse(c, resp, err)
 }
 
 // DeleteUserNotificationRule deletes a notification rule for a user.
 func (c *Client) DeleteUserNotificationRule(userID, ruleID string) error {
-	_, err := c.delete("/users/" + userID + "/notification_rules/" + ruleID)
+	_, err := c.delete(context.TODO(), "/users/"+userID+"/notification_rules/"+ruleID)
 	return err
 }
 
 // ListUserNotificationRules fetches notification rules of the existing user.
 func (c *Client) ListUserNotificationRules(userID string) (*ListUserNotificationRulesResponse, error) {
-	resp, err := c.get("/users/" + userID + "/notification_rules")
+	resp, err := c.get(context.TODO(), "/users/"+userID+"/notification_rules")
 	if err != nil {
 		return nil, err
 	}

--- a/vendor.go
+++ b/vendor.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -39,13 +40,11 @@ type ListVendorOptions struct {
 // ListVendors lists existing vendors.
 func (c *Client) ListVendors(o ListVendorOptions) (*ListVendorResponse, error) {
 	v, err := query.Values(o)
-
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := c.get("/vendors?" + v.Encode())
-
+	resp, err := c.get(context.TODO(), "/vendors?"+v.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +55,7 @@ func (c *Client) ListVendors(o ListVendorOptions) (*ListVendorResponse, error) {
 
 // GetVendor gets details about an existing vendor.
 func (c *Client) GetVendor(id string) (*Vendor, error) {
-	resp, err := c.get("/vendors/" + id)
+	resp, err := c.get(context.TODO(), "/vendors/"+id)
 	return getVendorFromResponse(c, resp, err)
 }
 


### PR DESCRIPTION
As of today there is not a way for callers to control the timeout of requests on
a per-call basis, as we do not expose context.Context in the APIs of this
package.

This change updates some of the internal code paths to use context.Context,
making use of a context.TODO() for now (until we can expose context.Context) in
the API.

This change also includes some style changes to help make the code a bit less
dense / more idiomatic in some cases. This also adds a few TODO comments, as a
reminder to come back and look at concerning blocks of code that caught my eye.