### PR TITLE
Add support for Service Event Rules

### DIFF
--- a/ruleset.go
+++ b/ruleset.go
@@ -104,13 +104,14 @@ type ListRulesetRulesResponse struct {
 
 // RuleActions represents a rule action
 type RuleActions struct {
-	Suppress    *RuleActionSuppress     `json:"suppress,omitempty"`
 	Annotate    *RuleActionParameter    `json:"annotate,omitempty"`
-	Severity    *RuleActionParameter    `json:"severity,omitempty"`
-	Priority    *RuleActionParameter    `json:"priority,omitempty"`
-	Route       *RuleActionParameter    `json:"route"`
 	EventAction *RuleActionParameter    `json:"event_action,omitempty"`
 	Extractions []*RuleActionExtraction `json:"extractions,omitempty"`
+	Priority    *RuleActionParameter    `json:"priority,omitempty"`
+	Severity    *RuleActionParameter    `json:"severity,omitempty"`
+	Suppress    *RuleActionSuppress     `json:"suppress,omitempty"`
+	Suspend     *RuleActionSuspend      `json:"suspend,omitempty"`
+	Route       *RuleActionParameter    `json:"route"`
 }
 
 // RuleActionParameter represents a generic parameter object on a rule action
@@ -124,6 +125,11 @@ type RuleActionSuppress struct {
 	ThresholdValue      int    `json:"threshold_value,omitempty"`
 	ThresholdTimeUnit   string `json:"threshold_time_unit,omitempty"`
 	ThresholdTimeAmount int    `json:"threshold_time_amount,omitempty"`
+}
+
+// RuleActionSuspend represents a rule suspend action object
+type RuleActionSuspend struct {
+	Value bool `json:"value,omitempty"`
 }
 
 // RuleActionExtraction represents a rule extraction action object

--- a/service_test.go
+++ b/service_test.go
@@ -429,3 +429,129 @@ func TestService_DeleteIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+// List Service Rules
+func TestService_ListRules(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/1/rules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"rules": [{"id": "1"}]}`))
+	})
+
+	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+
+	serviceID := "1"
+	res, err := client.ListServicetRules(serviceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListServiceRulesResponse{
+		Rules: []*ServiceRule{
+			{
+				ID: "1",
+			},
+		},
+	}
+	testEqual(t, want, res)
+}
+
+// Create Service Rule
+func TestService_CreateServiceRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/1/rules/", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Write([]byte(`{"rule": {"id": "1"}}`))
+	})
+
+	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+
+	serviceID := "1"
+	rule := &ServiceRule{}
+
+	res, _, err := client.CreateServiceRule(serviceID, rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ServiceRule{
+		ID: "1",
+	}
+	testEqual(t, want, res)
+}
+
+// Get Service Rule
+func TestService_GetServiceRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/1/rules/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Write([]byte(`{"rule": {"id": "1"}}`))
+	})
+
+	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+
+	serviceID := "1"
+	ruleID := "1"
+	res, _, err := client.GetServiceRule(serviceID, ruleID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ServiceRule{
+		ID: "1",
+	}
+	testEqual(t, want, res)
+}
+
+// Update Service Rule
+func TestService_UpdateServiceRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/1/rules/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Write([]byte(`{"rule": {"id": "1"}}`))
+	})
+
+	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+
+	serviceID := "1"
+	ruleID := "1"
+	rule := &ServiceRule{}
+
+	res, _, err := client.UpdateServiceRule(serviceID, ruleID, rule)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ServiceRule{
+		ID: "1",
+	}
+	testEqual(t, want, res)
+}
+
+// Delete Service Rule
+func TestService_DeleteServiceRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/1/rules/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	serviceID := "1"
+	ruleID := "1"
+
+	err := client.DeleteServiceRule(serviceID, ruleID)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Adding support for Service Event Rules. API reference:
[List Service's Event Rules](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1services~1%7Bid%7D~1rules/get)
[Get an Event Rule from a Service](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1services~1%7Bid%7D~1rules~1%7Brule_id%7D/get)
[Delete an Event Rule from a Service](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1services~1%7Bid%7D~1rules~1%7Brule_id%7D/delete)
[Create an Event Rule on a Service](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1services~1%7Bid%7D~1rules/post)
[Update an Event Rule on a Service](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1services~1%7Bid%7D~1rules~1%7Brule_id%7D/put)

Also, added the "suspend" rule action to keep the rule payload up to date with the API.