### PR TITLE
Update internal HTTP methods to not take pointer to map as argument

### DIFF
--- a/change_events.go
+++ b/change_events.go
@@ -63,7 +63,7 @@ func (c *Client) CreateChangeEvent(e ChangeEvent) (*ChangeEventResponse, error) 
 		changeEventPath,
 		false,
 		bytes.NewBuffer(data),
-		&headers,
+		headers,
 	)
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -225,7 +225,7 @@ func (c *Client) delete(ctx context.Context, path string) (*http.Response, error
 	return c.do(ctx, http.MethodDelete, path, nil, nil)
 }
 
-func (c *Client) put(ctx context.Context, path string, payload interface{}, headers *map[string]string) (*http.Response, error) {
+func (c *Client) put(ctx context.Context, path string, payload interface{}, headers map[string]string) (*http.Response, error) {
 	if payload != nil {
 		data, err := json.Marshal(payload)
 		if err != nil {
@@ -236,7 +236,7 @@ func (c *Client) put(ctx context.Context, path string, payload interface{}, head
 	return c.do(ctx, http.MethodPut, path, nil, headers)
 }
 
-func (c *Client) post(ctx context.Context, path string, payload interface{}, headers *map[string]string) (*http.Response, error) {
+func (c *Client) post(ctx context.Context, path string, payload interface{}, headers map[string]string) (*http.Response, error) {
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
@@ -249,17 +249,16 @@ func (c *Client) get(ctx context.Context, path string) (*http.Response, error) {
 }
 
 // needed where pagerduty use a different endpoint for certain actions (eg: v2 events)
-func (c *Client) doWithEndpoint(ctx context.Context, endpoint, method, path string, authRequired bool, body io.Reader, headers *map[string]string) (*http.Response, error) {
+func (c *Client) doWithEndpoint(ctx context.Context, endpoint, method, path string, authRequired bool, body io.Reader, headers map[string]string) (*http.Response, error) {
 	req, err := http.NewRequestWithContext(ctx, method, endpoint+path, body)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build request: %w", err)
 	}
 
 	req.Header.Set("Accept", "application/vnd.pagerduty+json;version=2")
-	if headers != nil {
-		for k, v := range *headers {
-			req.Header.Set(k, v)
-		}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 
 	if authRequired {
@@ -278,7 +277,7 @@ func (c *Client) doWithEndpoint(ctx context.Context, endpoint, method, path stri
 	return c.checkResponse(resp, err)
 }
 
-func (c *Client) do(ctx context.Context, method, path string, body io.Reader, headers *map[string]string) (*http.Response, error) {
+func (c *Client) do(ctx context.Context, method, path string, body io.Reader, headers map[string]string) (*http.Response, error) {
 	return c.doWithEndpoint(ctx, c.apiEndpoint, method, path, true, body, headers)
 }
 

--- a/event_v2.go
+++ b/event_v2.go
@@ -87,7 +87,7 @@ func (c *Client) ManageEvent(e *V2Event) (*V2EventResponse, error) {
 		return nil, err
 	}
 
-	resp, err := c.doWithEndpoint(context.TODO(), c.v2EventsAPIEndpoint, http.MethodPost, "/v2/enqueue", false, bytes.NewBuffer(data), &headers)
+	resp, err := c.doWithEndpoint(context.TODO(), c.v2EventsAPIEndpoint, http.MethodPost, "/v2/enqueue", false, bytes.NewBuffer(data), headers)
 	if err != nil {
 		return nil, err
 	}

--- a/incident.go
+++ b/incident.go
@@ -173,7 +173,7 @@ func (c *Client) CreateIncident(from string, o *CreateIncidentOptions) (*Inciden
 	headers["From"] = from
 	data := make(map[string]*CreateIncidentOptions)
 	data["incident"] = o
-	resp, e := c.post(context.TODO(), "/incidents", data, &headers)
+	resp, e := c.post(context.TODO(), "/incidents", data, headers)
 	if e != nil {
 		return nil, e
 	}
@@ -194,7 +194,7 @@ func (c *Client) ManageIncidents(from string, incidents []ManageIncidentsOptions
 	headers["From"] = from
 	data["incidents"] = incidents
 
-	resp, err := c.put(context.TODO(), "/incidents", data, &headers)
+	resp, err := c.put(context.TODO(), "/incidents", data, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -209,7 +209,7 @@ func (c *Client) MergeIncidents(from string, id string, sourceIncidents []MergeI
 	headers := make(map[string]string)
 	headers["From"] = from
 
-	resp, err := c.put(context.TODO(), "/incidents/"+id+"/merge", r, &headers)
+	resp, err := c.put(context.TODO(), "/incidents/"+id+"/merge", r, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +329,7 @@ func (c *Client) CreateIncidentNoteWithResponse(id string, note IncidentNote) (*
 	headers["From"] = note.User.Summary
 
 	data["note"] = note
-	resp, err := c.post(context.TODO(), "/incidents/"+id+"/notes", data, &headers)
+	resp, err := c.post(context.TODO(), "/incidents/"+id+"/notes", data, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (c *Client) CreateIncidentNote(id string, note IncidentNote) error {
 	headers := make(map[string]string)
 	headers["From"] = note.User.Summary
 	data["note"] = note
-	_, err := c.post(context.TODO(), "/incidents/"+id+"/notes", data, &headers)
+	_, err := c.post(context.TODO(), "/incidents/"+id+"/notes", data, headers)
 	return err
 }
 
@@ -459,7 +459,7 @@ func (c *Client) ResponderRequest(id string, o ResponderRequestOptions) (*Respon
 	headers := make(map[string]string)
 	headers["From"] = o.From
 
-	resp, err := c.post(context.TODO(), "/incidents/"+id+"/responder_requests", o, &headers)
+	resp, err := c.post(context.TODO(), "/incidents/"+id+"/responder_requests", o, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -485,7 +485,7 @@ func (c *Client) GetIncidentAlert(incidentID, alertID string) (*IncidentAlertRes
 func (c *Client) ManageIncidentAlerts(incidentID string, alerts *IncidentAlertList) (*ListAlertsResponse, *http.Response, error) {
 	headers := make(map[string]string)
 
-	resp, err := c.put(context.TODO(), "/incidents/"+incidentID+"/alerts/", alerts, &headers)
+	resp, err := c.put(context.TODO(), "/incidents/"+incidentID+"/alerts/", alerts, headers)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/maintenance_window.go
+++ b/maintenance_window.go
@@ -59,7 +59,7 @@ func (c *Client) CreateMaintenanceWindow(from string, o MaintenanceWindow) (*Mai
 	if from != "" {
 		headers["From"] = from
 	}
-	resp, err := c.post(context.TODO(), "/maintenance_windows", data, &headers)
+	resp, err := c.post(context.TODO(), "/maintenance_windows", data, headers)
 	return getMaintenanceWindowFromResponse(c, resp, err)
 }
 


### PR DESCRIPTION
Map types themselves are reference types, and can be passed in as `nil` even
without declaring the value as a pointer to the map.

Likewise, for maps that are nil the `range` operator is safe and no-ops and so
we do not need a nil check before doing the range. If for some reason we wanted
a check, a length check would be more appropriate than a nil check but it's not
necessary.