### PR TITLE
Correct formatting of deprecation notices.

### DIFF
--- a/ability.go
+++ b/ability.go
@@ -7,8 +7,9 @@ type ListAbilityResponse struct {
 	Abilities []string `json:"abilities"`
 }
 
-// ListAbilities lists all abilities on your account. It's recommended to use
-// ListAbilitiesWithContext instead.
+// ListAbilities lists all abilities on your account.
+//
+// Deprecated: Use ListAbilitiesWithContext instead.
 func (c *Client) ListAbilities() (*ListAbilityResponse, error) {
 	return c.ListAbilitiesWithContext(context.Background())
 }
@@ -29,6 +30,8 @@ func (c *Client) ListAbilitiesWithContext(ctx context.Context) (*ListAbilityResp
 }
 
 // TestAbility checks if your account has the given ability.
+//
+// Deprecated: Use TestAbilityWithContext instead.
 func (c *Client) TestAbility(ability string) error {
 	return c.TestAbilityWithContext(context.Background(), ability)
 }

--- a/addon.go
+++ b/addon.go
@@ -30,8 +30,9 @@ type ListAddonResponse struct {
 	Addons []Addon `json:"addons"`
 }
 
-// ListAddons lists all of the add-ons installed on your account. It's
-// recommended to use ListAddonsWithContext instead.
+// ListAddons lists all of the add-ons installed on your account.
+//
+// Deprecated: Use ListAddonsWithContext instead.
 func (c *Client) ListAddons(o ListAddonOptions) (*ListAddonResponse, error) {
 	return c.ListAddonsWithContext(context.Background(), o)
 }
@@ -56,8 +57,9 @@ func (c *Client) ListAddonsWithContext(ctx context.Context, o ListAddonOptions) 
 	return &result, nil
 }
 
-// InstallAddon installs an add-on for your account. It's recommended to use
-// InstallAddonWithContext instead.
+// InstallAddon installs an add-on for your account.
+//
+// Deprecated: Use InstallAddonWithContext instead.
 func (c *Client) InstallAddon(a Addon) (*Addon, error) {
 	return c.InstallAddonWithContext(context.Background(), a)
 }
@@ -80,8 +82,9 @@ func (c *Client) InstallAddonWithContext(ctx context.Context, a Addon) (*Addon, 
 	return getAddonFromResponse(c, resp)
 }
 
-// DeleteAddon deletes an add-on from your account. It's recommended to use
-// DeleteAddonWithContext instead.
+// DeleteAddon deletes an add-on from your account.
+//
+// Deprecated: Use DeleteAddonWithContext instead.
 func (c *Client) DeleteAddon(id string) error {
 	return c.DeleteAddonWithContext(context.Background(), id)
 }
@@ -92,8 +95,9 @@ func (c *Client) DeleteAddonWithContext(ctx context.Context, id string) error {
 	return err
 }
 
-// GetAddon gets details about an existing add-on. It's recommended to use
-// GetAddonWithContext instead.
+// GetAddon gets details about an existing add-on.
+//
+// Deprecated: Use GetAddonWithContext instead.
 func (c *Client) GetAddon(id string) (*Addon, error) {
 	return c.GetAddonWithContext(context.Background(), id)
 }
@@ -108,8 +112,9 @@ func (c *Client) GetAddonWithContext(ctx context.Context, id string) (*Addon, er
 	return getAddonFromResponse(c, resp)
 }
 
-// UpdateAddon updates an existing add-on. It's recommended to use
-// UpdateAddonWithContext instead.
+// UpdateAddon updates an existing add-on.
+//
+// Deprecated: Use UpdateAddonWithContext instead.
 func (c *Client) UpdateAddon(id string, a Addon) (*Addon, error) {
 	return c.UpdateAddonWithContext(context.Background(), id, a)
 }

--- a/business_service.go
+++ b/business_service.go
@@ -99,8 +99,9 @@ func (c *Client) ListBusinessServicesPaginated(ctx context.Context, o ListBusine
 	return businessServices, nil
 }
 
-// CreateBusinessService creates a new business service. It's recommended to use
-// CreateBusinessServiceWithContext instead
+// CreateBusinessService creates a new business service.
+//
+// Deprecated: Use CreateBusinessServiceWithContext instead
 func (c *Client) CreateBusinessService(b *BusinessService) (*BusinessService, *http.Response, error) {
 	return c.createBusinessServiceWithContext(context.Background(), b)
 }
@@ -120,8 +121,9 @@ func (c *Client) createBusinessServiceWithContext(ctx context.Context, b *Busine
 	return getBusinessServiceFromResponse(c, resp, err)
 }
 
-// GetBusinessService gets details about a business service. It's recommended to
-// use GetBusinessServiceWithContext instead.
+// GetBusinessService gets details about a business service.
+//
+// Deprecated: Use GetBusinessServiceWithContext instead.
 func (c *Client) GetBusinessService(id string) (*BusinessService, *http.Response, error) {
 	return c.getBusinessServiceWithContext(context.Background(), id)
 }
@@ -137,8 +139,9 @@ func (c *Client) getBusinessServiceWithContext(ctx context.Context, id string) (
 	return getBusinessServiceFromResponse(c, resp, err)
 }
 
-// DeleteBusinessService deletes a business_service. It's recommended to use
-// DeleteBusinessServiceWithContext instead.
+// DeleteBusinessService deletes a business_service.
+//
+// Deprecated: Use DeleteBusinessServiceWithContext instead.
 func (c *Client) DeleteBusinessService(id string) error {
 	return c.DeleteBusinessServiceWithContext(context.Background(), id)
 }
@@ -149,8 +152,9 @@ func (c *Client) DeleteBusinessServiceWithContext(ctx context.Context, id string
 	return err
 }
 
-// UpdateBusinessService updates a business_service. It's recommended to use
-// UpdateBusinessServiceWithContext instead.
+// UpdateBusinessService updates a business_service.
+//
+// Deprecated: Use UpdateBusinessServiceWithContext instead.
 func (c *Client) UpdateBusinessService(b *BusinessService) (*BusinessService, *http.Response, error) {
 	return c.updateBusinessServiceWithContext(context.Background(), b)
 }

