### PR TITLE
Fix possible nil pointer dereference in APIError.NotFound() method

### DIFF
--- a/client.go
+++ b/client.go
@@ -124,7 +124,7 @@ func (a APIError) Temporary() bool {
 // NotFound returns whether this was an error where it seems like the resource
 // was not found.
 func (a APIError) NotFound() bool {
-	return a.StatusCode == http.StatusNotFound || a.APIError.Code == 2100
+	return a.StatusCode == http.StatusNotFound || (a.APIError != nil && a.APIError.Code == 2100)
 }
 
 func newDefaultHTTPClient() *http.Client {


### PR DESCRIPTION
If someone were to receive a PagerDuty response that did not contain the error
JSON object, they would hit a nil pointer dereference if they attempted to call
the .NotFound() method if the status code is not 404.

This fixes it by doing a nil check before attempting to read the value to do the
comparison.