### PR TITLE
Fix tags on log entry options struct

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -392,8 +392,8 @@ type ListIncidentLogEntriesOptions struct {
 	Includes   []string `url:"include,omitempty,brackets"`
 	IsOverview bool     `url:"is_overview,omitempty"`
 	TimeZone   string   `url:"time_zone,omitempty"`
-	Since      string   `url:since,omitempty`
-	Until      string   `url:until,omitempty`
+	Since      string   `url:"since,omitempty"`
+	Until      string   `url:"until,omitempty"`
 }
 
 // ListIncidentLogEntries lists existing log entries for the specified incident.


### PR DESCRIPTION
Currently calls to fetch log entries don't respect the tags, and therefore use `Since` rather than `since` in the query params.  This means they aren't respected and all results are returned.