### PR TITLE
Fix query params on tags

### DIFF
--- a/tag.go
+++ b/tag.go
@@ -358,7 +358,7 @@ func getTagList(ctx context.Context, c *Client, entityType, entityID string, o L
 	}
 
 	// Make call to get all pages associated with the base endpoint.
-	if err := c.pagedGet(ctx, path+queryParms.Encode(), responseHandler); err != nil {
+	if err := c.pagedGet(ctx, path+"?"+queryParms.Encode(), responseHandler); err != nil {
 		return nil, err
 	}
 

--- a/tag_test.go
+++ b/tag_test.go
@@ -12,6 +12,7 @@ func TestTag_List(t *testing.T) {
 
 	mux.HandleFunc("/tags/", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		testEqual(t, r.URL.Query()["query"], []string{"MyTag"})
 		_, _ = w.Write([]byte(`{"tags": [{"id": "1","label":"MyTag"}]}`))
 	})
 
@@ -19,6 +20,7 @@ func TestTag_List(t *testing.T) {
 	client := &Client{apiEndpoint: server.URL, authToken: "foo", HTTPClient: defaultHTTPClient}
 	opts := ListTagOptions{
 		APIListObject: listObj,
+		Query:         "MyTag",
 	}
 	res, err := client.ListTags(opts)
 	if err != nil {


### PR DESCRIPTION
At the moment, this method is missing the `?` which results in a 404 when providing query parameters.