### PR TITLE
Fix the ResponderRequest input/output structures

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -557,19 +557,19 @@ type ResponderRequestTargets struct {
 
 // ResponderRequestOptions defines the input options for the Create Responder function.
 type ResponderRequestOptions struct {
-	From        string                   `json:"-"`
-	Message     string                   `json:"message"`
-	RequesterID string                   `json:"requester_id"`
-	Targets     []ResponderRequestTarget `json:"responder_request_targets"`
+	From        string                    `json:"-"`
+	Message     string                    `json:"message"`
+	RequesterID string                    `json:"requester_id"`
+	Targets     []ResponderRequestTargets `json:"responder_request_targets"`
 }
 
 // ResponderRequest contains the API structure for an incident responder request.
 type ResponderRequest struct {
-	Incident    Incident                `json:"incident"`
-	Requester   User                    `json:"requester,omitempty"`
-	RequestedAt string                  `json:"request_at,omitempty"`
-	Message     string                  `json:"message,omitempty"`
-	Targets     ResponderRequestTargets `json:"responder_request_targets"`
+	Incident    Incident                  `json:"incident"`
+	Requester   User                      `json:"requester,omitempty"`
+	RequestedAt string                    `json:"request_at,omitempty"`
+	Message     string                    `json:"message,omitempty"`
+	Targets     []ResponderRequestTargets `json:"responder_request_targets"`
 }
 
 // ResponderRequest will submit a request to have a responder join an incident.

--- a/incident_test.go
+++ b/incident_test.go
@@ -544,7 +544,7 @@ func TestIncident_ResponderRequest(t *testing.T) {
 			"type": "user_reference"
 		},
 		"message": "Help",
-		"responder_request_targets": {
+		"responder_request_targets": [{
 			"responder_request_target": {
 				"id": "PJ25ZYX",
 				"type": "user_reference",
@@ -555,7 +555,7 @@ func TestIncident_ResponderRequest(t *testing.T) {
 					}
 				}
 			}
-		}
+		}]
 	}
 }`))
 	})
@@ -566,11 +566,15 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	r.ID = "PJ25ZYX"
 	r.Type = "user_reference"
 
+	targets := []ResponderRequestTargets{
+		ResponderRequestTargets{Target: r},
+	}
+
 	input := ResponderRequestOptions{
 		From:        from,
 		Message:     "help",
 		RequesterID: "PL1JMK5",
-		Targets:     []ResponderRequestTarget{r},
+		Targets:     targets,
 	}
 
 	user := User{}
@@ -583,12 +587,16 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	target.Responders.State = "pending"
 	target.Responders.User.ID = "PJ25ZYX"
 
+	targets = []ResponderRequestTargets{
+		ResponderRequestTargets{Target: target},
+	}
+
 	want := &ResponderRequestResponse{
 		ResponderRequest: ResponderRequest{
 			Incident:  Incident{},
 			Requester: user,
 			Message:   "Help",
-			Targets:   ResponderRequestTargets{target},
+			Targets:   targets,
 		},
 	}
 	res, err := client.ResponderRequest(id, input)


### PR DESCRIPTION
The doc for [incidents/{id}/responder_requests](https://developer.pagerduty.com/api-reference/reference/REST/openapiv3.json/paths/~1incidents~1%7Bid%7D~1responder_requests/post) is mis-leading, in that the description, example, and formatted doc each show a different structure. This morning I worked with support to actually determine the necessary structure here, so have updated the input and output structure here to resolve this.

For any implementation of this previously the structure of the code will require updating, but as this was already broken this should be fine?

Currently:
```json
{
  "requester_id": "identifier",
  "message": "Help has been requested",
  "responder_request_targets": [
    {
      "type": "escalation_policy",
      "id": "identifier"
    }
  ]
}
```

Should be:
```json
{
  "requester_id": "identifier",
  "message": "Help has been requested",
  "responder_request_targets": [
    {
      "responder_request_target": {
        "type": "escalation_policy",
        "id": "identifier"
      }
    }
  ]
}
```