### PR TITLE
Add omitempty on Service.SupportHours and Service.ScheduledActions

### DIFF
--- a/service.go
+++ b/service.go
@@ -101,8 +101,8 @@ type Service struct {
 	EscalationPolicy        EscalationPolicy         `json:"escalation_policy,omitempty"`
 	Teams                   []Team                   `json:"teams,omitempty"`
 	IncidentUrgencyRule     *IncidentUrgencyRule     `json:"incident_urgency_rule,omitempty"`
-	SupportHours            *SupportHours            `json:"support_hours"`
-	ScheduledActions        []ScheduledAction        `json:"scheduled_actions"`
+	SupportHours            *SupportHours            `json:"support_hours,omitempty"`
+	ScheduledActions        []ScheduledAction        `json:"scheduled_actions,omitempty"`
 	AlertCreation           string                   `json:"alert_creation,omitempty"`
 	AlertGrouping           string                   `json:"alert_grouping,omitempty"`
 	AlertGroupingTimeout    *uint                    `json:"alert_grouping_timeout,omitempty"`


### PR DESCRIPTION
The lack of `omitempty` on these fields is causing `CreateService` calls to fail
when both are omitted. This broke in the v1.4.0 release so this is a bug fix.

Relates to #348

Fixes #346