--- a/change_events.go
+++ b/change_events.go
@@ -45,7 +45,7 @@ type ChangeEventResponse struct {
 // The v2EventsAPIEndpoint parameter must be set on the client
 // Documentation can be found at https://developer.pagerduty.com/docs/events-api-v2/send-change-events
 //
-// It's recommended to use CreateChangeEventWithContext instead.
+// Deprecated: Use CreateChangeEventWithContext instead.
 func (c *Client) CreateChangeEvent(e ChangeEvent) (*ChangeEventResponse, error) {
 	return c.CreateChangeEventWithContext(context.Background(), e)
 }

--- a/escalation_policy.go
+++ b/escalation_policy.go
@@ -59,8 +59,9 @@ type GetEscalationRuleOptions struct {
 	Includes []string `url:"include,omitempty,brackets"`
 }
 
-// ListEscalationPolicies lists all of the existing escalation policies. It's
-// recommended to use ListEscalationPoliciesWithContext instead.
+// ListEscalationPolicies lists all of the existing escalation policies.
+//
+// Deprecated: Use ListEscalationPoliciesWithContext instead.
 func (c *Client) ListEscalationPolicies(o ListEscalationPoliciesOptions) (*ListEscalationPoliciesResponse, error) {
 	return c.ListEscalationPoliciesWithContext(context.Background(), o)
 }
@@ -85,8 +86,9 @@ func (c *Client) ListEscalationPoliciesWithContext(ctx context.Context, o ListEs
 	return &result, nil
 }
 
-// CreateEscalationPolicy creates a new escalation policy. It's recommended to
-// use CreateEscalationPolicyWithContext instead.
+// CreateEscalationPolicy creates a new escalation policy.
+//
+// Deprecated: Use CreateEscalationPolicyWithContext instead.
 func (c *Client) CreateEscalationPolicy(e EscalationPolicy) (*EscalationPolicy, error) {
 	return c.CreateEscalationPolicyWithContext(context.Background(), e)
 }
@@ -101,8 +103,9 @@ func (c *Client) CreateEscalationPolicyWithContext(ctx context.Context, e Escala
 	return getEscalationPolicyFromResponse(c, resp, err)
 }
 
-// DeleteEscalationPolicy deletes an existing escalation policy and rules. It's
-// recommended to use DeleteEscalationPolicyWithContext instead.
+// DeleteEscalationPolicy deletes an existing escalation policy and rules.
+//
+// Deprecated: Use DeleteEscalationPolicyWithContext instead.
 func (c *Client) DeleteEscalationPolicy(id string) error {
 	return c.DeleteEscalationPolicyWithContext(context.Background(), id)
 }
@@ -119,7 +122,9 @@ type GetEscalationPolicyOptions struct {
 }
 
 // GetEscalationPolicy gets information about an existing escalation policy and
-// its rules. It's recommended to use GetEscalationPolicyWithContext instead.
+// its rules.
+//
+// Deprecated: Use GetEscalationPolicyWithContext instead.
 func (c *Client) GetEscalationPolicy(id string, o *GetEscalationPolicyOptions) (*EscalationPolicy, error) {
 	return c.GetEscalationPolicyWithContext(context.Background(), id, o)
 }
@@ -137,7 +142,8 @@ func (c *Client) GetEscalationPolicyWithContext(ctx context.Context, id string, 
 }
 
 // UpdateEscalationPolicy updates an existing escalation policy and its rules.
-// It's recommended to use UpdateEscalationPolicyWithContext instead.
+//
+// Deprecated: Use UpdateEscalationPolicyWithContext instead.
 func (c *Client) UpdateEscalationPolicy(id string, e *EscalationPolicy) (*EscalationPolicy, error) {
 	return c.UpdateEscalationPolicyWithContext(context.Background(), id, *e)
 }
@@ -153,8 +159,9 @@ func (c *Client) UpdateEscalationPolicyWithContext(ctx context.Context, id strin
 }
 
 // CreateEscalationRule creates a new escalation rule for an escalation policy
-// and appends it to the end of the existing escalation rules. It's recommended
-// to use CreateEscalationRuleWithContext instead.
+// and appends it to the end of the existing escalation rules.
+//
+// Deprecated: Use CreateEscalationRuleWithContext instead.
 func (c *Client) CreateEscalationRule(escID string, e EscalationRule) (*EscalationRule, error) {
 	return c.CreateEscalationRuleWithContext(context.Background(), escID, e)
 }
@@ -170,8 +177,9 @@ func (c *Client) CreateEscalationRuleWithContext(ctx context.Context, escID stri
 	return getEscalationRuleFromResponse(c, resp, err)
 }
 
-// GetEscalationRule gets information about an existing escalation rule. It's
-// recommended to use GetEscalationRuleWithContext instead.
+// GetEscalationRule gets information about an existing escalation rule.
+//
+// Deprecated: Use GetEscalationRuleWithContext instead.
 func (c *Client) GetEscalationRule(escID string, id string, o *GetEscalationRuleOptions) (*EscalationRule, error) {
 	return c.GetEscalationRuleWithContext(context.Background(), escID, id, o)
 }
@@ -187,8 +195,9 @@ func (c *Client) GetEscalationRuleWithContext(ctx context.Context, escID string,
 	return getEscalationRuleFromResponse(c, resp, err)
 }
 
-// DeleteEscalationRule deletes an existing escalation rule. It's recommended to
-// use DeleteEscalationRuleWithContext instead.
+// DeleteEscalationRule deletes an existing escalation rule.
+//
+// Deprecated: Use DeleteEscalationRuleWithContext instead.
 func (c *Client) DeleteEscalationRule(escID string, id string) error {
 	return c.DeleteEscalationRuleWithContext(context.Background(), escID, id)
 }
@@ -199,8 +208,9 @@ func (c *Client) DeleteEscalationRuleWithContext(ctx context.Context, escID stri
 	return err
 }
 
-// UpdateEscalationRule updates an existing escalation rule. It's recommended to
-// use UpdateEscalationRuleWithContext instead.
+// UpdateEscalationRule updates an existing escalation rule.
+//
+// Deprecated: Use UpdateEscalationRuleWithContext instead.
 func (c *Client) UpdateEscalationRule(escID string, id string, e *EscalationRule) (*EscalationRule, error) {
 	return c.UpdateEscalationRuleWithContext(context.Background(), escID, id, *e)
 }
@@ -216,8 +226,9 @@ func (c *Client) UpdateEscalationRuleWithContext(ctx context.Context, escID stri
 }
 
 // ListEscalationRules lists all of the escalation rules for an existing
-// escalation policy. It's recommended to use ListEscalationRulesWithContext
-// instead.
+// escalation policy.
+//
+// Deprecated: Use ListEscalationRulesWithContext instead.
 func (c *Client) ListEscalationRules(escID string) (*ListEscalationRulesResponse, error) {
 	return c.ListEscalationRulesWithContext(context.Background(), escID)
 }

--- a/event_v2.go
+++ b/event_v2.go
@@ -44,7 +44,9 @@ type V2EventResponse struct {
 const v2eventEndPoint = "https://events.pagerduty.com/v2/enqueue"
 
 // ManageEvent handles the trigger, acknowledge, and resolve methods for an
-// event. It's recommended to use ManageEventWithContext instead.
+// event.
+//
+// Deprecated: Use ManageEventWithContext instead.
 func ManageEvent(e V2Event) (*V2EventResponse, error) {
 	return ManageEventWithContext(context.Background(), e)
 }
@@ -90,7 +92,9 @@ func ManageEventWithContext(ctx context.Context, e V2Event) (*V2EventResponse, e
 }
 
 // ManageEvent handles the trigger, acknowledge, and resolve methods for an
-// event. It's recommended to use ManageEventWithContext instead.
+// event.
+//
+// Deprecated: Use ManageEventWithContext instead.
 func (c *Client) ManageEvent(e *V2Event) (*V2EventResponse, error) {
 	return c.ManageEventWithContext(context.Background(), e)
 }

--- a/extension.go
+++ b/extension.go
@@ -34,8 +34,9 @@ type ListExtensionOptions struct {
 	Query             string `url:"query,omitempty"`
 }
 
-// ListExtensions lists the extensions from the API. It's recommended to use
-// ListExtensionsWithContext instead.
+// ListExtensions lists the extensions from the API.
+//
+// Deprecated: Use ListExtensionsWithContext instead.
 func (c *Client) ListExtensions(o ListExtensionOptions) (*ListExtensionResponse, error) {
 	return c.ListExtensionsWithContext(context.Background(), o)
 }
@@ -61,6 +62,8 @@ func (c *Client) ListExtensionsWithContext(ctx context.Context, o ListExtensionO
 }
 
 // CreateExtension creates a single extension.
+//
+// Deprecated: Use CreateExtensionWithContext instead.
 func (c *Client) CreateExtension(e *Extension) (*Extension, error) {
 	return c.CreateExtensionWithContext(context.Background(), e)
 }
@@ -72,6 +75,8 @@ func (c *Client) CreateExtensionWithContext(ctx context.Context, e *Extension) (
 }
 
 // DeleteExtension deletes an extension by its ID.
+//
+// Deprecated: Use DeleteExtensionWithContext instead.
 func (c *Client) DeleteExtension(id string) error {
 	return c.DeleteExtensionWithContext(context.Background(), id)
 }
@@ -83,6 +88,8 @@ func (c *Client) DeleteExtensionWithContext(ctx context.Context, id string) erro
 }
 
 // GetExtension gets an extension by its ID.
+//
+// Deprecated: Use GetExtensionWithContext instead.
 func (c *Client) GetExtension(id string) (*Extension, error) {
 	return c.GetExtensionWithContext(context.Background(), id)
 }
@@ -94,6 +101,8 @@ func (c *Client) GetExtensionWithContext(ctx context.Context, id string) (*Exten
 }
 
 // UpdateExtension updates an extension by its ID.
+//
+// Deprecated: Use UpdateExtensionWithContext instead.
 func (c *Client) UpdateExtension(id string, e *Extension) (*Extension, error) {
 	return c.UpdateExtensionWithContext(context.Background(), id, e)
 }

--- a/extension_schema.go
+++ b/extension_schema.go
@@ -37,8 +37,9 @@ type ListExtensionSchemaOptions struct {
 }
 
 // ListExtensionSchemas lists all of the extension schemas. Each schema
-// represents a specific type of outbound extension. It's recommended to use
-// ListExtensionSchemasWithContext instead.
+// represents a specific type of outbound extension.
+//
+// Deprecated: Use ListExtensionSchemasWithContext instead.
 func (c *Client) ListExtensionSchemas(o ListExtensionSchemaOptions) (*ListExtensionSchemaResponse, error) {
 	return c.ListExtensionSchemasWithContext(context.Background(), o)
 }
@@ -64,8 +65,9 @@ func (c *Client) ListExtensionSchemasWithContext(ctx context.Context, o ListExte
 	return &result, nil
 }
 
-// GetExtensionSchema gets a single extension schema. It's recommended to use
-// GetExtensionSchemaWithContext instead.
+// GetExtensionSchema gets a single extension schema.
+//
+// Deprecated: Use GetExtensionSchemaWithContext instead.
 func (c *Client) GetExtensionSchema(id string) (*ExtensionSchema, error) {
 	return c.GetExtensionSchemaWithContext(context.Background(), id)
 }

--- a/incident.go
+++ b/incident.go
@@ -120,8 +120,9 @@ type ConferenceBridge struct {
 	ConferenceURL    string `json:"conference_url,omitempty"`
 }
 
-// ListIncidents lists existing incidents. It's recommended to use
-// ListIncidentsWithContext instead.
+// ListIncidents lists existing incidents.
+//
+// Deprecated: Use ListIncidentsWithContext instead.
 func (c *Client) ListIncidents(o ListIncidentsOptions) (*ListIncidentsResponse, error) {
 	return c.ListIncidentsWithContext(context.Background(), o)
 }
@@ -182,8 +183,9 @@ type MergeIncidentsOptions struct {
 }
 
 // CreateIncident creates an incident synchronously without a corresponding
-// event from a monitoring service. It's recommended to use
-// CreateIncidentWithContext instead.
+// event from a monitoring service.
+//
+// Deprecated: Use CreateIncidentWithContext instead.
 func (c *Client) CreateIncident(from string, o *CreateIncidentOptions) (*Incident, error) {
 	return c.CreateIncidentWithContext(context.Background(), from, o)
 }
@@ -213,7 +215,9 @@ func (c *Client) CreateIncidentWithContext(ctx context.Context, from string, o *
 }
 
 // ManageIncidents acknowledges, resolves, escalates, or reassigns one or more
-// incidents. It's recommended to use ManageIncidentsWithContext instead.
+// incidents.
+//
+// Deprecated: Use ManageIncidentsWithContext instead.
 func (c *Client) ManageIncidents(from string, incidents []ManageIncidentsOptions) (*ListIncidentsResponse, error) {
 	return c.ManageIncidentsWithContext(context.Background(), from, incidents)
 }
@@ -243,7 +247,8 @@ func (c *Client) ManageIncidentsWithContext(ctx context.Context, from string, in
 }
 
 // MergeIncidents merges a list of source incidents into a specified incident.
-// It's recommended to use MergeIncidentsWithContext instead.
+//
+// Deprecated: Use MergeIncidentsWithContext instead.
 func (c *Client) MergeIncidents(from string, id string, sourceIncidents []MergeIncidentsOptions) (*Incident, error) {
 	return c.MergeIncidentsWithContext(context.Background(), from, id, sourceIncidents)
 }
@@ -271,8 +276,9 @@ func (c *Client) MergeIncidentsWithContext(ctx context.Context, from, id string,
 	return &result.Incident, nil
 }
 
-// GetIncident shows detailed information about an incident. It's recommended to
-// use GetIncidentWithContext instead.
+// GetIncident shows detailed information about an incident.
+//
+// Deprecated: Use GetIncidentWithContext instead.
 func (c *Client) GetIncident(id string) (*Incident, error) {
 	return c.GetIncidentWithContext(context.Background(), id)
 }
@@ -310,8 +316,9 @@ type CreateIncidentNoteResponse struct {
 	IncidentNote IncidentNote `json:"note"`
 }
 
-// ListIncidentNotes lists existing notes for the specified incident. It's
-// recommended to use ListIncidentNotesWithContext instead.
+// ListIncidentNotes lists existing notes for the specified incident.
+//
+// Deprecated: Use ListIncidentNotesWithContext instead.
 func (c *Client) ListIncidentNotes(id string) ([]IncidentNote, error) {
 	return c.ListIncidentNotesWithContext(context.Background(), id)
 }
@@ -381,7 +388,8 @@ func (c *Client) ListIncidentAlerts(id string) (*ListAlertsResponse, error) {
 }
 
 // ListIncidentAlertsWithOpts lists existing alerts for the specified incident.
-// It's recommended to use ListIncidentAlertsWithContext instead.
+//
+// Deprecated: Use ListIncidentAlertsWithContext instead.
 func (c *Client) ListIncidentAlertsWithOpts(id string, o ListIncidentAlertsOptions) (*ListAlertsResponse, error) {
 	return c.ListIncidentAlertsWithContext(context.Background(), id, o)
 }
@@ -409,7 +417,8 @@ func (c *Client) ListIncidentAlertsWithContext(ctx context.Context, id string, o
 }
 
 // CreateIncidentNoteWithResponse creates a new note for the specified incident.
-// It's recommended to use CreateIncidentNoteWithContext instead.
+//
+// Deprecated: Use CreateIncidentNoteWithContext instead.
 func (c *Client) CreateIncidentNoteWithResponse(id string, note IncidentNote) (*IncidentNote, error) {
 	return c.CreateIncidentNoteWithContext(context.Background(), id, note)
 }
@@ -439,7 +448,7 @@ func (c *Client) CreateIncidentNoteWithContext(ctx context.Context, id string, n
 
 // CreateIncidentNote creates a new note for the specified incident.
 //
-// Deprecated: please use CreateIncidentNoteWithContext going forward
+// Deprecated: Use CreateIncidentNoteWithContext instead.
 func (c *Client) CreateIncidentNote(id string, note IncidentNote) error {
 	data := make(map[string]IncidentNote)
 	headers := make(map[string]string)
@@ -450,7 +459,9 @@ func (c *Client) CreateIncidentNote(id string, note IncidentNote) error {
 }
 
 // SnoozeIncidentWithResponse sets an incident to not alert for a specified
-// period of time. It's recommended to use SnoozeIncidentWithContext instead.
+// period of time.
+//
+// Deprecated: Use SnoozeIncidentWithContext instead.
 func (c *Client) SnoozeIncidentWithResponse(id string, duration uint) (*Incident, error) {
 	return c.SnoozeIncidentWithContext(context.Background(), id, duration)
 }
@@ -476,7 +487,7 @@ func (c *Client) SnoozeIncidentWithContext(ctx context.Context, id string, durat
 
 // SnoozeIncident sets an incident to not alert for a specified period of time.
 //
-// Deprecated: please use SnoozeIncidentWithContext going forward
+// Deprecated: Use SnoozeIncidentWithContext instead.
 func (c *Client) SnoozeIncident(id string, duration uint) error {
 	data := make(map[string]uint)
 	data["duration"] = duration
@@ -501,7 +512,8 @@ type ListIncidentLogEntriesOptions struct {
 }
 
 // ListIncidentLogEntries lists existing log entries for the specified incident.
-// It's recommended to use ListIncidentLogEntriesWithContext instead.
+//
+// Deprecated: Use ListIncidentLogEntriesWithContext instead.
 func (c *Client) ListIncidentLogEntries(id string, o ListIncidentLogEntriesOptions) (*ListIncidentLogEntriesResponse, error) {
 	return c.ListIncidentLogEntriesWithContext(context.Background(), id, o)
 }
@@ -573,7 +585,8 @@ type ResponderRequest struct {
 }
 
 // ResponderRequest will submit a request to have a responder join an incident.
-// It's recommended to use ResponderRequestWithContext instead.
+//
+// Deprecated: Use ResponderRequestWithContext instead.
 func (c *Client) ResponderRequest(id string, o ResponderRequestOptions) (*ResponderRequestResponse, error) {
 	return c.ResponderRequestWithContext(context.Background(), id, o)
 }
@@ -597,8 +610,9 @@ func (c *Client) ResponderRequestWithContext(ctx context.Context, id string, o R
 	return &result, nil
 }
 
-// GetIncidentAlert gets the alert that triggered the incident. It's recommended
-// to use GetIncidentAlertWithContext instead.
+// GetIncidentAlert gets the alert that triggered the incident.
+//
+// Deprecated: Use GetIncidentAlertWithContext instead.
 func (c *Client) GetIncidentAlert(incidentID, alertID string) (*IncidentAlertResponse, *http.Response, error) {
 	return c.getIncidentAlertWithContext(context.Background(), incidentID, alertID)
 }
@@ -623,8 +637,9 @@ func (c *Client) getIncidentAlertWithContext(ctx context.Context, incidentID, al
 	return &result, resp, nil
 }
 
-// ManageIncidentAlerts allows you to manage the alerts of an incident. It's
-// recommended to use ManageIncidentAlertsWithContext instead.
+// ManageIncidentAlerts allows you to manage the alerts of an incident.
+//
+// Deprecated: Use ManageIncidentAlertsWithContext instead.
 func (c *Client) ManageIncidentAlerts(incidentID string, alerts *IncidentAlertList) (*ListAlertsResponse, *http.Response, error) {
 	return c.manageIncidentAlertsWithContext(context.Background(), incidentID, alerts)
 }

--- a/log_entry.go
+++ b/log_entry.go
@@ -61,7 +61,9 @@ type ListLogEntriesOptions struct {
 }
 
 // ListLogEntries lists all of the incident log entries across the entire
-// account. It's recommended to use ListLogEntriesWithContext instead.
+// account.
+//
+// Deprecated: Use ListLogEntriesWithContext instead.
 func (c *Client) ListLogEntries(o ListLogEntriesOptions) (*ListLogEntryResponse, error) {
 	return c.ListLogEntriesWithContext(context.Background(), o)
 }
@@ -92,8 +94,9 @@ type GetLogEntryOptions struct {
 	Includes []string `url:"include,omitempty,brackets"`
 }
 
-// GetLogEntry list log entries for the specified incident. It's recommended to
-// use GetLogEntryWithContext instead.
+// GetLogEntry list log entries for the specified incident.
+//
+// Deprecated: Use GetLogEntryWithContext instead.
 func (c *Client) GetLogEntry(id string, o GetLogEntryOptions) (*LogEntry, error) {
 	return c.GetLogEntryWithContext(context.Background(), id, o)
 }

--- a/maintenance_window.go
+++ b/maintenance_window.go
@@ -38,7 +38,9 @@ type ListMaintenanceWindowsOptions struct {
 
 // ListMaintenanceWindows lists existing maintenance windows, optionally
 // filtered by service and/or team, or whether they are from the past, present
-// or future. It's recommended to use ListMaintenanceWindowsWithContext instead.
+// or future.
+//
+// Deprecated: Use ListMaintenanceWindowsWithContext instead.
 func (c *Client) ListMaintenanceWindows(o ListMaintenanceWindowsOptions) (*ListMaintenanceWindowsResponse, error) {
 	return c.ListMaintenanceWindowsWithContext(context.Background(), o)
 }
@@ -66,7 +68,9 @@ func (c *Client) ListMaintenanceWindowsWithContext(ctx context.Context, o ListMa
 }
 
 // CreateMaintenanceWindow creates a new maintenance window for the specified
-// services. It's recommended to use CreateMaintenanceWindowWithContext instead.
+// services.
+//
+// Deprecated: Use CreateMaintenanceWindowWithContext instead.
 func (c *Client) CreateMaintenanceWindow(from string, o MaintenanceWindow) (*MaintenanceWindow, error) {
 	return c.CreateMaintenanceWindowWithContext(context.Background(), from, o)
 }
@@ -91,14 +95,16 @@ func (c *Client) CreateMaintenanceWindowWithContext(ctx context.Context, from st
 }
 
 // CreateMaintenanceWindows creates a new maintenance window for the specified services.
-// Deprecated: Use `CreateMaintenanceWindowWithContext` instead.
+//
+// Deprecated: Use CreateMaintenanceWindowWithContext instead.
 func (c *Client) CreateMaintenanceWindows(o MaintenanceWindow) (*MaintenanceWindow, error) {
 	return c.CreateMaintenanceWindowWithContext(context.Background(), "", o)
 }
 
 // DeleteMaintenanceWindow deletes an existing maintenance window if it's in the
-// future, or ends it if it's currently on-going. It's recommended to use
-// DeleteMaintenanceWindowWithContext instead.
+// future, or ends it if it's currently on-going.
+//
+// Deprecated: Use DeleteMaintenanceWindowWithContext instead.
 func (c *Client) DeleteMaintenanceWindow(id string) error {
 	return c.DeleteMaintenanceWindowWithContext(context.Background(), id)
 }
@@ -115,8 +121,9 @@ type GetMaintenanceWindowOptions struct {
 	Includes []string `url:"include,omitempty,brackets"`
 }
 
-// GetMaintenanceWindow gets an existing maintenance window. It's recommended to
-// use GetMaintenanceWindowWithContext instead.
+// GetMaintenanceWindow gets an existing maintenance window.
+//
+// Deprecated: Use GetMaintenanceWindowWithContext instead.
 func (c *Client) GetMaintenanceWindow(id string, o GetMaintenanceWindowOptions) (*MaintenanceWindow, error) {
 	return c.GetMaintenanceWindowWithContext(context.Background(), id, o)
 }
@@ -132,8 +139,9 @@ func (c *Client) GetMaintenanceWindowWithContext(ctx context.Context, id string,
 	return getMaintenanceWindowFromResponse(c, resp, err)
 }
 
-// UpdateMaintenanceWindow updates an existing maintenance window. It's
-// recommended to use UpdateMaintenanceWindowWithContext instead.
+// UpdateMaintenanceWindow updates an existing maintenance window.
+//
+// Deprecated: Use UpdateMaintenanceWindowWithContext instead.
 func (c *Client) UpdateMaintenanceWindow(m MaintenanceWindow) (*MaintenanceWindow, error) {
 	return c.UpdateMaintenanceWindowWithContext(context.Background(), m)
 }

--- a/notification.go
+++ b/notification.go
@@ -33,7 +33,9 @@ type ListNotificationsResponse struct {
 
 // ListNotifications lists notifications for a given time range, optionally
 // filtered by type (sms_notification, email_notification, phone_notification,
-// or push_notification). It's recommended to use ListNotificationsWithContext instead.
+// or push_notification).
+//
+// Deprecated: Use ListNotificationsWithContext instead.
 func (c *Client) ListNotifications(o ListNotificationOptions) (*ListNotificationsResponse, error) {
 	return c.ListNotificationsWithContext(context.Background(), o)
 }

--- a/on_call.go
+++ b/on_call.go
@@ -35,8 +35,9 @@ type ListOnCallOptions struct {
 	Earliest            bool     `url:"earliest,omitempty"`
 }
 
-// ListOnCalls list the on-call entries during a given time range. It's
-// recommended to use ListOnCallsWithContext instead.
+// ListOnCalls list the on-call entries during a given time range.
+//
+// Deprecated: Use ListOnCallsWithContext instead.
 func (c *Client) ListOnCalls(o ListOnCallOptions) (*ListOnCallsResponse, error) {
 	return c.ListOnCallsWithContext(context.Background(), o)
 }

--- a/priorites.go
+++ b/priorites.go
@@ -18,8 +18,9 @@ type Priorities struct {
 	Priorities []PriorityProperty `json:"priorities"`
 }
 
-// ListPriorities lists existing priorities. It's recommended to use
-// ListPrioritiesWithContext instead.
+// ListPriorities lists existing priorities.
+//
+// Deprecated: Use ListPrioritiesWithContext instead.
 func (c *Client) ListPriorities() (*Priorities, error) {
 	return c.ListPrioritiesWithContext(context.Background())
 }

--- a/ruleset.go
+++ b/ruleset.go
@@ -184,8 +184,9 @@ func (c *Client) ListRulesetsPaginated(ctx context.Context) ([]*Ruleset, error) 
 	return rulesets, nil
 }
 
-// CreateRuleset creates a new ruleset. It's recommended to use
-// CreateRulesetWithContext instead.
+// CreateRuleset creates a new ruleset.
+//
+// Deprecated: Use CreateRulesetWithContext instead.
 func (c *Client) CreateRuleset(r *Ruleset) (*Ruleset, *http.Response, error) {
 	return c.createRulesetWithContext(context.Background(), r)
 }
@@ -205,8 +206,9 @@ func (c *Client) createRulesetWithContext(ctx context.Context, r *Ruleset) (*Rul
 	return getRulesetFromResponse(c, resp, err)
 }
 
-// DeleteRuleset deletes a ruleset. It's recommended to use
-// DeleteRulesetWithContext instead.
+// DeleteRuleset deletes a ruleset.
+//
+// Deprecated: Use DeleteRulesetWithContext instead.
 func (c *Client) DeleteRuleset(id string) error {
 	return c.DeleteRulesetWithContext(context.Background(), id)
 }
@@ -218,6 +220,8 @@ func (c *Client) DeleteRulesetWithContext(ctx context.Context, id string) error 
 }
 
 // GetRuleset gets details about a ruleset.
+//
+// Deprecated: Use GetRulesetWithContext instead.
 func (c *Client) GetRuleset(id string) (*Ruleset, *http.Response, error) {
 	return c.getRulesetWithContext(context.Background(), id)
 }
@@ -233,8 +237,9 @@ func (c *Client) getRulesetWithContext(ctx context.Context, id string) (*Ruleset
 	return getRulesetFromResponse(c, resp, err)
 }
 
-// UpdateRuleset updates a ruleset. It's recommended to use
-// UpdateRulesetWithContext instead.
+// UpdateRuleset updates a ruleset.
+//
+// Deprecated: Use UpdateRulesetWithContext instead.
 func (c *Client) UpdateRuleset(r *Ruleset) (*Ruleset, *http.Response, error) {
 	return c.updateRulesetWithContext(context.Background(), r)
 }
@@ -318,8 +323,9 @@ func (c *Client) ListRulesetRulesPaginated(ctx context.Context, rulesetID string
 	return rules, nil
 }
 
-// GetRulesetRule gets an event rule. It's recommended to use
-// GetRulesetRuleWithContext instead.
+// GetRulesetRule gets an event rule.
+//
+// Deprecated: Use GetRulesetRuleWithContext instead.
 func (c *Client) GetRulesetRule(rulesetID, ruleID string) (*RulesetRule, *http.Response, error) {
 	return c.getRulesetRuleWithContext(context.Background(), rulesetID, ruleID)
 }
@@ -335,8 +341,9 @@ func (c *Client) getRulesetRuleWithContext(ctx context.Context, rulesetID, ruleI
 	return getRuleFromResponse(c, resp, err)
 }
 
-// DeleteRulesetRule deletes a rule. It's recommended to use
-// DeleteRulesetRuleWithContext instead.
+// DeleteRulesetRule deletes a rule.
+//
+// Deprecated: Use DeleteRulesetRuleWithContext instead.
 func (c *Client) DeleteRulesetRule(rulesetID, ruleID string) error {
 	return c.DeleteRulesetRuleWithContext(context.Background(), rulesetID, ruleID)
 }
@@ -347,8 +354,9 @@ func (c *Client) DeleteRulesetRuleWithContext(ctx context.Context, rulesetID, ru
 	return err
 }
 
-// CreateRulesetRule creates a new rule for a ruleset. It's recommended to use
-// CreateRulesetRuleWithContext instead.
+// CreateRulesetRule creates a new rule for a ruleset.
+//
+// Deprecated: Use CreateRulesetRuleWithContext instead.
 func (c *Client) CreateRulesetRule(rulesetID string, rule *RulesetRule) (*RulesetRule, *http.Response, error) {
 	return c.CreateRulesetRuleWithContext(context.Background(), rulesetID, rule)
 }
@@ -364,6 +372,8 @@ func (c *Client) CreateRulesetRuleWithContext(ctx context.Context, rulesetID str
 }
 
 // UpdateRulesetRule updates a rule.
+//
+// Deprecated: Use UpdateRulesetRuleWithContext instead.
 func (c *Client) UpdateRulesetRule(rulesetID, ruleID string, r *RulesetRule) (*RulesetRule, *http.Response, error) {
 	return c.UpdateRulesetRuleWithContext(context.Background(), rulesetID, ruleID, r)
 }

--- a/schedule.go
+++ b/schedule.go
@@ -68,8 +68,9 @@ type UserReference struct {
 	User APIObject `json:"user"`
 }
 
-// ListSchedules lists the on-call schedules. It's recommended to use
-// ListSchedulesWithContext instead.
+// ListSchedules lists the on-call schedules.
+//
+// Deprecated: Use ListSchedulesWithContext instead.
 func (c *Client) ListSchedules(o ListSchedulesOptions) (*ListSchedulesResponse, error) {
 	return c.ListSchedulesWithContext(context.Background(), o)
 }
@@ -94,8 +95,9 @@ func (c *Client) ListSchedulesWithContext(ctx context.Context, o ListSchedulesOp
 	return &result, nil
 }
 
-// CreateSchedule creates a new on-call schedule. It's recommended to use
-// CreateScheduleWithContext instead.
+// CreateSchedule creates a new on-call schedule.
+//
+// Deprecated: Use CreateScheduleWithContext instead.
 func (c *Client) CreateSchedule(s Schedule) (*Schedule, error) {
 	return c.CreateScheduleWithContext(context.Background(), s)
 }
@@ -119,7 +121,9 @@ type PreviewScheduleOptions struct {
 }
 
 // PreviewSchedule previews what an on-call schedule would look like without
-// saving it. It's recommended to use PreviewScheduleWithContext instead.
+// saving it.
+//
+// Deprecated: Use PreviewScheduleWithContext instead.
 func (c *Client) PreviewSchedule(s Schedule, o PreviewScheduleOptions) error {
 	return c.PreviewScheduleWithContext(context.Background(), s, o)
 }
@@ -140,8 +144,9 @@ func (c *Client) PreviewScheduleWithContext(ctx context.Context, s Schedule, o P
 	return err
 }
 
-// DeleteSchedule deletes an on-call schedule. It's recommended to use
-// DeleteScheduleWithContext instead.
+// DeleteSchedule deletes an on-call schedule.
+//
+// Deprecated: Use DeleteScheduleWithContext instead.
 func (c *Client) DeleteSchedule(id string) error {
 	return c.DeleteScheduleWithContext(context.Background(), id)
 }
@@ -161,8 +166,9 @@ type GetScheduleOptions struct {
 }
 
 // GetSchedule shows detailed information about a schedule, including entries
-// for each layer and sub-schedule. It's recommended to use
-// GetScheduleWithContext instead.
+// for each layer and sub-schedule.
+//
+// Deprecated: Use GetScheduleWithContext instead.
 func (c *Client) GetSchedule(id string, o GetScheduleOptions) (*Schedule, error) {
 	return c.GetScheduleWithContext(context.Background(), id, o)
 }
@@ -184,8 +190,9 @@ type UpdateScheduleOptions struct {
 	Overflow bool `url:"overflow,omitempty"`
 }
 
-// UpdateSchedule updates an existing on-call schedule. It's recommended to use
-// UpdateScheduleWithContext instead.
+// UpdateSchedule updates an existing on-call schedule.
+//
+// Deprecated: Use UpdateScheduleWithContext instead.
 func (c *Client) UpdateSchedule(id string, s Schedule) (*Schedule, error) {
 	return c.UpdateScheduleWithContext(context.Background(), id, s)
 }
@@ -223,8 +230,9 @@ type Override struct {
 	User  APIObject `json:"user,omitempty"`
 }
 
-// ListOverrides lists overrides for a given time range. It's recommended to use
-// ListOverridesWithContext instead.
+// ListOverrides lists overrides for a given time range.
+//
+// Deprecated: Use ListOverridesWithContext instead.
 func (c *Client) ListOverrides(id string, o ListOverridesOptions) (*ListOverridesResponse, error) {
 	return c.ListOverridesWithContext(context.Background(), id, o)
 }
@@ -250,7 +258,9 @@ func (c *Client) ListOverridesWithContext(ctx context.Context, id string, o List
 }
 
 // CreateOverride creates an override for a specific user covering the specified
-// time range. It's recommended to use CreateOverrideWithContext instead.
+// time range.
+//
+// Deprecated: Use CreateOverrideWithContext instead.
 func (c *Client) CreateOverride(id string, o Override) (*Override, error) {
 	return c.CreateOverrideWithContext(context.Background(), id, o)
 }
@@ -270,8 +280,9 @@ func (c *Client) CreateOverrideWithContext(ctx context.Context, id string, o Ove
 	return getOverrideFromResponse(c, resp)
 }
 
-// DeleteOverride removes an override. It's recommended to use
-// DeleteOverrideWithContext instead.
+// DeleteOverride removes an override.
+//
+// Deprecated: Use DeleteOverrideWithContext instead.
 func (c *Client) DeleteOverride(scheduleID, overrideID string) error {
 	return c.DeleteOverrideWithContext(context.Background(), scheduleID, overrideID)
 }
@@ -290,7 +301,9 @@ type ListOnCallUsersOptions struct {
 }
 
 // ListOnCallUsers lists all of the users on call in a given schedule for a
-// given time range. It's recommended to use ListOnCallUsersWithContext instead.
+// given time range.
+//
+// Deprecated: Use ListOnCallUsersWithContext instead.
 func (c *Client) ListOnCallUsers(id string, o ListOnCallUsersOptions) ([]User, error) {
 	return c.ListOnCallUsersWithContext(context.Background(), id, o)
 }

--- a/service.go
+++ b/service.go
@@ -138,8 +138,9 @@ type ListServiceResponse struct {
 	Services []Service
 }
 
-// ListServices lists existing services. It's recommended to use
-// ListServicesWithContext instead.
+// ListServices lists existing services.
+//
+// Deprecated: Use ListServicesWithContext instead.
 func (c *Client) ListServices(o ListServiceOptions) (*ListServiceResponse, error) {
 	return c.ListServicesWithContext(context.Background(), o)
 }
@@ -200,8 +201,9 @@ type GetServiceOptions struct {
 	Includes []string `url:"include,brackets,omitempty"`
 }
 
-// GetService gets details about an existing service. It's recommended to use
-// GetServiceWithContext instead.
+// GetService gets details about an existing service.
+//
+// Deprecated: Use GetServiceWithContext instead.
 func (c *Client) GetService(id string, o *GetServiceOptions) (*Service, error) {
 	return c.GetServiceWithContext(context.Background(), id, o)
 }
@@ -217,8 +219,9 @@ func (c *Client) GetServiceWithContext(ctx context.Context, id string, o *GetSer
 	return getServiceFromResponse(c, resp, err)
 }
 
-// CreateService creates a new service. It's recommended to use
-// CreateServiceWithContext instead.
+// CreateService creates a new service.
+//
+// Deprecated: Use CreateServiceWithContext instead.
 func (c *Client) CreateService(s Service) (*Service, error) {
 	return c.CreateServiceWithContext(context.Background(), s)
 }
@@ -233,8 +236,9 @@ func (c *Client) CreateServiceWithContext(ctx context.Context, s Service) (*Serv
 	return getServiceFromResponse(c, resp, err)
 }
 
-// UpdateService updates an existing service. It's recommended to use
-// UpdateServiceWithContext instead.
+// UpdateService updates an existing service.
+//
+// Deprecated: Use UpdateServiceWithContext instead.
 func (c *Client) UpdateService(s Service) (*Service, error) {
 	return c.UpdateServiceWithContext(context.Background(), s)
 }
@@ -249,8 +253,9 @@ func (c *Client) UpdateServiceWithContext(ctx context.Context, s Service) (*Serv
 	return getServiceFromResponse(c, resp, err)
 }
 
-// DeleteService deletes an existing service. It's recommended to use
-// DeleteServiceWithContext instead.
+// DeleteService deletes an existing service.
+//
+// Deprecated: Use DeleteServiceWithContext instead.
 func (c *Client) DeleteService(id string) error {
 	return c.DeleteServiceWithContext(context.Background(), id)
 }
@@ -261,8 +266,9 @@ func (c *Client) DeleteServiceWithContext(ctx context.Context, id string) error 
 	return err
 }
 
-// CreateIntegration creates a new integration belonging to a service. It's
-// recommended to use CreateIntegrationWithContext instead.
+// CreateIntegration creates a new integration belonging to a service.
+//
+// Deprecated: Use CreateIntegrationWithContext instead.
 func (c *Client) CreateIntegration(id string, i Integration) (*Integration, error) {
 	return c.CreateIntegrationWithContext(context.Background(), id, i)
 }
@@ -282,8 +288,9 @@ type GetIntegrationOptions struct {
 	Includes []string `url:"include,omitempty,brackets"`
 }
 
-// GetIntegration gets details about an integration belonging to a service. It's
-// recommended to use GetIntegrationWithContext instead.
+// GetIntegration gets details about an integration belonging to a service.
+//
+// Deprecated: Use GetIntegrationWithContext instead.
 func (c *Client) GetIntegration(serviceID, integrationID string, o GetIntegrationOptions) (*Integration, error) {
 	return c.GetIntegrationWithContext(context.Background(), serviceID, integrationID, o)
 }
@@ -299,8 +306,9 @@ func (c *Client) GetIntegrationWithContext(ctx context.Context, serviceID, integ
 	return getIntegrationFromResponse(c, resp, err)
 }
 
-// UpdateIntegration updates an integration belonging to a service. It's
-// recommended to use UpdateIntegrationWithContext instead.
+// UpdateIntegration updates an integration belonging to a service.
+//
+// Deprecated: Use UpdateIntegrationWithContext instead.
 func (c *Client) UpdateIntegration(serviceID string, i Integration) (*Integration, error) {
 	return c.UpdateIntegrationWithContext(context.Background(), serviceID, i)
 }
@@ -311,8 +319,9 @@ func (c *Client) UpdateIntegrationWithContext(ctx context.Context, serviceID str
 	return getIntegrationFromResponse(c, resp, err)
 }
 
-// DeleteIntegration deletes an existing integration. It's recommended to use
-// DeleteIntegrationWithContext instead.
+// DeleteIntegration deletes an existing integration.
+//
+// Deprecated: Use DeleteIntegrationWithContext instead.
 func (c *Client) DeleteIntegration(serviceID string, integrationID string) error {
 	return c.DeleteIntegrationWithContext(context.Background(), serviceID, integrationID)
 }

--- a/service_dependency.go
+++ b/service_dependency.go
@@ -25,7 +25,8 @@ type ListServiceDependencies struct {
 }
 
 // ListBusinessServiceDependencies lists dependencies of a business service.
-// It's recommended to use ListBusinessServiceDependenciesWithContext instead.
+//
+// Deprecated: Use ListBusinessServiceDependenciesWithContext instead.
 func (c *Client) ListBusinessServiceDependencies(businessServiceID string) (*ListServiceDependencies, *http.Response, error) {
 	return c.listBusinessServiceDependenciesWithContext(context.Background(), businessServiceID)
 }
@@ -51,7 +52,8 @@ func (c *Client) listBusinessServiceDependenciesWithContext(ctx context.Context,
 }
 
 // ListTechnicalServiceDependencies lists dependencies of a technical service.
-// It's recommended to use ListTechnicalServiceDependenciesWithContext instead.
+//
+// Deprecated: Use ListTechnicalServiceDependenciesWithContext instead.
 func (c *Client) ListTechnicalServiceDependencies(serviceID string) (*ListServiceDependencies, *http.Response, error) {
 	return c.listTechnicalServiceDependenciesWithContext(context.Background(), serviceID)
 }
@@ -77,7 +79,8 @@ func (c *Client) listTechnicalServiceDependenciesWithContext(ctx context.Context
 }
 
 // AssociateServiceDependencies Create new dependencies between two services.
-// It's recommended to use AssociateServiceDependenciesWithContext instead.
+//
+// Deprecated: Use AssociateServiceDependenciesWithContext instead.
 func (c *Client) AssociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
 	return c.associateServiceDependenciesWithContext(context.Background(), dependencies)
 }
@@ -103,6 +106,8 @@ func (c *Client) associateServiceDependenciesWithContext(ctx context.Context, de
 }
 
 // DisassociateServiceDependencies Disassociate dependencies between two services.
+//
+// Deprecated: Use DisassociateServiceDependenciesWithContext instead.
 func (c *Client) DisassociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
 	return c.disassociateServiceDependenciesWithContext(context.Background(), dependencies)
 }

--- a/tag.go
+++ b/tag.go
@@ -82,8 +82,9 @@ func (c *Client) ListTagsPaginated(ctx context.Context, o ListTagOptions) ([]*Ta
 	return tags, nil
 }
 
-// CreateTag creates a new tag. It's recommended to use CreateTagWithContext
-// instead.
+// CreateTag creates a new tag.
+//
+// Deprecated: Use CreateTagWithContext instead.
 func (c *Client) CreateTag(t *Tag) (*Tag, *http.Response, error) {
 	return c.CreateTagWithContext(context.Background(), t)
 }
@@ -98,8 +99,9 @@ func (c *Client) CreateTagWithContext(ctx context.Context, t *Tag) (*Tag, *http.
 	return getTagFromResponse(c, resp, err)
 }
 
-// DeleteTag removes an existing tag. It's recommended to use
-// DeleteTagWithContext instead.
+// DeleteTag removes an existing tag.
+//
+// Deprecated: Use DeleteTagWithContext instead.
 func (c *Client) DeleteTag(id string) error {
 	return c.DeleteTagWithContext(context.Background(), id)
 }
@@ -110,8 +112,9 @@ func (c *Client) DeleteTagWithContext(ctx context.Context, id string) error {
 	return err
 }
 
-// GetTag gets details about an existing tag. It's recommended to use
-// GetTagWithContext instead.
+// GetTag gets details about an existing tag.
+//
+// Deprecated: Use GetTagWithContext instead.
 func (c *Client) GetTag(id string) (*Tag, *http.Response, error) {
 	return c.GetTagWithContext(context.Background(), id)
 }
@@ -122,8 +125,9 @@ func (c *Client) GetTagWithContext(ctx context.Context, id string) (*Tag, *http.
 	return getTagFromResponse(c, resp, err)
 }
 
-// AssignTags adds and removes tag assignments with entities. It's recommended
-// to use AssignTagsWithContext instead.
+// AssignTags adds and removes tag assignments with entities.
+//
+// Deprecated: Use AssignTagsWithContext instead.
 func (c *Client) AssignTags(e, eid string, a *TagAssignments) (*http.Response, error) {
 	return c.AssignTagsWithContext(context.Background(), e, eid, a)
 }

--- a/team.go
+++ b/team.go
@@ -28,7 +28,9 @@ type ListTeamOptions struct {
 }
 
 // ListTeams lists teams of your PagerDuty account, optionally filtered by a
-// search query. It's recommended to use ListTeamsWithContext instead.
+// search query.
+//
+// Deprecated: Use ListTeamsWithContext instead.
 func (c *Client) ListTeams(o ListTeamOptions) (*ListTeamResponse, error) {
 	return c.ListTeamsWithContext(context.Background(), o)
 }
@@ -54,8 +56,9 @@ func (c *Client) ListTeamsWithContext(ctx context.Context, o ListTeamOptions) (*
 	return &result, nil
 }
 
-// CreateTeam creates a new team. It's recommended to use CreateTeamWithContext
-// instead.
+// CreateTeam creates a new team.
+//
+// Deprecated: Use CreateTeamWithContext instead.
 func (c *Client) CreateTeam(t *Team) (*Team, error) {
 	return c.CreateTeamWithContext(context.Background(), t)
 }
@@ -66,8 +69,9 @@ func (c *Client) CreateTeamWithContext(ctx context.Context, t *Team) (*Team, err
 	return getTeamFromResponse(c, resp, err)
 }
 
-// DeleteTeam removes an existing team. It's recommended to use
-// DeleteTeamWithContext instead.
+// DeleteTeam removes an existing team.
+//
+// Deprecated: Use DeleteTeamWithContext instead.
 func (c *Client) DeleteTeam(id string) error {
 	return c.DeleteTeamWithContext(context.Background(), id)
 }
@@ -78,8 +82,9 @@ func (c *Client) DeleteTeamWithContext(ctx context.Context, id string) error {
 	return err
 }
 
-// GetTeam gets details about an existing team. It's recommended to use
-// GetTeamWithContext instead.
+// GetTeam gets details about an existing team.
+//
+// Deprecated: Use GetTeamWithContext instead.
 func (c *Client) GetTeam(id string) (*Team, error) {
 	return c.GetTeamWithContext(context.Background(), id)
 }
@@ -90,8 +95,9 @@ func (c *Client) GetTeamWithContext(ctx context.Context, id string) (*Team, erro
 	return getTeamFromResponse(c, resp, err)
 }
 
-// UpdateTeam updates an existing team. It's recommended to use
-// UpdateTeamWithContext instead.
+// UpdateTeam updates an existing team.
+//
+// Deprecated: Use UpdateTeamWithContext instead.
 func (c *Client) UpdateTeam(id string, t *Team) (*Team, error) {
 	return c.UpdateTeamWithContext(context.Background(), id, t)
 }
@@ -102,8 +108,9 @@ func (c *Client) UpdateTeamWithContext(ctx context.Context, id string, t *Team) 
 	return getTeamFromResponse(c, resp, err)
 }
 
-// RemoveEscalationPolicyFromTeam removes an escalation policy from a team. It's
-// recommended to use RemoveEscalationPolicyFromTeamWithContext instead.
+// RemoveEscalationPolicyFromTeam removes an escalation policy from a team.
+//
+// Deprecated: Use RemoveEscalationPolicyFromTeamWithContext instead.
 func (c *Client) RemoveEscalationPolicyFromTeam(teamID, epID string) error {
 	return c.RemoveEscalationPolicyFromTeamWithContext(context.Background(), teamID, epID)
 }
@@ -114,8 +121,9 @@ func (c *Client) RemoveEscalationPolicyFromTeamWithContext(ctx context.Context, 
 	return err
 }
 
-// AddEscalationPolicyToTeam adds an escalation policy to a team. It's
-// recommended to use AddEscalationPolicyToTeamWithContext instead.
+// AddEscalationPolicyToTeam adds an escalation policy to a team.
+//
+// Deprecated: Use AddEscalationPolicyToTeamWithContext instead.
 func (c *Client) AddEscalationPolicyToTeam(teamID, epID string) error {
 	return c.AddEscalationPolicyToTeamWithContext(context.Background(), teamID, epID)
 }
@@ -126,8 +134,9 @@ func (c *Client) AddEscalationPolicyToTeamWithContext(ctx context.Context, teamI
 	return err
 }
 
-// RemoveUserFromTeam removes a user from a team. It's recommended to use
-// RemoveUserFromTeamWithContext instead.
+// RemoveUserFromTeam removes a user from a team.
+//
+// Deprecated: Use RemoveUserFromTeamWithContext instead.
 func (c *Client) RemoveUserFromTeam(teamID, userID string) error {
 	return c.RemoveUserFromTeamWithContext(context.Background(), teamID, userID)
 }
@@ -139,6 +148,8 @@ func (c *Client) RemoveUserFromTeamWithContext(ctx context.Context, teamID, user
 }
 
 // AddUserToTeam adds a user to a team.
+//
+// Deprecated: Use AddUserToTeamWithContext instead.
 func (c *Client) AddUserToTeam(teamID, userID string) error {
 	return c.AddUserToTeamWithContext(context.Background(), AddUserToTeamOptions{TeamID: teamID, UserID: userID})
 }
@@ -220,7 +231,8 @@ type ListMembersResponse struct {
 }
 
 // ListMembers gets the first page of users associated with the specified team.
-// It's recommended to use ListMembersWithContext instead.
+//
+// Deprecated: Use ListMembersWithContext instead.
 func (c *Client) ListMembers(teamID string, o ListMembersOptions) (*ListMembersResponse, error) {
 	return c.ListMembersWithContext(context.Background(), teamID, o)
 }

--- a/user.go
+++ b/user.go
@@ -90,7 +90,9 @@ type GetCurrentUserOptions struct {
 }
 
 // ListUsers lists users of your PagerDuty account, optionally filtered by a
-// search query. It's recommended to use ListUsersWithContext instead.
+// search query.
+//
+// Deprecated: Use ListUsersWithContext instead.
 func (c *Client) ListUsers(o ListUsersOptions) (*ListUsersResponse, error) {
 	return c.ListUsersWithContext(context.Background(), o)
 }
@@ -115,8 +117,9 @@ func (c *Client) ListUsersWithContext(ctx context.Context, o ListUsersOptions) (
 	return &result, nil
 }
 
-// CreateUser creates a new user. It's recommended to use CreateUserWithContext
-// instead.
+// CreateUser creates a new user.
+//
+// Deprecated: Use CreateUserWithContext instead.
 func (c *Client) CreateUser(u User) (*User, error) {
 	return c.CreateUserWithContext(context.Background(), u)
 }
@@ -131,8 +134,9 @@ func (c *Client) CreateUserWithContext(ctx context.Context, u User) (*User, erro
 	return getUserFromResponse(c, resp, err)
 }
 
-// DeleteUser deletes a user. It's recommended to use DeleteUserWithContext
-// instead.
+// DeleteUser deletes a user.
+//
+// Deprecated: Use DeleteUserWithContext instead.
 func (c *Client) DeleteUser(id string) error {
 	return c.DeleteUserWithContext(context.Background(), id)
 }
@@ -143,8 +147,9 @@ func (c *Client) DeleteUserWithContext(ctx context.Context, id string) error {
 	return err
 }
 
-// GetUser gets details about an existing user. It's recommended to use
-// GetUserWithContext instead.
+// GetUser gets details about an existing user.
+//
+// Deprecated: Use GetUserWithContext instead.
 func (c *Client) GetUser(id string, o GetUserOptions) (*User, error) {
 	return c.GetUserWithContext(context.Background(), id, o)
 }
@@ -160,8 +165,9 @@ func (c *Client) GetUserWithContext(ctx context.Context, id string, o GetUserOpt
 	return getUserFromResponse(c, resp, err)
 }
 
-// UpdateUser updates an existing user. It's recommended to use
-// UpdateUserWithContext instead.
+// UpdateUser updates an existing user.
+//
+// Deprecated: Use UpdateUserWithContext instead.
 func (c *Client) UpdateUser(u User) (*User, error) {
 	return c.UpdateUserWithContext(context.Background(), u)
 }
@@ -177,8 +183,9 @@ func (c *Client) UpdateUserWithContext(ctx context.Context, u User) (*User, erro
 }
 
 // GetCurrentUser gets details about the authenticated user when using a
-// user-level API key or OAuth token. It's recommended to use
-// GetCurrentUserWithContext instead.
+// user-level API key or OAuth token.
+//
+// Deprecated: Use GetCurrentUserWithContext instead.
 func (c *Client) GetCurrentUser(o GetCurrentUserOptions) (*User, error) {
 	return c.GetCurrentUserWithContext(context.Background(), o)
 }
@@ -215,8 +222,9 @@ func getUserFromResponse(c *Client, resp *http.Response, err error) (*User, erro
 	return &t, nil
 }
 
-// ListUserContactMethods fetches contact methods of the existing user. It's
-// recommended to use ListUserContactMethodsWithContext instead.
+// ListUserContactMethods fetches contact methods of the existing user.
+//
+// Deprecated: Use ListUserContactMethodsWithContext instead.
 func (c *Client) ListUserContactMethods(userID string) (*ListContactMethodsResponse, error) {
 	return c.ListUserContactMethodsWithContext(context.Background(), userID)
 }
@@ -236,8 +244,9 @@ func (c *Client) ListUserContactMethodsWithContext(ctx context.Context, userID s
 	return &result, nil
 }
 
-// GetUserContactMethod gets details about a contact method. It's recommended to
-// use GetUserContactMethodWithContext instead.
+// GetUserContactMethod gets details about a contact method.
+//
+// Deprecated: Use GetUserContactMethodWithContext instead.
 func (c *Client) GetUserContactMethod(userID, contactMethodID string) (*ContactMethod, error) {
 	return c.GetUserContactMethodWithContext(context.Background(), userID, contactMethodID)
 }
@@ -248,8 +257,9 @@ func (c *Client) GetUserContactMethodWithContext(ctx context.Context, userID, co
 	return getContactMethodFromResponse(c, resp, err)
 }
 
-// DeleteUserContactMethod deletes a user. It's recommended to use
-// DeleteUserContactMethodWithContext instead.
+// DeleteUserContactMethod deletes a user.
+//
+// Deprecated: Use DeleteUserContactMethodWithContext instead.
 func (c *Client) DeleteUserContactMethod(userID, contactMethodID string) error {
 	return c.DeleteUserContactMethodWithContext(context.Background(), userID, contactMethodID)
 }
@@ -260,8 +270,9 @@ func (c *Client) DeleteUserContactMethodWithContext(ctx context.Context, userID,
 	return err
 }
 
-// CreateUserContactMethod creates a new contact method for user. It's
-// recommended to use CreateUserContactMethodWithContext instead.
+// CreateUserContactMethod creates a new contact method for user.
+//
+// Deprecated: Use CreateUserContactMethodWithContext instead.
 func (c *Client) CreateUserContactMethod(userID string, cm ContactMethod) (*ContactMethod, error) {
 	return c.CreateUserContactMethodWithContext(context.Background(), userID, cm)
 }
@@ -312,8 +323,9 @@ func getContactMethodFromResponse(c *Client, resp *http.Response, err error) (*C
 	return &t, nil
 }
 
-// GetUserNotificationRule gets details about a notification rule. It's
-// recommended to use GetUserNotificationRuleWithContext instead.
+// GetUserNotificationRule gets details about a notification rule.
+//
+// Deprecated: Use GetUserNotificationRuleWithContext instead.
 func (c *Client) GetUserNotificationRule(userID, ruleID string) (*NotificationRule, error) {
 	return c.GetUserNotificationRuleWithContext(context.Background(), userID, ruleID)
 }
@@ -324,8 +336,9 @@ func (c *Client) GetUserNotificationRuleWithContext(ctx context.Context, userID,
 	return getUserNotificationRuleFromResponse(c, resp, err)
 }
 
-// CreateUserNotificationRule creates a new notification rule for a user. It's
-// recommended to use CreateUserNotificationRuleWithContext instead.
+// CreateUserNotificationRule creates a new notification rule for a user.
+//
+// Deprecated: Use CreateUserNotificationRuleWithContext instead.
 func (c *Client) CreateUserNotificationRule(userID string, rule NotificationRule) (*NotificationRule, error) {
 	return c.CreateUserNotificationRuleWithContext(context.Background(), userID, rule)
 }
@@ -340,8 +353,9 @@ func (c *Client) CreateUserNotificationRuleWithContext(ctx context.Context, user
 	return getUserNotificationRuleFromResponse(c, resp, err)
 }
 
-// UpdateUserNotificationRule updates a notification rule for a user. It's
-// recommended to use UpdateUserNotificationRuleWithContext instead.
+// UpdateUserNotificationRule updates a notification rule for a user.
+//
+// Deprecated: Use UpdateUserNotificationRuleWithContext instead.
 func (c *Client) UpdateUserNotificationRule(userID string, rule NotificationRule) (*NotificationRule, error) {
 	return c.UpdateUserNotificationRuleWithContext(context.Background(), userID, rule)
 }
@@ -356,8 +370,9 @@ func (c *Client) UpdateUserNotificationRuleWithContext(ctx context.Context, user
 	return getUserNotificationRuleFromResponse(c, resp, err)
 }
 
-// DeleteUserNotificationRule deletes a notification rule for a user. It's
-// recommended to use DeleteUserNotificationRuleWithContext instead.
+// DeleteUserNotificationRule deletes a notification rule for a user.
+//
+// Deprecated: Use DeleteUserNotificationRuleWithContext instead.
 func (c *Client) DeleteUserNotificationRule(userID, ruleID string) error {
 	return c.DeleteUserNotificationRuleWithContext(context.Background(), userID, ruleID)
 }
@@ -369,6 +384,8 @@ func (c *Client) DeleteUserNotificationRuleWithContext(ctx context.Context, user
 }
 
 // ListUserNotificationRules fetches notification rules of the existing user.
+//
+// Deprecated: Use ListUserNotificationRulesWithContext instead.
 func (c *Client) ListUserNotificationRules(userID string) (*ListUserNotificationRulesResponse, error) {
 	return c.ListUserNotificationRulesWithContext(context.Background(), userID)
 }

--- a/vendor.go
+++ b/vendor.go
@@ -37,8 +37,9 @@ type ListVendorOptions struct {
 	Query string `url:"query,omitempty"`
 }
 
-// ListVendors lists existing vendors. It's recommended to use
-// ListVendorsWithContext instead.
+// ListVendors lists existing vendors.
+//
+// Deprecated: Use ListVendorsWithContext instead.
 func (c *Client) ListVendors(o ListVendorOptions) (*ListVendorResponse, error) {
 	return c.ListVendorsWithContext(context.Background(), o)
 }
@@ -63,8 +64,9 @@ func (c *Client) ListVendorsWithContext(ctx context.Context, o ListVendorOptions
 	return &result, nil
 }
 
-// GetVendor gets details about an existing vendor. It's recommended to use
-// GetVendorWithContext instead.
+// GetVendor gets details about an existing vendor.
+//
+// Deprecated: Use GetVendorWithContext instead.
 func (c *Client) GetVendor(id string) (*Vendor, error) {
 	return c.GetVendorWithContext(context.Background(), id)
 }


### PR DESCRIPTION
There is a specific format for deprecation notices in Go doc comments
(see https://golang.org/wiki/Deprecated) that ensures they are correctly
rendered (e.g.
https://pkg.go.dev/github.com/PagerDuty/go-pagerduty#Client.CreateIncidentNote).

Add a handful of missing deprecation notices to functions that now have
parallel WithContext counterparts.