### PR TITLE
Update APIError.Error() to provide more helpful error messages

### DIFF
--- a/client.go
+++ b/client.go
@@ -133,10 +133,38 @@ func (a APIError) Error() string {
 		return fmt.Sprintf("HTTP response failed with status code %d and no JSON error object was present", a.StatusCode)
 	}
 
+	if len(a.APIError.ErrorObject.Errors) == 0 {
+		return fmt.Sprintf(
+			"HTTP response failed with status code %d, message: %s (code: %d)",
+			a.StatusCode, a.APIError.ErrorObject.Message, a.APIError.ErrorObject.Code,
+		)
+	}
+
 	return fmt.Sprintf(
-		"HTTP response failed with status code %d, message: %s (code: %d)",
-		a.StatusCode, a.APIError.ErrorObject.Message, a.APIError.ErrorObject.Code,
+		"HTTP response failed with status code %d, message: %s (code: %d): %s",
+		a.StatusCode,
+		a.APIError.ErrorObject.Message,
+		a.APIError.ErrorObject.Code,
+		apiErrorsDetailString(a.APIError.ErrorObject.Errors),
 	)
+}
+
+func apiErrorsDetailString(errs []string) string {
+	switch n := len(errs); n {
+	case 0:
+		panic("errs slice is empty")
+
+	case 1:
+		return errs[0]
+
+	default:
+		e := "error"
+		if n > 2 {
+			e += "s"
+		}
+
+		return fmt.Sprintf("%s (and %d more %s...)", errs[0], n-1, e)
+	}
 }
 
 // RateLimited returns whether the response had a status of 429, and as such the

--- a/client_test.go
+++ b/client_test.go
@@ -93,21 +93,44 @@ func TestGetBasePrefix(t *testing.T) {
 }
 
 func TestAPIError_Error(t *testing.T) {
-	const jsonBody = `{"error":{"code": 420, "message": "Enhance Your Calm", "errors":["Enhance Your Calm", "Slow Your Roll"]}}`
+	t.Run("json_tests", func(t *testing.T) {
+		tests := []struct {
+			name  string
+			input string
+			want  string
+		}{
+			{
+				name:  "one_error",
+				input: `{"error":{"code": 420, "message": "Enhance Your Calm", "errors":["No Seriously, Enhance Your Calm"]}}`,
+				want:  "HTTP response failed with status code 429, message: Enhance Your Calm (code: 420): No Seriously, Enhance Your Calm",
+			},
+			{
+				name:  "two_error",
+				input: `{"error":{"code": 420, "message": "Enhance Your Calm", "errors":["No Seriously, Enhance Your Calm", "Slow Your Roll"]}}`,
+				want:  "HTTP response failed with status code 429, message: Enhance Your Calm (code: 420): No Seriously, Enhance Your Calm (and 1 more error...)",
+			},
+			{
+				name:  "three_error",
+				input: `{"error":{"code": 420, "message": "Enhance Your Calm", "errors":["No Seriously, Enhance Your Calm", "Slow Your Roll", "No, really..."]}}`,
+				want:  "HTTP response failed with status code 429, message: Enhance Your Calm (code: 420): No Seriously, Enhance Your Calm (and 2 more errors...)",
+			},
+		}
 
-	var a APIError
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var a APIError
+				if err := json.Unmarshal([]byte(tt.input), &a); err != nil {
+					t.Fatalf("failed to unmarshal JSON: %s", err)
+				}
 
-	if err := json.Unmarshal([]byte(jsonBody), &a); err != nil {
-		t.Fatalf("failed to unmarshal JSON: %s", err)
-	}
+				a.StatusCode = 429
 
-	a.StatusCode = 429
-
-	const want = "HTTP response failed with status code 429, message: Enhance Your Calm (code: 420)"
-
-	if got := a.Error(); got != want {
-		t.Errorf("a.Error() = %q, want %q", got, want)
-	}
+				if got := a.Error(); got != tt.want {
+					t.Errorf("a.Error() = %q, want %q", got, tt.want)
+				}
+			})
+		}
+	})
 
 	tests := []struct {
 		name string


### PR DESCRIPTION
While refactoring the API handling with the `APIError` type, we gave callers
more capability to inspect the errors that come from the API so that we can
handle them. Unfortunately, in the process we lost some fidelity in the strings
returned by its `Error()` method, compared to how errors used to be handled.

This updates the `APIError.Error()` method to now include the first detailed
error string provided from the API, if there is one, and incidate how many more
existed in the response (without printing them). This should help keep the error
tidy, while making it actionable by consumers. Consumers of this package are
still encouraged to deeply inspect the error, to handle each one.

This was inspired by #327, which the reporter closed after learning how to
deeply inspect the returned error value.