### PR TITLE
Remove returned *http.Response from ruleset-related methods

### DIFF
--- a/ruleset.go
+++ b/ruleset.go
@@ -187,17 +187,12 @@ func (c *Client) ListRulesetsPaginated(ctx context.Context) ([]*Ruleset, error) 
 // CreateRuleset creates a new ruleset.
 //
 // Deprecated: Use CreateRulesetWithContext instead.
-func (c *Client) CreateRuleset(r *Ruleset) (*Ruleset, *http.Response, error) {
-	return c.createRulesetWithContext(context.Background(), r)
+func (c *Client) CreateRuleset(r *Ruleset) (*Ruleset, error) {
+	return c.CreateRulesetWithContext(context.Background(), r)
 }
 
 // CreateRulesetWithContext creates a new ruleset.
 func (c *Client) CreateRulesetWithContext(ctx context.Context, r *Ruleset) (*Ruleset, error) {
-	rs, _, err := c.createRulesetWithContext(ctx, r)
-	return rs, err
-}
-
-func (c *Client) createRulesetWithContext(ctx context.Context, r *Ruleset) (*Ruleset, *http.Response, error) {
 	d := map[string]*Ruleset{
 		"ruleset": r,
 	}
@@ -222,17 +217,12 @@ func (c *Client) DeleteRulesetWithContext(ctx context.Context, id string) error 
 // GetRuleset gets details about a ruleset.
 //
 // Deprecated: Use GetRulesetWithContext instead.
-func (c *Client) GetRuleset(id string) (*Ruleset, *http.Response, error) {
-	return c.getRulesetWithContext(context.Background(), id)
+func (c *Client) GetRuleset(id string) (*Ruleset, error) {
+	return c.GetRulesetWithContext(context.Background(), id)
 }
 
 // GetRulesetWithContext gets details about a ruleset.
 func (c *Client) GetRulesetWithContext(ctx context.Context, id string) (*Ruleset, error) {
-	rs, _, err := c.getRulesetWithContext(ctx, id)
-	return rs, err
-}
-
-func (c *Client) getRulesetWithContext(ctx context.Context, id string) (*Ruleset, *http.Response, error) {
 	resp, err := c.get(ctx, "/rulesets/"+id)
 	return getRulesetFromResponse(c, resp, err)
 }
@@ -240,17 +230,12 @@ func (c *Client) getRulesetWithContext(ctx context.Context, id string) (*Ruleset
 // UpdateRuleset updates a ruleset.
 //
 // Deprecated: Use UpdateRulesetWithContext instead.
-func (c *Client) UpdateRuleset(r *Ruleset) (*Ruleset, *http.Response, error) {
-	return c.updateRulesetWithContext(context.Background(), r)
+func (c *Client) UpdateRuleset(r *Ruleset) (*Ruleset, error) {
+	return c.UpdateRulesetWithContext(context.Background(), r)
 }
 
 // UpdateRulesetWithContext updates a ruleset.
 func (c *Client) UpdateRulesetWithContext(ctx context.Context, r *Ruleset) (*Ruleset, error) {
-	rs, _, err := c.updateRulesetWithContext(ctx, r)
-	return rs, err
-}
-
-func (c *Client) updateRulesetWithContext(ctx context.Context, r *Ruleset) (*Ruleset, *http.Response, error) {
 	d := map[string]*Ruleset{
 		"ruleset": r,
 	}
@@ -259,22 +244,22 @@ func (c *Client) updateRulesetWithContext(ctx context.Context, r *Ruleset) (*Rul
 	return getRulesetFromResponse(c, resp, err)
 }
 
-func getRulesetFromResponse(c *Client, resp *http.Response, err error) (*Ruleset, *http.Response, error) {
+func getRulesetFromResponse(c *Client, resp *http.Response, err error) (*Ruleset, error) {
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var target map[string]Ruleset
 	if dErr := c.decodeJSON(resp, &target); dErr != nil {
-		return nil, nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
+		return nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
 	}
 
 	t, nodeOK := target["ruleset"]
 	if !nodeOK {
-		return nil, nil, fmt.Errorf("JSON response does not have ruleset field")
+		return nil, fmt.Errorf("JSON response does not have ruleset field")
 	}
 
-	return &t, resp, nil
+	return &t, nil
 }
 
 // ListRulesetRules gets all rules for a ruleset. This method currently handles pagination of
@@ -326,17 +311,12 @@ func (c *Client) ListRulesetRulesPaginated(ctx context.Context, rulesetID string
 // GetRulesetRule gets an event rule.
 //
 // Deprecated: Use GetRulesetRuleWithContext instead.
-func (c *Client) GetRulesetRule(rulesetID, ruleID string) (*RulesetRule, *http.Response, error) {
-	return c.getRulesetRuleWithContext(context.Background(), rulesetID, ruleID)
+func (c *Client) GetRulesetRule(rulesetID, ruleID string) (*RulesetRule, error) {
+	return c.GetRulesetRuleWithContext(context.Background(), rulesetID, ruleID)
 }
 
 // GetRulesetRuleWithContext gets an event rule
 func (c *Client) GetRulesetRuleWithContext(ctx context.Context, rulesetID, ruleID string) (*RulesetRule, error) {
-	rsr, _, err := c.getRulesetRuleWithContext(ctx, rulesetID, ruleID)
-	return rsr, err
-}
-
-func (c *Client) getRulesetRuleWithContext(ctx context.Context, rulesetID, ruleID string) (*RulesetRule, *http.Response, error) {
 	resp, err := c.get(ctx, "/rulesets/"+rulesetID+"/rules/"+ruleID)
 	return getRuleFromResponse(c, resp, err)
 }
@@ -357,12 +337,12 @@ func (c *Client) DeleteRulesetRuleWithContext(ctx context.Context, rulesetID, ru
 // CreateRulesetRule creates a new rule for a ruleset.
 //
 // Deprecated: Use CreateRulesetRuleWithContext instead.
-func (c *Client) CreateRulesetRule(rulesetID string, rule *RulesetRule) (*RulesetRule, *http.Response, error) {
+func (c *Client) CreateRulesetRule(rulesetID string, rule *RulesetRule) (*RulesetRule, error) {
 	return c.CreateRulesetRuleWithContext(context.Background(), rulesetID, rule)
 }
 
 // CreateRulesetRuleWithContext creates a new rule for a ruleset.
-func (c *Client) CreateRulesetRuleWithContext(ctx context.Context, rulesetID string, rule *RulesetRule) (*RulesetRule, *http.Response, error) {
+func (c *Client) CreateRulesetRuleWithContext(ctx context.Context, rulesetID string, rule *RulesetRule) (*RulesetRule, error) {
 	d := map[string]*RulesetRule{
 		"rule": rule,
 	}
@@ -374,12 +354,12 @@ func (c *Client) CreateRulesetRuleWithContext(ctx context.Context, rulesetID str
 // UpdateRulesetRule updates a rule.
 //
 // Deprecated: Use UpdateRulesetRuleWithContext instead.
-func (c *Client) UpdateRulesetRule(rulesetID, ruleID string, r *RulesetRule) (*RulesetRule, *http.Response, error) {
+func (c *Client) UpdateRulesetRule(rulesetID, ruleID string, r *RulesetRule) (*RulesetRule, error) {
 	return c.UpdateRulesetRuleWithContext(context.Background(), rulesetID, ruleID, r)
 }
 
 // UpdateRulesetRuleWithContext updates a rule.
-func (c *Client) UpdateRulesetRuleWithContext(ctx context.Context, rulesetID, ruleID string, r *RulesetRule) (*RulesetRule, *http.Response, error) {
+func (c *Client) UpdateRulesetRuleWithContext(ctx context.Context, rulesetID, ruleID string, r *RulesetRule) (*RulesetRule, error) {
 	d := map[string]*RulesetRule{
 		"rule": r,
 	}
@@ -388,22 +368,22 @@ func (c *Client) UpdateRulesetRuleWithContext(ctx context.Context, rulesetID, ru
 	return getRuleFromResponse(c, resp, err)
 }
 
-func getRuleFromResponse(c *Client, resp *http.Response, err error) (*RulesetRule, *http.Response, error) {
+func getRuleFromResponse(c *Client, resp *http.Response, err error) (*RulesetRule, error) {
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	var target map[string]RulesetRule
 	if dErr := c.decodeJSON(resp, &target); dErr != nil {
-		return nil, nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
+		return nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
 	}
 
 	const rootNode = "rule"
 
 	t, nodeOK := target[rootNode]
 	if !nodeOK {
-		return nil, nil, fmt.Errorf("JSON response does not have %s field", rootNode)
+		return nil, fmt.Errorf("JSON response does not have %s field", rootNode)
 	}
 
-	return &t, resp, nil
+	return &t, nil
 }

--- a/ruleset_test.go
+++ b/ruleset_test.go
@@ -46,7 +46,7 @@ func TestRuleset_Create(t *testing.T) {
 	input := &Ruleset{
 		Name: "foo",
 	}
-	res, _, err := client.CreateRuleset(input)
+	res, err := client.CreateRuleset(input)
 
 	want := &Ruleset{
 		ID:   "1",
@@ -72,7 +72,7 @@ func TestRuleset_Get(t *testing.T) {
 	client := defaultTestClient(server.URL, "foo")
 	ruleSetID := "1"
 
-	res, _, err := client.GetRuleset(ruleSetID)
+	res, err := client.GetRuleset(ruleSetID)
 
 	want := &Ruleset{
 		ID:   "1",
@@ -100,7 +100,7 @@ func TestRuleset_Update(t *testing.T) {
 		ID:   "1",
 		Name: "foo",
 	}
-	res, _, err := client.UpdateRuleset(input)
+	res, err := client.UpdateRuleset(input)
 
 	want := &Ruleset{
 		ID:   "1",
@@ -172,7 +172,7 @@ func TestRuleset_GetRule(t *testing.T) {
 
 	rulesetID := "1"
 	ruleID := "1"
-	res, _, err := client.GetRulesetRule(rulesetID, ruleID)
+	res, err := client.GetRulesetRule(rulesetID, ruleID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -198,7 +198,7 @@ func TestRuleset_CreateRule(t *testing.T) {
 	rulesetID := "1"
 	rule := &RulesetRule{}
 
-	res, _, err := client.CreateRulesetRule(rulesetID, rule)
+	res, err := client.CreateRulesetRule(rulesetID, rule)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestRuleset_UpdateRule(t *testing.T) {
 	ruleID := "1"
 	rule := &RulesetRule{}
 
-	res, _, err := client.UpdateRulesetRule(rulesetID, ruleID, rule)
+	res, err := client.UpdateRulesetRule(rulesetID, ruleID, rule)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is a breaking change.

This is one of the changes that will need to be made to complete issue #305,
which is being done in a minor release even though it does contain breaking
changes.

The internal implementation details of how this was implemented meant it never
worked in a way that consumers could use, because the body was always empty.
Seeing as this API never worked and we do not wish to support it, we are going
to remove it so that anyone who may have depended on it, but missed that it was
broken, can be made aware.

If someone wanted to capture the full response of these API calls, they can now
do so using the the functionality added in #325 (4f01c5befe6bde8e812f8acf42546764d58bf7c8).