### PR TITLE
Remove returned *http.Response from svc dependency related methods

### DIFF
--- a/service_dependency.go
+++ b/service_dependency.go
@@ -2,7 +2,6 @@ package pagerduty
 
 import (
 	"context"
-	"net/http"
 )
 
 // ServiceDependency represents a relationship between a business and technical service
@@ -27,108 +26,87 @@ type ListServiceDependencies struct {
 // ListBusinessServiceDependencies lists dependencies of a business service.
 //
 // Deprecated: Use ListBusinessServiceDependenciesWithContext instead.
-func (c *Client) ListBusinessServiceDependencies(businessServiceID string) (*ListServiceDependencies, *http.Response, error) {
-	return c.listBusinessServiceDependenciesWithContext(context.Background(), businessServiceID)
+func (c *Client) ListBusinessServiceDependencies(businessServiceID string) (*ListServiceDependencies, error) {
+	return c.ListBusinessServiceDependenciesWithContext(context.Background(), businessServiceID)
 }
 
 // ListBusinessServiceDependenciesWithContext lists dependencies of a business service.
 func (c *Client) ListBusinessServiceDependenciesWithContext(ctx context.Context, businessServiceID string) (*ListServiceDependencies, error) {
-	lsd, _, err := c.listBusinessServiceDependenciesWithContext(ctx, businessServiceID)
-	return lsd, err
-}
-
-func (c *Client) listBusinessServiceDependenciesWithContext(ctx context.Context, businessServiceID string) (*ListServiceDependencies, *http.Response, error) {
 	resp, err := c.get(ctx, "/service_dependencies/business_services/"+businessServiceID)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var result ListServiceDependencies
 	if err = c.decodeJSON(resp, &result); err != nil {
-		return nil, resp, err
+		return nil, err
 	}
 
-	return &result, resp, nil
+	return &result, nil
 }
 
 // ListTechnicalServiceDependencies lists dependencies of a technical service.
 //
 // Deprecated: Use ListTechnicalServiceDependenciesWithContext instead.
-func (c *Client) ListTechnicalServiceDependencies(serviceID string) (*ListServiceDependencies, *http.Response, error) {
-	return c.listTechnicalServiceDependenciesWithContext(context.Background(), serviceID)
+func (c *Client) ListTechnicalServiceDependencies(serviceID string) (*ListServiceDependencies, error) {
+	return c.ListTechnicalServiceDependenciesWithContext(context.Background(), serviceID)
 }
 
 // ListTechnicalServiceDependenciesWithContext lists dependencies of a technical service.
 func (c *Client) ListTechnicalServiceDependenciesWithContext(ctx context.Context, serviceID string) (*ListServiceDependencies, error) {
-	lsd, _, err := c.listTechnicalServiceDependenciesWithContext(ctx, serviceID)
-	return lsd, err
-}
-
-func (c *Client) listTechnicalServiceDependenciesWithContext(ctx context.Context, serviceID string) (*ListServiceDependencies, *http.Response, error) {
 	resp, err := c.get(ctx, "/service_dependencies/technical_services/"+serviceID)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var result ListServiceDependencies
 	if err = c.decodeJSON(resp, &result); err != nil {
-		return nil, resp, err
+		return nil, err
 	}
 
-	return &result, resp, nil
+	return &result, nil
 }
 
 // AssociateServiceDependencies Create new dependencies between two services.
 //
 // Deprecated: Use AssociateServiceDependenciesWithContext instead.
-func (c *Client) AssociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
-	return c.associateServiceDependenciesWithContext(context.Background(), dependencies)
+func (c *Client) AssociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, error) {
+	return c.AssociateServiceDependenciesWithContext(context.Background(), dependencies)
 }
 
 // AssociateServiceDependenciesWithContext Create new dependencies between two services.
 func (c *Client) AssociateServiceDependenciesWithContext(ctx context.Context, dependencies *ListServiceDependencies) (*ListServiceDependencies, error) {
-	lsd, _, err := c.associateServiceDependenciesWithContext(ctx, dependencies)
-	return lsd, err
-}
-
-func (c *Client) associateServiceDependenciesWithContext(ctx context.Context, dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
 	resp, err := c.post(ctx, "/service_dependencies/associate", dependencies, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var result ListServiceDependencies
 	if err = c.decodeJSON(resp, &result); err != nil {
-		return nil, resp, err
+		return nil, err
 	}
 
-	return &result, resp, nil
+	return &result, nil
 }
 
 // DisassociateServiceDependencies Disassociate dependencies between two services.
 //
 // Deprecated: Use DisassociateServiceDependenciesWithContext instead.
-func (c *Client) DisassociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
-	return c.disassociateServiceDependenciesWithContext(context.Background(), dependencies)
+func (c *Client) DisassociateServiceDependencies(dependencies *ListServiceDependencies) (*ListServiceDependencies, error) {
+	return c.DisassociateServiceDependenciesWithContext(context.Background(), dependencies)
 }
 
 // DisassociateServiceDependenciesWithContext Disassociate dependencies between two services.
 func (c *Client) DisassociateServiceDependenciesWithContext(ctx context.Context, dependencies *ListServiceDependencies) (*ListServiceDependencies, error) {
-	lsd, _, err := c.disassociateServiceDependenciesWithContext(ctx, dependencies)
-	return lsd, err
-}
-
-// DisassociateServiceDependencies Disassociate dependencies between two services.
-func (c *Client) disassociateServiceDependenciesWithContext(ctx context.Context, dependencies *ListServiceDependencies) (*ListServiceDependencies, *http.Response, error) {
 	resp, err := c.post(ctx, "/service_dependencies/disassociate", dependencies, nil)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var result ListServiceDependencies
 	if err = c.decodeJSON(resp, &result); err != nil {
-		return nil, resp, err
+		return nil, err
 	}
 
-	return &result, resp, nil
+	return &result, nil
 }

--- a/service_dependency_test.go
+++ b/service_dependency_test.go
@@ -17,7 +17,7 @@ func TestBusinessServiceDependency_List(t *testing.T) {
 
 	client := defaultTestClient(server.URL, "foo")
 	bServeID := "1"
-	res, _, err := client.ListBusinessServiceDependencies(bServeID)
+	res, err := client.ListBusinessServiceDependencies(bServeID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +51,7 @@ func TestTechnicalServiceDependency_List(t *testing.T) {
 
 	client := defaultTestClient(server.URL, "foo")
 	bServeID := "1"
-	res, _, err := client.ListTechnicalServiceDependencies(bServeID)
+	res, err := client.ListTechnicalServiceDependencies(bServeID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +98,7 @@ func TestServiceDependency_Associate(t *testing.T) {
 			},
 		},
 	}
-	res, _, err := client.AssociateServiceDependencies(input)
+	res, err := client.AssociateServiceDependencies(input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +144,7 @@ func TestServiceDependency_Disassociate(t *testing.T) {
 			},
 		},
 	}
-	res, _, err := client.DisassociateServiceDependencies(input)
+	res, err := client.DisassociateServiceDependencies(input)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is a breaking change.

This is one of the changes that will need to be made to complete issue #305,
which is being done in a minor release even though it does contain breaking
changes.

The internal implementation details of how this was implemented meant it never
worked in a way that consumers could use, because the body was always empty.
Seeing as this API never worked and we do not wish to support it, we are going
to remove it so that anyone who may have depended on it, but missed that it was
broken, can be made aware.

If someone wanted to capture the full response of these API calls, they can now
do so using the the functionality added in #325 (4f01c5befe6bde8e812f8acf42546764d58bf7c8).