### PR TITLE
Add missing context.Context support and propagation

### DIFF
--- a/service_dependency.go
+++ b/service_dependency.go
@@ -89,7 +89,7 @@ func (c *Client) AssociateServiceDependenciesWithContext(ctx context.Context, de
 }
 
 func (c *Client) associateServiceDependenciesWithContext(ctx context.Context, dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
-	resp, err := c.post(context.TODO(), "/service_dependencies/associate", dependencies, nil)
+	resp, err := c.post(ctx, "/service_dependencies/associate", dependencies, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/tag.go
+++ b/tag.go
@@ -122,9 +122,15 @@ func (c *Client) GetTagWithContext(ctx context.Context, id string) (*Tag, *http.
 	return getTagFromResponse(c, resp, err)
 }
 
-// AssignTags adds and removes tag assignments with entities
+// AssignTags adds and removes tag assignments with entities. It's recommended
+// to use AssignTagsWithContext instead.
 func (c *Client) AssignTags(e, eid string, a *TagAssignments) (*http.Response, error) {
-	resp, err := c.post(context.TODO(), "/"+e+"/"+eid+"/change_tags", a, nil)
+	return c.AssignTagsWithContext(context.Background(), e, eid, a)
+}
+
+// AssignTagsWithContext adds and removes tag assignments with entities.
+func (c *Client) AssignTagsWithContext(ctx context.Context, e, eid string, a *TagAssignments) (*http.Response, error) {
+	resp, err := c.post(ctx, "/"+e+"/"+eid+"/change_tags", a, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
While looking at something I discovered that I had accidentally missed adding
full `context.Context` support in two places. In particular, in
`service_dependency.go` the context for `AssociateServiceDependenciesWithContext`
wasn't being used. Second, I missed adding context support to `AssignTags()`
completely.