### PR TITLE
Add comment above IncidentDetails.Alerts field explaining behaviors

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -29,7 +29,10 @@ type IncidentDetails struct {
 	AlertCounts          AlertCounts       `json:"alert_counts"`
 	Metadata             interface{}       `json:"metadata"`
 	Description          string            `json:"description"`
-	Alerts               []IncidentAlert   `json:"alerts,omitempty"`
+
+	// Alerts is the list of alerts within this incident. Each item in the slice
+	// is not fully hydrated, so only the AlertKey field will be set.
+	Alerts []IncidentAlert `json:"alerts,omitempty"`
 }
 
 // WebhookPayloadMessages is the wrapper around the Webhook payloads. The Array may contain multiple message elements if webhook firing actions occurred in quick succession


### PR DESCRIPTION
For the Webhook object sent from PagerDuty, the "alerts" key is not a JSON array
of fully hydrated objects. Instead, only the "alert_key" JSON key is set within
each object, which might be unclear based on the type we use in the Go client.

This change adds a comment above the Alerts field to indicate it's not a slice
of fully hydrated `IncidentAlert` values, and that only `AlertKey` is set.