### PR TITLE
Fix invalid JSON struct tag, and other linter issues

### DIFF
--- a/ability.go
+++ b/ability.go
@@ -28,12 +28,12 @@ func (c *Client) ListAbilitiesWithContext(ctx context.Context) (*ListAbilityResp
 	return &result, nil
 }
 
-// TestAbility Check if your account has the given ability.
+// TestAbility checks if your account has the given ability.
 func (c *Client) TestAbility(ability string) error {
 	return c.TestAbilityWithContext(context.Background(), ability)
 }
 
-// TestAbility Check if your account has the given ability.
+// TestAbilityWithContext checks if your account has the given ability.
 func (c *Client) TestAbilityWithContext(ctx context.Context, ability string) error {
 	_, err := c.get(ctx, "/abilities/"+ability)
 	return err

--- a/ability_test.go
+++ b/ability_test.go
@@ -12,14 +12,13 @@ func TestAbility_ListAbilities(t *testing.T) {
 
 	mux.HandleFunc("/abilities", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"abilities": ["sso"]}`))
+		_, _ = w.Write([]byte(`{"abilities": ["sso"]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	want := &ListAbilityResponse{Abilities: []string{"sso"}}
 
 	res, err := client.ListAbilities()
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +34,7 @@ func TestAbility_ListAbilitiesFailure(t *testing.T) {
 		w.WriteHeader(http.StatusForbidden)
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	if _, err := client.ListAbilities(); err == nil {
 		t.Fatal("expected error; got nil")
@@ -51,7 +50,7 @@ func TestAbility_TestAbility(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	if err := client.TestAbility("sso"); err != nil {
 		t.Fatal(err)
@@ -67,7 +66,7 @@ func TestAbility_TestAbilityFailure(t *testing.T) {
 		w.WriteHeader(http.StatusForbidden)
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	if err := client.TestAbility("sso"); err == nil {
 		t.Fatal("expected error; got nil")

--- a/addon_test.go
+++ b/addon_test.go
@@ -11,11 +11,11 @@ func TestAddon_List(t *testing.T) {
 
 	mux.HandleFunc("/addons", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"addons": [{"name": "Internal Status Page"}]}`))
+		_, _ = w.Write([]byte(`{"addons": [{"name": "Internal Status Page"}]}`))
 	})
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
 	var opts ListAddonOptions
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.ListAddons(opts)
 	want := &ListAddonResponse{
@@ -43,10 +43,10 @@ func TestAddon_Install(t *testing.T) {
 	mux.HandleFunc("/addons", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte(`{"addon": {"name": "Internal Status Page", "id": "1"}}`))
+		_, _ = w.Write([]byte(`{"addon": {"name": "Internal Status Page", "id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.InstallAddon(input)
 
@@ -68,9 +68,9 @@ func TestAddon_Get(t *testing.T) {
 
 	mux.HandleFunc("/addons/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"addon": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"addon": {"id": "1"}}`))
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.GetAddon("1")
 
@@ -91,9 +91,9 @@ func TestAddon_Update(t *testing.T) {
 
 	mux.HandleFunc("/addons/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"addon": {"name": "Internal Status Page", "id": "1"}}`))
+		_, _ = w.Write([]byte(`{"addon": {"name": "Internal Status Page", "id": "1"}}`))
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	input := Addon{
 		Name: "Internal Status Page",
@@ -121,9 +121,8 @@ func TestAddon_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 		w.WriteHeader(http.StatusNoContent)
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	err := client.DeleteAddon("1")
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -30,14 +30,17 @@ func TestAnalytics_GetAggregatedIncidentData(t *testing.T) {
 	}
 
 	bytesAnalyticsResponse, err := json.Marshal(analyticsResponse)
+	testErrCheck(t, "json.Marshal()", "", err)
+
 	mux.HandleFunc("/analytics/metrics/incidents/all", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write(bytesAnalyticsResponse)
+		_, _ = w.Write(bytesAnalyticsResponse)
 	})
 
-	client := &Client{apiEndpoint: server.URL,
-		authToken:  "foo",
-		HTTPClient: defaultHTTPClient,
+	client := &Client{
+		apiEndpoint: server.URL,
+		authToken:   "foo",
+		HTTPClient:  defaultHTTPClient,
 	}
 
 	res, err := client.GetAggregatedIncidentData(context.Background(), analyticsRequest)
@@ -75,14 +78,17 @@ func TestAnalytics_GetAggregatedServiceData(t *testing.T) {
 		TimeZone:      "Etc/UTC",
 	}
 	bytesAnalyticsResponse, err := json.Marshal(analyticsResponse)
+	testErrCheck(t, "json.Marshal()", "", err)
+
 	mux.HandleFunc("/analytics/metrics/incidents/services", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write(bytesAnalyticsResponse)
+		_, _ = w.Write(bytesAnalyticsResponse)
 	})
 
-	client := &Client{apiEndpoint: server.URL,
-		authToken:  "foo",
-		HTTPClient: defaultHTTPClient,
+	client := &Client{
+		apiEndpoint: server.URL,
+		authToken:   "foo",
+		HTTPClient:  defaultHTTPClient,
 	}
 
 	res, err := client.GetAggregatedServiceData(context.Background(), analyticsRequest)
@@ -120,14 +126,17 @@ func TestAnalytics_GetAggregatedTeamData(t *testing.T) {
 		TimeZone:      "Etc/UTC",
 	}
 	bytesAnalyticsResponse, err := json.Marshal(analyticsResponse)
+	testErrCheck(t, "json.Marshal()", "", err)
+
 	mux.HandleFunc("/analytics/metrics/incidents/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write(bytesAnalyticsResponse)
+		_, _ = w.Write(bytesAnalyticsResponse)
 	})
 
-	client := &Client{apiEndpoint: server.URL,
-		authToken:  "foo",
-		HTTPClient: defaultHTTPClient,
+	client := &Client{
+		apiEndpoint: server.URL,
+		authToken:   "foo",
+		HTTPClient:  defaultHTTPClient,
 	}
 
 	res, err := client.GetAggregatedTeamData(context.Background(), analyticsRequest)

--- a/business_service_test.go
+++ b/business_service_test.go
@@ -14,12 +14,12 @@ func TestBusinessService_List(t *testing.T) {
 
 	mux.HandleFunc("/business_services/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"business_services": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"business_services": [{"id": "1"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListBusinessServiceOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListBusinessServiceOptions{
 		APIListObject: listObj,
 	}
 	res, err := client.ListBusinessServices(opts)
@@ -44,10 +44,10 @@ func TestBusinessService_Create(t *testing.T) {
 
 	mux.HandleFunc("/business_services", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"business_service": {"id": "1", "name": "foo"}}`))
+		_, _ = w.Write([]byte(`{"business_service": {"id": "1", "name": "foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := &BusinessService{
 		Name: "foo",
 	}
@@ -71,10 +71,10 @@ func TestBusinessService_Get(t *testing.T) {
 
 	mux.HandleFunc("/business_services/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"business_service": {"id": "1", "name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"business_service": {"id": "1", "name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	ruleSetID := "1"
 
 	res, _, err := client.GetBusinessService(ruleSetID)
@@ -109,10 +109,10 @@ func TestBusinessService_Update(t *testing.T) {
 			t.Fatalf("got ID in the body when we were not supposed to")
 		}
 
-		w.Write([]byte(`{"business_service": {"id": "1", "name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"business_service": {"id": "1", "name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := &BusinessService{
 		ID:   "1",
 		Name: "foo",
@@ -139,10 +139,9 @@ func TestBusinessService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	ID := "1"
 	err := client.DeleteBusinessService(ID)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/change_events_test.go
+++ b/change_events_test.go
@@ -22,11 +22,11 @@ func TestChangeEvent_Create(t *testing.T) {
 		"/v2/change/enqueue", func(w http.ResponseWriter, r *http.Request) {
 			testMethod(t, r, "POST")
 			w.WriteHeader(http.StatusAccepted)
-			w.Write([]byte(`{"message": "Change event processed", "status": "success"}`))
+			_, _ = w.Write([]byte(`{"message": "Change event processed", "status": "success"}`))
 		},
 	)
 
-	var client = &Client{
+	client := &Client{
 		v2EventsAPIEndpoint: server.URL,
 		apiEndpoint:         server.URL,
 		authToken:           "foo",
@@ -60,7 +60,6 @@ func TestChangeEvent_Create(t *testing.T) {
 	}
 
 	res, err := client.CreateChangeEvent(ce)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -82,7 +81,7 @@ func TestChangeEvent_CreateWithPayloadVerification(t *testing.T) {
 		},
 	)
 
-	var client = &Client{
+	client := &Client{
 		v2EventsAPIEndpoint: server.URL,
 		apiEndpoint:         server.URL,
 		authToken:           "foo",
@@ -111,5 +110,4 @@ func TestChangeEvent_CreateWithPayloadVerification(t *testing.T) {
 	}
 
 	_, _ = client.CreateChangeEvent(ce)
-
 }

--- a/client.go
+++ b/client.go
@@ -54,6 +54,8 @@ type APIReference struct {
 	Type string `json:"type,omitempty"`
 }
 
+// APIDetails are the fields required to represent a details non-hydrated
+// object.
 type APIDetails struct {
 	Type    string `json:"type,omitempty"`
 	Details string `json:"details,omitempty"`
@@ -312,7 +314,8 @@ func (c *Client) do(ctx context.Context, method, path string, body io.Reader, he
 }
 
 func (c *Client) decodeJSON(resp *http.Response, payload interface{}) error {
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // explicitly discard error
+
 	decoder := json.NewDecoder(resp.Body)
 	return decoder.Decode(payload)
 }

--- a/constants.go
+++ b/constants.go
@@ -1,5 +1,6 @@
 package pagerduty
 
 const (
-	Version = "1.1.2"
+	// Version is current version of this client.
+	Version = "1.4.0"
 )

--- a/escalation_policy_test.go
+++ b/escalation_policy_test.go
@@ -11,12 +11,12 @@ func TestEscalationPolicy_List(t *testing.T) {
 
 	mux.HandleFunc("/escalation_policies", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"escalation_policies": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"escalation_policies": [{"id": "1"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
 	var opts ListEscalationPoliciesOptions
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.ListEscalationPolicies(opts)
 
@@ -44,9 +44,9 @@ func TestEscalationPolicy_Create(t *testing.T) {
 
 	mux.HandleFunc("/escalation_policies", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"escalation_policy": {"name": "foo", "id": "1"}}`))
+		_, _ = w.Write([]byte(`{"escalation_policy": {"name": "foo", "id": "1"}}`))
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	res, err := client.CreateEscalationPolicy(input)
 
 	want := &EscalationPolicy{
@@ -70,7 +70,7 @@ func TestEscalationPolicy_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 		w.WriteHeader(http.StatusNoContent)
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	err := client.DeleteEscalationPolicy("1")
 	if err != nil {
 		t.Fatal(err)
@@ -83,9 +83,9 @@ func TestEscalationPolicy_Get(t *testing.T) {
 
 	mux.HandleFunc("/escalation_policies/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"escalation_policy": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"escalation_policy": {"id": "1"}}`))
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	var opts *GetEscalationPolicyOptions
 	res, err := client.GetEscalationPolicy("1", opts)
 
@@ -107,10 +107,10 @@ func TestEscalationPolicy_Update(t *testing.T) {
 
 	mux.HandleFunc("/escalation_policies/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"escalation_policy": {"name": "foo", "id": "1"}}`))
+		_, _ = w.Write([]byte(`{"escalation_policy": {"name": "foo", "id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := &EscalationPolicy{Name: "foo"}
 	want := &EscalationPolicy{
 		APIObject: APIObject{
@@ -119,7 +119,6 @@ func TestEscalationPolicy_Update(t *testing.T) {
 		Name: "foo",
 	}
 	res, err := client.UpdateEscalationPolicy("1", input)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,10 +139,10 @@ func TestEscalationPolicy_UpdateTeams(t *testing.T) {
 
 	mux.HandleFunc("/escalation_policies/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"escalation_policy": {"name": "foo", "id": "1", "teams": []}}`))
+		_, _ = w.Write([]byte(`{"escalation_policy": {"name": "foo", "id": "1", "teams": []}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	res, err := client.UpdateEscalationPolicy("1", input)
 
 	want := &EscalationPolicy{

--- a/event.go
+++ b/event.go
@@ -51,7 +51,9 @@ func CreateEventWithHTTPClient(e Event, client HTTPClient) (*EventResponse, erro
 	if err != nil {
 		return nil, fmt.Errorf("failed to action request: %w", err)
 	}
-	defer resp.Body.Close()
+
+	defer func() { _ = resp.Body.Close() }() // explicitly discard error
+
 	if resp.StatusCode != http.StatusOK {
 		return &EventResponse{HttpStatus: resp.StatusCode}, fmt.Errorf("HTTP Status Code: %d", resp.StatusCode)
 	}

--- a/event_v2.go
+++ b/event_v2.go
@@ -70,7 +70,7 @@ func ManageEventWithContext(ctx context.Context, e V2Event) (*V2EventResponse, e
 		return nil, err
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // explicitly discard error
 
 	if resp.StatusCode != http.StatusAccepted {
 		bytes, err := ioutil.ReadAll(resp.Body)

--- a/event_v2_test.go
+++ b/event_v2_test.go
@@ -11,9 +11,9 @@ func TestEventV2_ManageEvent(t *testing.T) {
 
 	mux.HandleFunc("/v2/enqueue", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"status": "ok", "dedup_key": "yes", "message": "ok"}`))
+		_, _ = w.Write([]byte(`{"status": "ok", "dedup_key": "yes", "message": "ok"}`))
 	})
-	var client = &Client{v2EventsAPIEndpoint: server.URL, apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{v2EventsAPIEndpoint: server.URL, apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	evt := &V2Event{
 		RoutingKey: "abc123",
 	}

--- a/extension_schema_test.go
+++ b/extension_schema_test.go
@@ -11,13 +11,12 @@ func TestExtensionSchema_List(t *testing.T) {
 
 	mux.HandleFunc("/extension_schemas", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"extension_schemas":[{"id":"1","summary":"foo","send_types":["trigger", "acknowledge", "resolve"]}]}`))
-
+		_, _ = w.Write([]byte(`{"extension_schemas":[{"id":"1","summary":"foo","send_types":["trigger", "acknowledge", "resolve"]}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListExtensionSchemaOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListExtensionSchemaOptions{
 		APIListObject: listObj,
 		Query:         "foo",
 	}
@@ -53,10 +52,10 @@ func TestExtensionSchema_Get(t *testing.T) {
 
 	mux.HandleFunc("/extension_schemas/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"extension_schema": {"name": "foo", "id": "1", "send_types": ["trigger", "acknowledge", "resolve"]}}`))
+		_, _ = w.Write([]byte(`{"extension_schema": {"name": "foo", "id": "1", "send_types": ["trigger", "acknowledge", "resolve"]}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.GetExtensionSchema("1")
 

--- a/extension_test.go
+++ b/extension_test.go
@@ -12,13 +12,12 @@ func TestExtension_List(t *testing.T) {
 
 	mux.HandleFunc("/extensions", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"extensions":[{"id":"1","summary":"foo","config": {"restrict": "any"}, "extension_objects":[{"id":"foo","summary":"foo"}]}]}`))
-
+		_, _ = w.Write([]byte(`{"extensions":[{"id":"1","summary":"foo","config": {"restrict": "any"}, "extension_objects":[{"id":"foo","summary":"foo"}]}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListExtensionOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListExtensionOptions{
 		APIListObject: listObj,
 		Query:         "foo",
 	}
@@ -70,15 +69,15 @@ func TestExtension_Create(t *testing.T) {
 		if name == "foo" {
 			testNoEndpointURL(t, got)
 			testMethod(t, r, "POST")
-			w.Write([]byte(`{"extension": {"name": "foo", "id": "1"}}`))
+			_, _ = w.Write([]byte(`{"extension": {"name": "foo", "id": "1"}}`))
 		} else {
 			testGotExpectedURL(t, "expected_url", got)
 			testMethod(t, r, "POST")
-			w.Write([]byte(`{"extension": {"name": "bar", "id": "2", "endpoint_url": "expected_url"}}`))
+			_, _ = w.Write([]byte(`{"extension": {"name": "bar", "id": "2", "endpoint_url": "expected_url"}}`))
 		}
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	want1 := &Extension{
 		Name: "foo",
@@ -117,7 +116,7 @@ func TestExtension_Delete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	if err := client.DeleteExtension("1"); err != nil {
 		t.Fatal(err)
@@ -130,10 +129,10 @@ func TestExtension_Get(t *testing.T) {
 
 	mux.HandleFunc("/extensions/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"extension": {"name": "foo", "id": "1"}}`))
+		_, _ = w.Write([]byte(`{"extension": {"name": "foo", "id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.GetExtension("1")
 
@@ -166,7 +165,7 @@ func TestExtension_Update(t *testing.T) {
 		testNoEndpointURL(t, got)
 
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"extension": {"name": "foo", "id": "1"}}`))
+		_, _ = w.Write([]byte(`{"extension": {"name": "foo", "id": "1"}}`))
 	})
 
 	mux.HandleFunc("/extensions/2", func(w http.ResponseWriter, r *http.Request) {
@@ -178,10 +177,10 @@ func TestExtension_Update(t *testing.T) {
 		testGotExpectedURL(t, "expected_url", got)
 
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"extension": {"name": "foo", "id": "2", "endpoint_url": "expected_url"}}`))
+		_, _ = w.Write([]byte(`{"extension": {"name": "foo", "id": "2", "endpoint_url": "expected_url"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	want1 := &Extension{
 		Name: "foo",

--- a/incident.go
+++ b/incident.go
@@ -40,7 +40,7 @@ type Priority struct {
 	Description string `json:"description,omitempty"`
 }
 
-// Resolve reason is the data structure describing the reason an incident was resolved
+// ResolveReason is the data structure describing the reason an incident was resolved
 type ResolveReason struct {
 	Type     string    `json:"type,omitempty"`
 	Incident APIObject `json:"incident"`
@@ -52,6 +52,7 @@ type IncidentBody struct {
 	Details string `json:"details,omitempty"`
 }
 
+// Assignee is an individual assigned to an incident.
 type Assignee struct {
 	Assignee APIObject `json:"assignee"`
 }
@@ -536,7 +537,8 @@ type IncidentResponders struct {
 	RequestedAt string    `json:"requested_at"`
 }
 
-// ResponderRequestResponse
+// ResponderRequestResponse is the response from the API when requesting someone
+// respond to an incident.
 type ResponderRequestResponse struct {
 	ResponderRequest ResponderRequest `json:"responder_request"`
 }

--- a/incident_test.go
+++ b/incident_test.go
@@ -11,12 +11,12 @@ func TestIncident_List(t *testing.T) {
 
 	mux.HandleFunc("/incidents", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"incidents": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"incidents": [{"id": "1"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
 	var opts ListIncidentsOptions
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.ListIncidents(opts)
 
@@ -34,6 +34,7 @@ func TestIncident_List(t *testing.T) {
 	}
 	testEqual(t, want, res)
 }
+
 func TestIncident_Create(t *testing.T) {
 	setup()
 	defer teardown()
@@ -46,9 +47,9 @@ func TestIncident_Create(t *testing.T) {
 
 	mux.HandleFunc("/incidents", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"incident": {"title": "foo", "id": "1", "urgency": "low"}}`))
+		_, _ = w.Write([]byte(`{"incident": {"title": "foo", "id": "1", "urgency": "low"}}`))
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	from := "foo@bar.com"
 	res, err := client.CreateIncident(from, input)
 
@@ -70,10 +71,10 @@ func TestIncident_Manage_status(t *testing.T) {
 
 	mux.HandleFunc("/incidents", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"incidents": [{"title": "foo", "id": "1", "status": "acknowledged"}]}`))
+		_, _ = w.Write([]byte(`{"incidents": [{"title": "foo", "id": "1", "status": "acknowledged"}]}`))
 	})
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	from := "foo@bar.com"
 
 	input := []ManageIncidentsOptions{
@@ -95,7 +96,6 @@ func TestIncident_Manage_status(t *testing.T) {
 		},
 	}
 	res, err := client.ManageIncidents(from, input)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,10 +108,10 @@ func TestIncident_Manage_priority(t *testing.T) {
 
 	mux.HandleFunc("/incidents", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"incidents": [{"title": "foo", "id": "1", "priority": {"id": "PRIORITY_ID_HERE", "type": "priority_reference"}}]}`))
+		_, _ = w.Write([]byte(`{"incidents": [{"title": "foo", "id": "1", "priority": {"id": "PRIORITY_ID_HERE", "type": "priority_reference"}}]}`))
 	})
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	from := "foo@bar.com"
 
 	input := []ManageIncidentsOptions{
@@ -141,7 +141,6 @@ func TestIncident_Manage_priority(t *testing.T) {
 		},
 	}
 	res, err := client.ManageIncidents(from, input)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,10 +153,10 @@ func TestIncident_Manage_assignments(t *testing.T) {
 
 	mux.HandleFunc("/incidents", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"incidents": [{"title": "foo", "id": "1", "assignments": [{"assignee":{"id": "ASSIGNEE_ONE", "type": "user_reference"}},{"assignee":{"id": "ASSIGNEE_TWO", "type": "user_reference"}}]}]}`))
+		_, _ = w.Write([]byte(`{"incidents": [{"title": "foo", "id": "1", "assignments": [{"assignee":{"id": "ASSIGNEE_ONE", "type": "user_reference"}},{"assignee":{"id": "ASSIGNEE_TWO", "type": "user_reference"}}]}]}`))
 	})
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	from := "foo@bar.com"
 
 	input := []ManageIncidentsOptions{
@@ -205,7 +204,6 @@ func TestIncident_Manage_assignments(t *testing.T) {
 		},
 	}
 	res, err := client.ManageIncidents(from, input)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -218,16 +216,15 @@ func TestIncident_Merge(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1/merge", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"incident": {"title": "foo", "id": "1"}}`))
+		_, _ = w.Write([]byte(`{"incident": {"title": "foo", "id": "1"}}`))
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	from := "foo@bar.com"
 
 	input := []MergeIncidentsOptions{{ID: "2", Type: "incident"}}
 	want := &Incident{Id: "1", Title: "foo"}
 
 	res, err := client.MergeIncidents(from, "1", input)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -240,10 +237,10 @@ func TestIncident_Get(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"incident": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"incident": {"id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	id := "1"
 	res, err := client.GetIncident(id)
@@ -262,10 +259,10 @@ func TestIncident_ListIncidentNotes(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1/notes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"notes": [{"id": "1","content":"foo"}]}`))
+		_, _ = w.Write([]byte(`{"notes": [{"id": "1","content":"foo"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 
 	res, err := client.ListIncidentNotes(id)
@@ -282,16 +279,17 @@ func TestIncident_ListIncidentNotes(t *testing.T) {
 	}
 	testEqual(t, want, res)
 }
+
 func TestIncident_ListIncidentAlerts(t *testing.T) {
 	setup()
 	defer teardown()
 
 	mux.HandleFunc("/incidents/1/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"alerts": [{"id": "1","summary":"foo"}]}`))
+		_, _ = w.Write([]byte(`{"alerts": [{"id": "1","summary":"foo"}]}`))
 	})
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 
 	res, err := client.ListIncidentAlerts(id)
@@ -313,19 +311,20 @@ func TestIncident_ListIncidentAlerts(t *testing.T) {
 	}
 	testEqual(t, want, res)
 }
+
 func TestIncident_ListIncidentAlertsWithOpts(t *testing.T) {
 	setup()
 	defer teardown()
 
 	mux.HandleFunc("/incidents/1/alerts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"alerts": [{"id": "1","summary":"foo"}]}`))
+		_, _ = w.Write([]byte(`{"alerts": [{"id": "1","summary":"foo"}]}`))
 	})
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 
-	var alertOpts = ListIncidentAlertsOptions{
+	alertOpts := ListIncidentAlertsOptions{
 		APIListObject: listObj,
 		Includes:      []string{},
 	}
@@ -361,12 +360,11 @@ func TestIncident_CreateIncidentNote(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1/notes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"note": {"id": "1","content": "foo"}}`))
+		_, _ = w.Write([]byte(`{"note": {"id": "1","content": "foo"}}`))
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	err := client.CreateIncidentNote(id, input)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -383,9 +381,9 @@ func TestIncident_CreateIncidentNoteWithResponse(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1/notes", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"note": {"id": "1","content": "foo"}}`))
+		_, _ = w.Write([]byte(`{"note": {"id": "1","content": "foo"}}`))
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	res, err := client.CreateIncidentNoteWithResponse(id, input)
 
@@ -407,9 +405,9 @@ func TestIncident_SnoozeIncident(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1/snooze", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"incident": {"id": "1", "pending_actions": [{"type": "unacknowledge", "at":"2019-12-31T16:58:35Z"}]}}`))
+		_, _ = w.Write([]byte(`{"incident": {"id": "1", "pending_actions": [{"type": "unacknowledge", "at":"2019-12-31T16:58:35Z"}]}}`))
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	var duration uint = 3600
 	id := "1"
 
@@ -426,9 +424,9 @@ func TestIncident_SnoozeIncidentWithResponse(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1/snooze", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"incident": {"id": "1", "pending_actions": [{"type": "unacknowledge", "at":"2019-12-31T16:58:35Z"}]}}`))
+		_, _ = w.Write([]byte(`{"incident": {"id": "1", "pending_actions": [{"type": "unacknowledge", "at":"2019-12-31T16:58:35Z"}]}}`))
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	var duration uint = 3600
 	id := "1"
 
@@ -457,12 +455,12 @@ func TestIncident_ListLogEntries(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1/log_entries", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"log_entries": [{"id": "1","summary":"foo"}]}`))
+		_, _ = w.Write([]byte(`{"log_entries": [{"id": "1","summary":"foo"}]}`))
 	})
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
-	var entriesOpts = ListIncidentLogEntriesOptions{
+	entriesOpts := ListIncidentLogEntriesOptions{
 		APIListObject: listObj,
 		Includes:      []string{},
 		IsOverview:    true,
@@ -497,12 +495,12 @@ func TestIncident_ListLogEntriesSinceUntil(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1/log_entries", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"log_entries": [{"id": "1","summary":"foo"}]}`))
+		_, _ = w.Write([]byte(`{"log_entries": [{"id": "1","summary":"foo"}]}`))
 	})
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
-	var entriesOpts = ListIncidentLogEntriesOptions{
+	entriesOpts := ListIncidentLogEntriesOptions{
 		APIListObject: listObj,
 		Includes:      []string{},
 		IsOverview:    true,
@@ -539,7 +537,7 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	id := "1"
 	mux.HandleFunc("/incidents/"+id+"/responder_requests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{
+		_, _ = w.Write([]byte(`{
 	"responder_request": {
 		"requester": {
 			"id": "PL1JMK5",
@@ -560,9 +558,8 @@ func TestIncident_ResponderRequest(t *testing.T) {
 		}
 	}
 }`))
-
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	from := "foo@bar.com"
 
 	r := ResponderRequestTarget{}
@@ -595,7 +592,6 @@ func TestIncident_ResponderRequest(t *testing.T) {
 		},
 	}
 	res, err := client.ResponderRequest(id, input)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -608,10 +604,10 @@ func TestIncident_GetAlert(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1/alerts/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"alert": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"alert": {"id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	incidentID := "1"
 	alertID := "1"
@@ -630,16 +626,17 @@ func TestIncident_GetAlert(t *testing.T) {
 	}
 	testEqual(t, want, res)
 }
+
 func TestIncident_ManageAlerts(t *testing.T) {
 	setup()
 	defer teardown()
 
 	mux.HandleFunc("/incidents/1/alerts/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"alerts": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"alerts": [{"id": "1"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	incidentID := "1"
 

--- a/log_entry_test.go
+++ b/log_entry_test.go
@@ -12,12 +12,12 @@ func TestLogEntry_List(t *testing.T) {
 
 	mux.HandleFunc("/log_entries", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"log_entries": [{"id": "1","summary":"foo"}]}`))
+		_, _ = w.Write([]byte(`{"log_entries": [{"id": "1","summary":"foo"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var entriesOpts = ListLogEntriesOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	entriesOpts := ListLogEntriesOptions{
 		APIListObject: listObj,
 		Includes:      []string{},
 		IsOverview:    true,
@@ -51,10 +51,10 @@ func TestLogEntry_Get(t *testing.T) {
 
 	mux.HandleFunc("/log_entries/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"log_entry": {"id": "1", "summary": "foo"}}`))
+		_, _ = w.Write([]byte(`{"log_entry": {"id": "1", "summary": "foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	opts := GetLogEntryOptions{TimeZone: "UTC", Includes: []string{}}
 	res, err := client.GetLogEntry(id, opts)

--- a/maintenance_window_test.go
+++ b/maintenance_window_test.go
@@ -12,12 +12,12 @@ func TestMaintenanceWindow_List(t *testing.T) {
 
 	mux.HandleFunc("/maintenance_windows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"maintenance_windows": [{"id": "1", "summary": "foo"}]}`))
+		_, _ = w.Write([]byte(`{"maintenance_windows": [{"id": "1", "summary": "foo"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListMaintenanceWindowsOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListMaintenanceWindowsOptions{
 		APIListObject: listObj,
 		Query:         "foo",
 		Includes:      []string{},
@@ -55,10 +55,10 @@ func TestMaintenanceWindow_Create(t *testing.T) {
 
 	mux.HandleFunc("/maintenance_windows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"maintenance_window": {"description": "foo", "id": "1"}}`))
+		_, _ = w.Write([]byte(`{"maintenance_window": {"description": "foo", "id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.CreateMaintenanceWindow(from, input)
 
@@ -74,6 +74,7 @@ func TestMaintenanceWindow_Create(t *testing.T) {
 	}
 	testEqual(t, want, res)
 }
+
 func TestMaintenanceWindow_Create_NoFrom(t *testing.T) {
 	setup()
 	defer teardown()
@@ -83,10 +84,10 @@ func TestMaintenanceWindow_Create_NoFrom(t *testing.T) {
 
 	mux.HandleFunc("/maintenance_windows", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"maintenance_window": {"description": "foo", "id": "1"}}`))
+		_, _ = w.Write([]byte(`{"maintenance_window": {"description": "foo", "id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.CreateMaintenanceWindow(from, input)
 
@@ -112,9 +113,8 @@ func TestMaintenanceWindow_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 		w.WriteHeader(http.StatusNoContent)
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	err := client.DeleteMaintenanceWindow("1")
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,10 +127,10 @@ func TestMaintenanceWindow_Get(t *testing.T) {
 
 	mux.HandleFunc("/maintenance_windows/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"maintenance_window": {"description": "foo", "id": "1"}}`))
+		_, _ = w.Write([]byte(`{"maintenance_window": {"description": "foo", "id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	opts := GetMaintenanceWindowOptions{Includes: []string{}}
 	res, err := client.GetMaintenanceWindow(id, opts)
@@ -162,9 +162,9 @@ func TestMaintenanceWindow_Update(t *testing.T) {
 
 	mux.HandleFunc("/maintenance_windows/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"maintenance_window": {"description": "foo", "id": "1"}}`))
+		_, _ = w.Write([]byte(`{"maintenance_window": {"description": "foo", "id": "1"}}`))
 	})
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.UpdateMaintenanceWindow(input)
 

--- a/notification_test.go
+++ b/notification_test.go
@@ -12,12 +12,12 @@ func TestNotification_List(t *testing.T) {
 
 	mux.HandleFunc("/notifications", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"notifications": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"notifications": [{"id": "1"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListNotificationOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListNotificationOptions{
 		APIListObject: listObj,
 		Includes:      []string{},
 		Filter:        "foo",

--- a/on_call_test.go
+++ b/on_call_test.go
@@ -12,12 +12,12 @@ func TestOnCall_List(t *testing.T) {
 
 	mux.HandleFunc("/oncalls", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"oncalls": [{"escalation_level":2}]}`))
+		_, _ = w.Write([]byte(`{"oncalls": [{"escalation_level":2}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListOnCallOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListOnCallOptions{
 		APIListObject:       listObj,
 		TimeZone:            "UTC",
 		Includes:            []string{},

--- a/priorites.go
+++ b/priorites.go
@@ -11,6 +11,8 @@ type PriorityProperty struct {
 	Description string `json:"description"`
 }
 
+// Priorities repreents the API response from PagerDuty when listing the
+// configured priorities.
 type Priorities struct {
 	APIListObject
 	Priorities []PriorityProperty `json:"priorities"`

--- a/priorities_test.go
+++ b/priorities_test.go
@@ -12,11 +12,11 @@ func TestPriorities_List(t *testing.T) {
 
 	mux.HandleFunc("/priorities", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"priorities": [{"id": "1", "summary": "foo"}]}`))
+		_, _ = w.Write([]byte(`{"priorities": [{"id": "1", "summary": "foo"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.ListPriorities()
 

--- a/ruleset_test.go
+++ b/ruleset_test.go
@@ -12,10 +12,10 @@ func TestRuleset_List(t *testing.T) {
 
 	mux.HandleFunc("/rulesets/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"rulesets": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"rulesets": [{"id": "1"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	res, err := client.ListRulesets()
 	if err != nil {
@@ -39,10 +39,10 @@ func TestRuleset_Create(t *testing.T) {
 
 	mux.HandleFunc("/rulesets", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"ruleset": {"id": "1", "name": "foo"}}`))
+		_, _ = w.Write([]byte(`{"ruleset": {"id": "1", "name": "foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := &Ruleset{
 		Name: "foo",
 	}
@@ -66,10 +66,10 @@ func TestRuleset_Get(t *testing.T) {
 
 	mux.HandleFunc("/rulesets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"ruleset": {"id": "1", "name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"ruleset": {"id": "1", "name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	ruleSetID := "1"
 
 	res, _, err := client.GetRuleset(ruleSetID)
@@ -92,10 +92,10 @@ func TestRuleset_Update(t *testing.T) {
 
 	mux.HandleFunc("/rulesets/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"ruleset": {"id": "1", "name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"ruleset": {"id": "1", "name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := &Ruleset{
 		ID:   "1",
 		Name: "foo",
@@ -122,10 +122,9 @@ func TestRuleset_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	err := client.DeleteRuleset(id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,10 +137,10 @@ func TestRuleset_ListRules(t *testing.T) {
 
 	mux.HandleFunc("/rulesets/1/rules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"rules": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"rules": [{"id": "1"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	rulesetID := "1"
 	res, err := client.ListRulesetRules(rulesetID)
@@ -166,10 +165,10 @@ func TestRuleset_GetRule(t *testing.T) {
 
 	mux.HandleFunc("/rulesets/1/rules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"rule": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"rule": {"id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	rulesetID := "1"
 	ruleID := "1"
@@ -191,10 +190,10 @@ func TestRuleset_CreateRule(t *testing.T) {
 
 	mux.HandleFunc("/rulesets/1/rules/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"rule": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"rule": {"id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	rulesetID := "1"
 	rule := &RulesetRule{}
@@ -217,10 +216,10 @@ func TestRuleset_UpdateRule(t *testing.T) {
 
 	mux.HandleFunc("/rulesets/1/rules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"rule": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"rule": {"id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	rulesetID := "1"
 	ruleID := "1"
@@ -246,12 +245,11 @@ func TestRuleset_DeleteRule(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	ruleID := "1"
 	rulesetID := "1"
 
 	err := client.DeleteRulesetRule(rulesetID, ruleID)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/schedule.go
+++ b/schedule.go
@@ -215,7 +215,7 @@ type ListOverridesResponse struct {
 	Overrides []Override `json:"overrides,omitempty"`
 }
 
-// Overrides are any schedule layers from the override layer.
+// Override are any schedule layers from the override layer.
 type Override struct {
 	ID    string    `json:"id,omitempty"`
 	Start string    `json:"start,omitempty"`

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -12,12 +12,12 @@ func TestSchedule_List(t *testing.T) {
 
 	mux.HandleFunc("/schedules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"schedules": [{"id": "1","summary":"foo"}]}`))
+		_, _ = w.Write([]byte(`{"schedules": [{"id": "1","summary":"foo"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListSchedulesOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListSchedulesOptions{
 		APIListObject: listObj,
 		Query:         "foo",
 	}
@@ -48,10 +48,10 @@ func TestSchedule_Create(t *testing.T) {
 
 	mux.HandleFunc("/schedules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"schedule": {"id": "1","summary":"foo"}}`))
+		_, _ = w.Write([]byte(`{"schedule": {"id": "1","summary":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := Schedule{
 		APIObject: APIObject{
 			ID:      "1",
@@ -84,10 +84,9 @@ func TestSchedule_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	err := client.DeleteSchedule(id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,11 +99,11 @@ func TestSchedule_Get(t *testing.T) {
 
 	mux.HandleFunc("/schedules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"schedule": {"id": "1","summary":"foo"}}`))
+		_, _ = w.Write([]byte(`{"schedule": {"id": "1","summary":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
 
 	input := "1"
 	opts := GetScheduleOptions{
@@ -135,10 +134,10 @@ func TestSchedule_Update(t *testing.T) {
 
 	mux.HandleFunc("/schedules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"schedule": {"id": "1","summary":"foo"}}`))
+		_, _ = w.Write([]byte(`{"schedule": {"id": "1","summary":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	id := "1"
 	sched := Schedule{
@@ -169,12 +168,12 @@ func TestSchedule_ListOverrides(t *testing.T) {
 
 	mux.HandleFunc("/schedules/1/overrides", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"overrides": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"overrides": [{"id": "1"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListOverridesOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListOverridesOptions{
 		APIListObject: listObj,
 		Since:         "foo",
 		Until:         "bar",
@@ -207,11 +206,11 @@ func TestSchedule_CreateOverride(t *testing.T) {
 
 	mux.HandleFunc("/schedules/1/overrides", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"override": {"id": "1", "start": "foo", "end": "bar"}}`))
+		_, _ = w.Write([]byte(`{"override": {"id": "1", "start": "foo", "end": "bar"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var input = Override{
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	input := Override{
 		Start: "foo",
 		End:   "bar",
 	}
@@ -240,11 +239,10 @@ func TestSchedule_DeleteOverride(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	schedID := "1"
 	overID := "1"
 	err := client.DeleteOverride(schedID, overID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -257,12 +255,12 @@ func TestSchedule_ListOnCallUsers(t *testing.T) {
 
 	mux.HandleFunc("/schedules/1/users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"users": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"users": [{"id": "1"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListOnCallUsersOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListOnCallUsersOptions{
 		APIListObject: listObj,
 		Since:         "foo",
 		Until:         "bar",

--- a/service.go
+++ b/service.go
@@ -323,7 +323,7 @@ func (c *Client) DeleteIntegrationWithContext(ctx context.Context, serviceID str
 	return err
 }
 
-// ListServiceRules gets all rules for a service.
+// ListServiceRulesPaginated gets all rules for a service.
 func (c *Client) ListServiceRulesPaginated(ctx context.Context, serviceID string) ([]ServiceRule, error) {
 	var rules []ServiceRule
 

--- a/service_dependency_test.go
+++ b/service_dependency_test.go
@@ -12,10 +12,10 @@ func TestBusinessServiceDependency_List(t *testing.T) {
 
 	mux.HandleFunc("/service_dependencies/business_services/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"relationships": [{"id": "1","dependent_service":{"id":"1"},"supporting_service":{"id":"1"},"type":"service_dependency"}]}`))
+		_, _ = w.Write([]byte(`{"relationships": [{"id": "1","dependent_service":{"id":"1"},"supporting_service":{"id":"1"},"type":"service_dependency"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	bServeID := "1"
 	res, _, err := client.ListBusinessServiceDependencies(bServeID)
 	if err != nil {
@@ -46,10 +46,10 @@ func TestTechnicalServiceDependency_List(t *testing.T) {
 
 	mux.HandleFunc("/service_dependencies/technical_services/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"relationships": [{"id": "1","dependent_service":{"id":"1"},"supporting_service":{"id":"1"},"type":"service_dependency"}]}`))
+		_, _ = w.Write([]byte(`{"relationships": [{"id": "1","dependent_service":{"id":"1"},"supporting_service":{"id":"1"},"type":"service_dependency"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	bServeID := "1"
 	res, _, err := client.ListTechnicalServiceDependencies(bServeID)
 	if err != nil {
@@ -80,10 +80,10 @@ func TestServiceDependency_Associate(t *testing.T) {
 
 	mux.HandleFunc("/service_dependencies/associate", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"relationships": [{"id": "1","dependent_service":{"id":"1"},"supporting_service":{"id":"1"},"type":"service_dependency"}]}`))
+		_, _ = w.Write([]byte(`{"relationships": [{"id": "1","dependent_service":{"id":"1"},"supporting_service":{"id":"1"},"type":"service_dependency"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := &ListServiceDependencies{
 		Relationships: []*ServiceDependency{
 			{
@@ -99,7 +99,6 @@ func TestServiceDependency_Associate(t *testing.T) {
 		},
 	}
 	res, _, err := client.AssociateServiceDependencies(input)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,10 +126,10 @@ func TestServiceDependency_Disassociate(t *testing.T) {
 
 	mux.HandleFunc("/service_dependencies/disassociate", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"relationships": [{"id": "1","dependent_service":{"id":"1"},"supporting_service":{"id":"1"},"type":"service_dependency"}]}`))
+		_, _ = w.Write([]byte(`{"relationships": [{"id": "1","dependent_service":{"id":"1"},"supporting_service":{"id":"1"},"type":"service_dependency"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := &ListServiceDependencies{
 		Relationships: []*ServiceDependency{
 			{
@@ -146,7 +145,6 @@ func TestServiceDependency_Disassociate(t *testing.T) {
 		},
 	}
 	res, _, err := client.DisassociateServiceDependencies(input)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/service_test.go
+++ b/service_test.go
@@ -15,12 +15,12 @@ func TestService_List(t *testing.T) {
 
 	mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"services": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"services": [{"id": "1"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListServiceOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListServiceOptions{
 		APIListObject: listObj,
 		TeamIDs:       []string{},
 		TimeZone:      "foo",
@@ -67,12 +67,12 @@ func TestService_ListPaginated(t *testing.T) {
                           "More": %s,
                           "Offset": %d,
                           "Limit": 1}`, offset, more, offset)
-		w.Write([]byte(resp))
+		_, _ = w.Write([]byte(resp))
 	})
 
-	var listObj = APIListObject{Limit: 1, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListServiceOptions{
+	listObj := APIListObject{Limit: 1, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListServiceOptions{
 		APIListObject: listObj,
 		TeamIDs:       []string{},
 		TimeZone:      "foo",
@@ -87,7 +87,8 @@ func TestService_ListPaginated(t *testing.T) {
 			APIObject: APIObject{
 				ID: "0",
 			},
-		}, {
+		},
+		{
 			APIObject: APIObject{
 				ID: "1",
 			},
@@ -107,10 +108,10 @@ func TestService_Get(t *testing.T) {
 
 	mux.HandleFunc("/services/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	id := "1"
 	opts := &GetServiceOptions{
@@ -138,10 +139,10 @@ func TestService_Create(t *testing.T) {
 
 	mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := Service{
 		Name: "foo",
 	}
@@ -167,10 +168,10 @@ func TestService_CreateWithAlertGroupParamsTime(t *testing.T) {
 
 	mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := Service{
 		Name: "foo",
 		AlertGroupingParameters: &AlertGroupingParameters{
@@ -202,10 +203,10 @@ func TestService_CreateWithAlertGroupParamsContentBased(t *testing.T) {
 
 	mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := Service{
 		Name: "foo",
 		AlertGroupingParameters: &AlertGroupingParameters{
@@ -238,10 +239,10 @@ func TestService_CreateWithAlertGroupParamsIntelligent(t *testing.T) {
 
 	mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := Service{
 		Name: "foo",
 		AlertGroupingParameters: &AlertGroupingParameters{
@@ -270,10 +271,10 @@ func TestService_Update(t *testing.T) {
 
 	mux.HandleFunc("/services/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	input := Service{
 		APIObject: APIObject{
@@ -305,10 +306,9 @@ func TestService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	err := client.DeleteService(id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,11 +321,11 @@ func TestService_CreateIntegration(t *testing.T) {
 
 	mux.HandleFunc("/services/1/integrations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"integration": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"integration": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var input = Integration{
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	input := Integration{
 		Name: "foo",
 	}
 	servID := "1"
@@ -352,11 +352,11 @@ func TestService_GetIntegration(t *testing.T) {
 
 	mux.HandleFunc("/services/1/integrations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"integration": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"integration": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var input = GetIntegrationOptions{
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	input := GetIntegrationOptions{
 		Includes: []string{},
 	}
 	servID := "1"
@@ -384,11 +384,11 @@ func TestService_UpdateIntegration(t *testing.T) {
 
 	mux.HandleFunc("/services/1/integrations/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"integration": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"integration": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var input = Integration{
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	input := Integration{
 		APIObject: APIObject{
 			ID: "1",
 		},
@@ -420,11 +420,10 @@ func TestService_DeleteIntegration(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	servID := "1"
 	intID := "1"
 	err := client.DeleteIntegration(servID, intID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -437,10 +436,10 @@ func TestService_ListRules(t *testing.T) {
 
 	mux.HandleFunc("/services/1/rules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"rules": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"rules": [{"id": "1"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	serviceID := "1"
 	res, err := client.ListServiceRulesPaginated(context.Background(), serviceID)
@@ -459,10 +458,10 @@ func TestService_CreateServiceRule(t *testing.T) {
 
 	mux.HandleFunc("/services/1/rules/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"rule": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"rule": {"id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	serviceID := "1"
 	rule := ServiceRule{}
@@ -485,10 +484,10 @@ func TestService_GetServiceRule(t *testing.T) {
 
 	mux.HandleFunc("/services/1/rules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"rule": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"rule": {"id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	serviceID := "1"
 	ruleID := "1"
@@ -510,10 +509,10 @@ func TestService_UpdateServiceRule(t *testing.T) {
 
 	mux.HandleFunc("/services/1/rules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"rule": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"rule": {"id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	serviceID := "1"
 	ruleID := "1"
@@ -539,12 +538,11 @@ func TestService_DeleteServiceRule(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	serviceID := "1"
 	ruleID := "1"
 
 	err := client.DeleteServiceRule(context.Background(), serviceID, ruleID)
-
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tag_test.go
+++ b/tag_test.go
@@ -12,12 +12,12 @@ func TestTag_List(t *testing.T) {
 
 	mux.HandleFunc("/tags/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"tags": [{"id": "1","label":"MyTag"}]}`))
+		_, _ = w.Write([]byte(`{"tags": [{"id": "1","label":"MyTag"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListTagOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListTagOptions{
 		APIListObject: listObj,
 	}
 	res, err := client.ListTags(opts)
@@ -45,10 +45,10 @@ func TestTag_Create(t *testing.T) {
 
 	mux.HandleFunc("/tags", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"tag": {"id": "1","Label":"foo"}}`))
+		_, _ = w.Write([]byte(`{"tag": {"id": "1","Label":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := &Tag{
 		Label: "foo",
 	}
@@ -76,10 +76,9 @@ func TestTag_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	err := client.DeleteTag(id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,10 +91,10 @@ func TestTag_Get(t *testing.T) {
 
 	mux.HandleFunc("/tags/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"tag": {"id": "1","label":"foo"}}`))
+		_, _ = w.Write([]byte(`{"tag": {"id": "1","label":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	res, _, err := client.GetTag(id)
 
@@ -121,7 +120,7 @@ func TestTag_AssignAdd(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	ta := &TagAssignments{
 		Add: []*TagAssignment{
 			{
@@ -136,7 +135,6 @@ func TestTag_AssignAdd(t *testing.T) {
 	}
 	// this endpoint only returns  an "ok" in the body. no point in testing for it.
 	_, err := client.AssignTags("teams", "1", ta)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +149,7 @@ func TestTag_AssignRemove(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	ta := &TagAssignments{
 		Remove: []*TagAssignment{
 			{
@@ -162,7 +160,6 @@ func TestTag_AssignRemove(t *testing.T) {
 	}
 	// this endpoint only returns  an "ok" in the body. no point in testing for it.
 	_, err := client.AssignTags("teams", "1", ta)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -175,10 +172,10 @@ func TestTag_GetUsersByTag(t *testing.T) {
 
 	mux.HandleFunc("/tags/1/users/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"users": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"users": [{"id": "1"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	tid := "1"
 
 	res, err := client.GetUsersByTag(tid)
@@ -203,10 +200,10 @@ func TestTag_GetTeamsByTag(t *testing.T) {
 
 	mux.HandleFunc("/tags/1/teams/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"teams": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"teams": [{"id": "1"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	tid := "1"
 
 	res, err := client.GetTeamsByTag(tid)
@@ -231,10 +228,10 @@ func TestTag_GetEscalationPoliciesByTag(t *testing.T) {
 
 	mux.HandleFunc("/tags/1/escalation_policies/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"escalation_policies": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"escalation_policies": [{"id": "1"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	tid := "1"
 
 	res, err := client.GetEscalationPoliciesByTag(tid)
@@ -259,15 +256,15 @@ func TestTag_GetTagsForEntity(t *testing.T) {
 
 	mux.HandleFunc("/escalation_policies/1/tags/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"tags": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"tags": [{"id": "1"}]}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	eid := "1"
 	e := "escalation_policies"
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
 
-	var opts = ListTagOptions{
+	opts := ListTagOptions{
 		APIListObject: listObj,
 	}
 	res, err := client.GetTagsForEntity(e, eid, opts)

--- a/team_test.go
+++ b/team_test.go
@@ -15,12 +15,12 @@ func TestTeam_List(t *testing.T) {
 
 	mux.HandleFunc("/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"teams": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"teams": [{"id": "1"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListTeamOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListTeamOptions{
 		APIListObject: listObj,
 		Query:         "foo",
 	}
@@ -50,10 +50,10 @@ func TestTeam_Create(t *testing.T) {
 
 	mux.HandleFunc("/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"team": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"team": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := &Team{
 		Name: "foo",
 	}
@@ -81,10 +81,9 @@ func TestTeam_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	err := client.DeleteTeam(id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -97,10 +96,10 @@ func TestTeam_Get(t *testing.T) {
 
 	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"team": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"team": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	res, err := client.GetTeam(id)
 
@@ -124,10 +123,10 @@ func TestTeam_Update(t *testing.T) {
 
 	mux.HandleFunc("/teams/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"team": {"id": "1","name":"foo"}}`))
+		_, _ = w.Write([]byte(`{"team": {"id": "1","name":"foo"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 
 	input := &Team{
 		APIObject: APIObject{
@@ -160,12 +159,11 @@ func TestTeam_RemoveEscalationPolicyFromTeam(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	teamID := "1"
 	epID := "1"
 
 	err := client.RemoveEscalationPolicyFromTeam(teamID, epID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,12 +178,11 @@ func TestTeam_AddEscalationPolicyToTeam(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	teamID := "1"
 	epID := "1"
 
 	err := client.AddEscalationPolicyToTeam(teamID, epID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,12 +197,11 @@ func TestTeam_RemoveUserFromTeam(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	teamID := "1"
 	userID := "1"
 
 	err := client.RemoveUserFromTeam(teamID, userID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,12 +216,11 @@ func TestTeam_AddUserToTeam(t *testing.T) {
 		testMethod(t, r, "PUT")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	teamID := "1"
 	userID := "1"
 
 	err := client.AddUserToTeam(teamID, userID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -304,7 +299,6 @@ func genMembersRespPage(details pageDetails, t *testing.T) string {
 		"limit":  details.limit,
 		"offset": details.offset,
 	})
-
 	if err != nil {
 		t.Fatalf("Failed to apply values to template: %v", err)
 	}
@@ -316,7 +310,6 @@ func genRespPages(amount,
 	maxPageSize int,
 	pageGenerator func(pageDetails, *testing.T) string,
 	t *testing.T) []string {
-
 	pages := make([]string, 0)
 
 	lowNumber := 1
@@ -340,7 +333,8 @@ func genRespPages(amount,
 			highNumber: tempHighNumber,
 			limit:      maxPageSize,
 			more:       more,
-			offset:     offset}, t)
+			offset:     offset,
+		}, t)
 
 		pages = append(pages, page)
 

--- a/user_test.go
+++ b/user_test.go
@@ -12,12 +12,12 @@ func TestUser_List(t *testing.T) {
 
 	mux.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"users": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"users": [{"id": "1"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListUsersOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListUsersOptions{
 		APIListObject: listObj,
 		Query:         "foo",
 		TeamIDs:       []string{},
@@ -49,10 +49,10 @@ func TestUser_Create(t *testing.T) {
 
 	mux.HandleFunc("/users", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"user": {"id": "1", "email":"foo@bar.com"}}`))
+		_, _ = w.Write([]byte(`{"user": {"id": "1", "email":"foo@bar.com"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := User{
 		Email: "foo@bar.com",
 	}
@@ -80,10 +80,9 @@ func TestUser_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	id := "1"
 	err := client.DeleteUser(id)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,10 +95,10 @@ func TestUser_Get(t *testing.T) {
 
 	mux.HandleFunc("/users/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"user": {"id": "1", "email":"foo@bar.com"}}`))
+		_, _ = w.Write([]byte(`{"user": {"id": "1", "email":"foo@bar.com"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	userID := "1"
 	opts := GetUserOptions{
 		Includes: []string{},
@@ -126,10 +125,10 @@ func TestUser_Update(t *testing.T) {
 
 	mux.HandleFunc("/users/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"user": {"id": "1", "email":"foo@bar.com"}}`))
+		_, _ = w.Write([]byte(`{"user": {"id": "1", "email":"foo@bar.com"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	input := User{
 		APIObject: APIObject{
 			ID: "1",
@@ -158,10 +157,10 @@ func TestUser_GetCurrent(t *testing.T) {
 
 	mux.HandleFunc("/users/me", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"user": {"id": "1", "email":"foo@bar.com"}}`))
+		_, _ = w.Write([]byte(`{"user": {"id": "1", "email":"foo@bar.com"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	opts := GetCurrentUserOptions{
 		Includes: []string{},
 	}
@@ -187,11 +186,11 @@ func TestUser_ListContactMethods(t *testing.T) {
 
 	mux.HandleFunc("/users/1/contact_methods", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"contact_methods": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"contact_methods": [{"id": "1"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	ID := "1"
 
 	res, err := client.ListUserContactMethods(ID)
@@ -218,10 +217,10 @@ func TestUser_GetContactMethod(t *testing.T) {
 
 	mux.HandleFunc("/users/1/contact_methods/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"contact_method": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"contact_method": {"id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	methodID := "1"
 	userID := "1"
 
@@ -244,10 +243,10 @@ func TestUser_CreateContactMethod(t *testing.T) {
 
 	mux.HandleFunc("/users/1/contact_methods", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"contact_method": {"id": "1", "type": "email_contact_method"}}`))
+		_, _ = w.Write([]byte(`{"contact_method": {"id": "1", "type": "email_contact_method"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	userID := "1"
 	contactMethod := ContactMethod{
 		Type: "email_contact_method",
@@ -274,12 +273,11 @@ func TestUser_DeleteContactMethod(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	userID := "1"
 	contactMethodID := "1"
 
 	err := client.DeleteUserContactMethod(userID, contactMethodID)
-
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -292,10 +290,10 @@ func TestUser_UpdateContactMethod(t *testing.T) {
 
 	mux.HandleFunc("/users/1/contact_methods/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"contact_method": {"id": "1", "type": "email_contact_method"}}`))
+		_, _ = w.Write([]byte(`{"contact_method": {"id": "1", "type": "email_contact_method"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	userID := "1"
 	contactMethod := ContactMethod{
 		ID:   "1",
@@ -321,10 +319,10 @@ func TestUser_GetUserNotificationRule(t *testing.T) {
 
 	mux.HandleFunc("/users/1/notification_rules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"notification_rule": {"id": "1", "start_delay_in_minutes": 1, "urgency": "low", "contact_method": {"id": "1"}}}`))
+		_, _ = w.Write([]byte(`{"notification_rule": {"id": "1", "start_delay_in_minutes": 1, "urgency": "low", "contact_method": {"id": "1"}}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	ruleID := "1"
 	userID := "1"
 
@@ -352,10 +350,10 @@ func TestUser_CreateUserNotificationRule(t *testing.T) {
 
 	mux.HandleFunc("/users/1/notification_rules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
-		w.Write([]byte(`{"notification_rule": {"id": "1", "start_delay_in_minutes": 1, "urgency": "low", "contact_method": {"id": "1"}}}`))
+		_, _ = w.Write([]byte(`{"notification_rule": {"id": "1", "start_delay_in_minutes": 1, "urgency": "low", "contact_method": {"id": "1"}}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	userID := "1"
 	rule := NotificationRule{
 		Type: "email_contact_method",
@@ -384,11 +382,11 @@ func TestUser_ListUserNotificationRules(t *testing.T) {
 
 	mux.HandleFunc("/users/1/notification_rules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"notification_rules": [{"id": "1", "start_delay_in_minutes": 1, "urgency": "low", "contact_method": {"id": "1"}}]}`))
+		_, _ = w.Write([]byte(`{"notification_rules": [{"id": "1", "start_delay_in_minutes": 1, "urgency": "low", "contact_method": {"id": "1"}}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	ID := "1"
 
 	res, err := client.ListUserNotificationRules(ID)
@@ -420,10 +418,10 @@ func TestUser_UpdateUserNotificationRule(t *testing.T) {
 
 	mux.HandleFunc("/users/1/notification_rules/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		w.Write([]byte(`{"notification_rule": {"id": "1", "start_delay_in_minutes": 1, "urgency": "low", "contact_method": {"id": "1"}}}`))
+		_, _ = w.Write([]byte(`{"notification_rule": {"id": "1", "start_delay_in_minutes": 1, "urgency": "low", "contact_method": {"id": "1"}}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	userID := "1"
 	rule := NotificationRule{
 		ID:   "1",
@@ -457,7 +455,7 @@ func TestUser_DeleteUserNotificationRule(t *testing.T) {
 	userID := "1"
 	ruleID := "1"
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	if err := client.DeleteUserNotificationRule(userID, ruleID); err != nil {
 		t.Fatal(err)
 	}

--- a/vendor_test.go
+++ b/vendor_test.go
@@ -12,12 +12,12 @@ func TestVendor_List(t *testing.T) {
 
 	mux.HandleFunc("/vendors", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"vendors": [{"id": "1"}]}`))
+		_, _ = w.Write([]byte(`{"vendors": [{"id": "1"}]}`))
 	})
 
-	var listObj = APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
-	var opts = ListVendorOptions{
+	listObj := APIListObject{Limit: 0, Offset: 0, More: false, Total: 0}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	opts := ListVendorOptions{
 		APIListObject: listObj,
 		Query:         "foo",
 	}
@@ -47,10 +47,10 @@ func TestVendor_Get(t *testing.T) {
 
 	mux.HandleFunc("/vendors/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		w.Write([]byte(`{"vendor": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"vendor": {"id": "1"}}`))
 	})
 
-	var client = &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
+	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	venID := "1"
 
 	res, err := client.GetVendor(venID)

--- a/webhook.go
+++ b/webhook.go
@@ -41,7 +41,7 @@ type WebhookPayloadMessages struct {
 type WebhookPayload struct {
 	ID         string          `json:"id"`
 	Event      string          `json:"event"`
-	CreatedOn  time.Time       `json:"created_on`
+	CreatedOn  time.Time       `json:"created_on"`
 	Incident   IncidentDetails `json:"incident"`
 	LogEntries []LogEntry      `json:"log_entries"`
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -14,7 +14,6 @@ func TestWebhook_DecodeWebhook(t *testing.T) {
 
 	jsonData := strings.NewReader(webhookPayload)
 	res, err := DecodeWebhook(jsonData)
-
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This change is a pretty noisy change in that I went through and cleaned up all
of the issues that my linters flagged. I wanted to get this done, so that we can
add them as automatic CI checks for future PRs.

In the process I did find one critical bug, where we had a malformed JSON struct
tag:

https://github.com/PagerDuty/go-pagerduty/blob/69ade4b95ef0ff1d582a7d9f226a98f9db886df1/webhook.go#L44

There are two linter issues we cannot fix until v1.5.0, because they are
breaking changes. As such, the v1.5.0 development line would be the first place
we can enforce those CI checks.

Fixes #317