### PR TITLE
Remove returned *http.Response from incident-related methods

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -3,7 +3,6 @@ package pagerduty
 import (
 	"context"
 	"fmt"
-	"net/http"
 
 	"github.com/google/go-querystring/query"
 )
@@ -613,55 +612,45 @@ func (c *Client) ResponderRequestWithContext(ctx context.Context, id string, o R
 // GetIncidentAlert gets the alert that triggered the incident.
 //
 // Deprecated: Use GetIncidentAlertWithContext instead.
-func (c *Client) GetIncidentAlert(incidentID, alertID string) (*IncidentAlertResponse, *http.Response, error) {
-	return c.getIncidentAlertWithContext(context.Background(), incidentID, alertID)
+func (c *Client) GetIncidentAlert(incidentID, alertID string) (*IncidentAlertResponse, error) {
+	return c.GetIncidentAlertWithContext(context.Background(), incidentID, alertID)
 }
 
 // GetIncidentAlertWithContext gets the alert that triggered the incident.
 func (c *Client) GetIncidentAlertWithContext(ctx context.Context, incidentID, alertID string) (*IncidentAlertResponse, error) {
-	iar, _, err := c.getIncidentAlertWithContext(context.Background(), incidentID, alertID)
-	return iar, err
-}
-
-func (c *Client) getIncidentAlertWithContext(ctx context.Context, incidentID, alertID string) (*IncidentAlertResponse, *http.Response, error) {
 	resp, err := c.get(ctx, "/incidents/"+incidentID+"/alerts/"+alertID)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var result IncidentAlertResponse
 	if err = c.decodeJSON(resp, &result); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return &result, resp, nil
+	return &result, nil
 }
 
 // ManageIncidentAlerts allows you to manage the alerts of an incident.
 //
 // Deprecated: Use ManageIncidentAlertsWithContext instead.
-func (c *Client) ManageIncidentAlerts(incidentID string, alerts *IncidentAlertList) (*ListAlertsResponse, *http.Response, error) {
-	return c.manageIncidentAlertsWithContext(context.Background(), incidentID, alerts)
+func (c *Client) ManageIncidentAlerts(incidentID string, alerts *IncidentAlertList) (*ListAlertsResponse, error) {
+	return c.ManageIncidentAlertsWithContext(context.Background(), incidentID, alerts)
 }
 
 // ManageIncidentAlertsWithContext allows you to manage the alerts of an incident.
 func (c *Client) ManageIncidentAlertsWithContext(ctx context.Context, incidentID string, alerts *IncidentAlertList) (*ListAlertsResponse, error) {
-	lar, _, err := c.manageIncidentAlertsWithContext(context.Background(), incidentID, alerts)
-	return lar, err
-}
-
-func (c *Client) manageIncidentAlertsWithContext(ctx context.Context, incidentID string, alerts *IncidentAlertList) (*ListAlertsResponse, *http.Response, error) {
 	resp, err := c.put(ctx, "/incidents/"+incidentID+"/alerts/", alerts, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var result ListAlertsResponse
 	if err = c.decodeJSON(resp, &result); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return &result, resp, nil
+	return &result, nil
 }
 
 /* TODO: Create Status Updates */

--- a/incident_test.go
+++ b/incident_test.go
@@ -619,7 +619,7 @@ func TestIncident_GetAlert(t *testing.T) {
 
 	incidentID := "1"
 	alertID := "1"
-	res, _, err := client.GetIncidentAlert(incidentID, alertID)
+	res, err := client.GetIncidentAlert(incidentID, alertID)
 
 	want := &IncidentAlertResponse{
 		IncidentAlert: &IncidentAlert{
@@ -657,7 +657,7 @@ func TestIncident_ManageAlerts(t *testing.T) {
 			},
 		},
 	}
-	res, _, err := client.ManageIncidentAlerts(incidentID, input)
+	res, err := client.ManageIncidentAlerts(incidentID, input)
 
 	want := &ListAlertsResponse{
 		Alerts: []IncidentAlert{


### PR DESCRIPTION
This is a breaking change.

This is one of the changes that will need to be made to complete issue #305,
which is being done in a minor release even though it does contain breaking
changes.

The internal implementation details of how this was implemented meant it never
worked in a way that consumers could use, because the body was always empty.
Seeing as this API never worked and we do not wish to support it, we are going
to remove it so that anyone who may have depended on it, but missed that it was
broken, can be made aware.

If someone wanted to capture the full response of these API calls, they can now
do so using the the functionality added in #325 (4f01c5befe6bde8e812f8acf42546764d58bf7c8).