### PR TITLE
Update service_dependency.go to accept a context.Context

### DIFF
--- a/service_dependency.go
+++ b/service_dependency.go
@@ -25,41 +25,105 @@ type ListServiceDependencies struct {
 }
 
 // ListBusinessServiceDependencies lists dependencies of a business service.
+// It's recommended to use ListBusinessServiceDependenciesWithContext instead.
 func (c *Client) ListBusinessServiceDependencies(businessServiceID string) (*ListServiceDependencies, *http.Response, error) {
-	resp, err := c.get(context.TODO(), "/service_dependencies/business_services/"+businessServiceID)
+	return c.listBusinessServiceDependenciesWithContext(context.Background(), businessServiceID)
+}
+
+// ListBusinessServiceDependenciesWithContext lists dependencies of a business service.
+func (c *Client) ListBusinessServiceDependenciesWithContext(ctx context.Context, businessServiceID string) (*ListServiceDependencies, error) {
+	lsd, _, err := c.listBusinessServiceDependenciesWithContext(ctx, businessServiceID)
+	return lsd, err
+}
+
+func (c *Client) listBusinessServiceDependenciesWithContext(ctx context.Context, businessServiceID string) (*ListServiceDependencies, *http.Response, error) {
+	resp, err := c.get(ctx, "/service_dependencies/business_services/"+businessServiceID)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var result ListServiceDependencies
-	return &result, resp, c.decodeJSON(resp, &result)
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, resp, err
+	}
+
+	return &result, resp, nil
 }
 
 // ListTechnicalServiceDependencies lists dependencies of a technical service.
+// It's recommended to use ListTechnicalServiceDependenciesWithContext instead.
 func (c *Client) ListTechnicalServiceDependencies(serviceID string) (*ListServiceDependencies, *http.Response, error) {
-	resp, err := c.get(context.TODO(), "/service_dependencies/technical_services/"+serviceID)
+	return c.listTechnicalServiceDependenciesWithContext(context.Background(), serviceID)
+}
+
+// ListTechnicalServiceDependenciesWithContext lists dependencies of a technical service.
+func (c *Client) ListTechnicalServiceDependenciesWithContext(ctx context.Context, serviceID string) (*ListServiceDependencies, error) {
+	lsd, _, err := c.listTechnicalServiceDependenciesWithContext(ctx, serviceID)
+	return lsd, err
+}
+
+func (c *Client) listTechnicalServiceDependenciesWithContext(ctx context.Context, serviceID string) (*ListServiceDependencies, *http.Response, error) {
+	resp, err := c.get(ctx, "/service_dependencies/technical_services/"+serviceID)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var result ListServiceDependencies
-	return &result, resp, c.decodeJSON(resp, &result)
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, resp, err
+	}
+
+	return &result, resp, nil
 }
 
 // AssociateServiceDependencies Create new dependencies between two services.
+// It's recommended to use AssociateServiceDependenciesWithContext instead.
 func (c *Client) AssociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
+	return c.associateServiceDependenciesWithContext(context.Background(), dependencies)
+}
+
+// AssociateServiceDependenciesWithContext Create new dependencies between two services.
+func (c *Client) AssociateServiceDependenciesWithContext(ctx context.Context, dependencies *ListServiceDependencies) (*ListServiceDependencies, error) {
+	lsd, _, err := c.associateServiceDependenciesWithContext(ctx, dependencies)
+	return lsd, err
+}
+
+func (c *Client) associateServiceDependenciesWithContext(ctx context.Context, dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
 	resp, err := c.post(context.TODO(), "/service_dependencies/associate", dependencies, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var result ListServiceDependencies
-	return &result, resp, c.decodeJSON(resp, &result)
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, resp, err
+	}
+
+	return &result, resp, nil
 }
 
 // DisassociateServiceDependencies Disassociate dependencies between two services.
 func (c *Client) DisassociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
-	resp, err := c.post(context.TODO(), "/service_dependencies/disassociate", dependencies, nil)
+	return c.disassociateServiceDependenciesWithContext(context.Background(), dependencies)
+}
+
+// DisassociateServiceDependenciesWithContext Disassociate dependencies between two services.
+func (c *Client) DisassociateServiceDependenciesWithContext(ctx context.Context, dependencies *ListServiceDependencies) (*ListServiceDependencies, error) {
+	lsd, _, err := c.disassociateServiceDependenciesWithContext(ctx, dependencies)
+	return lsd, err
+}
+
+// DisassociateServiceDependencies Disassociate dependencies between two services.
+func (c *Client) disassociateServiceDependenciesWithContext(ctx context.Context, dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
+	resp, err := c.post(ctx, "/service_dependencies/disassociate", dependencies, nil)
 	if err != nil {
 		return nil, nil, err
 	}
+
 	var result ListServiceDependencies
-	return &result, resp, c.decodeJSON(resp, &result)
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, resp, err
+	}
+
+	return &result, resp, nil
 }


### PR DESCRIPTION
This also updates the new methods to not return the `*http.Response`, as it
doesn't seem needed.

Updates #267