### PR TITLE
Fix `pd schedule override create`.

### DIFF
--- a/command/schedule_override_create.go
+++ b/command/schedule_override_create.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"strings"
 )
@@ -48,7 +48,7 @@ func (c *ScheduleOverrideCreate) Run(args []string) int {
 	}
 	log.Info("service id is:", flags.Arg(0))
 	log.Info("Input file is:", flags.Arg(1))
-	f, err := os.Open(flags.Arg(0))
+	f, err := os.Open(flags.Arg(1))
 	if err != nil {
 		log.Error(err)
 		return -1


### PR DESCRIPTION
It was trying to load a file named after the schedule ID instead of the
second argument, which is the file name.