### PR TITLE
allow setting suppress to false

### DIFF
--- a/ruleset.go
+++ b/ruleset.go
@@ -121,7 +121,7 @@ type RuleActionParameter struct {
 
 // RuleActionSuppress represents a rule suppress action object
 type RuleActionSuppress struct {
-	Value               bool   `json:"value,omitempty"`
+	Value               bool   `json:"value"`
 	ThresholdValue      int    `json:"threshold_value,omitempty"`
 	ThresholdTimeUnit   string `json:"threshold_time_unit,omitempty"`
 	ThresholdTimeAmount int    `json:"threshold_time_amount,omitempty"`


### PR DESCRIPTION
The Pagerduty API allows setting suppress to false. omitempty prevents this from working.