### PR TITLE
implement missing maintenance-window subcommands

### DIFF
--- a/command/maintenance_window_create.go
+++ b/command/maintenance_window_create.go
@@ -1,13 +1,15 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
-	"github.com/mitchellh/cli"
 	"os"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type MaintenanceWindowCreate struct {
@@ -59,7 +61,7 @@ func (c *MaintenanceWindowCreate) Run(args []string) int {
 		return -1
 	}
 	log.Debugf("%#v", m)
-	if _, err := client.CreateMaintenanceWindows(m); err != nil {
+	if _, err := client.CreateMaintenanceWindowWithContext(context.Background(), "", m); err != nil {
 		log.Error(err)
 		return -1
 	}

--- a/command/maintenance_window_create.go
+++ b/command/maintenance_window_create.go
@@ -1,15 +1,13 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/PagerDuty/go-pagerduty"
+	log "github.com/sirupsen/logrus"
+	"github.com/mitchellh/cli"
 	"os"
 	"strings"
-
-	"github.com/PagerDuty/go-pagerduty"
-	"github.com/mitchellh/cli"
-	log "github.com/sirupsen/logrus"
 )
 
 type MaintenanceWindowCreate struct {
@@ -61,7 +59,7 @@ func (c *MaintenanceWindowCreate) Run(args []string) int {
 		return -1
 	}
 	log.Debugf("%#v", m)
-	if _, err := client.CreateMaintenanceWindowWithContext(context.Background(), "", m); err != nil {
+	if _, err := client.CreateMaintenanceWindows(m); err != nil {
 		log.Error(err)
 		return -1
 	}

--- a/command/maintenance_window_delete.go
+++ b/command/maintenance_window_delete.go
@@ -1,11 +1,16 @@
 package main
 
 import (
-	"github.com/mitchellh/cli"
+	"context"
+	"fmt"
 	"strings"
+
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type MaintenanceWindowDelete struct {
+	Meta
 }
 
 func MaintenanceWindowDeleteCommand() (cli.Command, error) {
@@ -14,7 +19,11 @@ func MaintenanceWindowDeleteCommand() (cli.Command, error) {
 
 func (c *MaintenanceWindowDelete) Help() string {
 	helpText := `
-	`
+	maintenance-window delete Delete or end a maintenance window
+
+	Options:
+		-id      The maintenance window ID
+	` + c.Meta.Help()
 	return strings.TrimSpace(helpText)
 }
 
@@ -23,5 +32,27 @@ func (c *MaintenanceWindowDelete) Synopsis() string {
 }
 
 func (c *MaintenanceWindowDelete) Run(args []string) int {
+	var mwID string
+	flags := c.Meta.FlagSet("maintenance-window delete")
+	flags.Usage = func() { fmt.Println(c.Help())}
+	flags.StringVar(&mwID, "id", "", "Maintenance window ID")
+
+	if err := flags.Parse(args); err != nil {
+		log.Error(err)
+		return -1
+	}
+	if err := c.Meta.Setup(); err != nil {
+		log.Error(err)
+		return -1
+	}
+	if mwID == "" {
+		log.Error("You must provide a maintenance window ID")
+		return -1
+	}
+	client := c.Meta.Client()
+	if err := client.DeleteMaintenanceWindowWithContext(context.Background(), mwID); err != nil {
+		log.Error(err)
+		return -1
+	}
 	return 0
 }

--- a/command/maintenance_window_delete.go
+++ b/command/maintenance_window_delete.go
@@ -34,25 +34,29 @@ func (c *MaintenanceWindowDelete) Synopsis() string {
 func (c *MaintenanceWindowDelete) Run(args []string) int {
 	var mwID string
 	flags := c.Meta.FlagSet("maintenance-window delete")
-	flags.Usage = func() { fmt.Println(c.Help())}
+	flags.Usage = func() { fmt.Println(c.Help()) }
 	flags.StringVar(&mwID, "id", "", "Maintenance window ID")
 
 	if err := flags.Parse(args); err != nil {
 		log.Error(err)
 		return -1
 	}
-	if err := c.Meta.Setup(); err != nil {
-		log.Error(err)
-		return -1
-	}
+
 	if mwID == "" {
 		log.Error("You must provide a maintenance window ID")
 		return -1
 	}
+
+	if err := c.Meta.Setup(); err != nil {
+		log.Error(err)
+		return -1
+	}
+
 	client := c.Meta.Client()
 	if err := client.DeleteMaintenanceWindowWithContext(context.Background(), mwID); err != nil {
 		log.Error(err)
 		return -1
 	}
+
 	return 0
 }

--- a/command/maintenance_window_list.go
+++ b/command/maintenance_window_list.go
@@ -41,7 +41,7 @@ func (c *MaintenanceWindowList) Run(args []string) int {
 	var includes, serviceIDs, teamIDs []string
 	var query, filter string
 	flags := c.Meta.FlagSet("maintenance-window list")
-	flags.Usage = func() { fmt.Println(c.Help())}
+	flags.Usage = func() { fmt.Println(c.Help()) }
 	flags.Var((*ArrayFlags)(&includes), "includes", "Additional details to include (can be specified multiple times)")
 	flags.Var((*ArrayFlags)(&serviceIDs), "service-id", "Show maintenance windows for the specified services only (can be specified multiple times)")
 	flags.Var((*ArrayFlags)(&teamIDs), "team-id", "Show maintenance windows for the specified teams only (can be specified multiple times)")
@@ -52,10 +52,12 @@ func (c *MaintenanceWindowList) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
+
 	if err := c.Meta.Setup(); err != nil {
 		log.Error(err)
 		return -1
 	}
+
 	client := c.Meta.Client()
 	opts := pagerduty.ListMaintenanceWindowsOptions{
 		Query:      query,
@@ -64,11 +66,13 @@ func (c *MaintenanceWindowList) Run(args []string) int {
 		ServiceIDs: serviceIDs,
 		Filter:     filter,
 	}
+
 	mws, err := client.ListMaintenanceWindowsWithContext(context.Background(), opts)
 	if err != nil {
 		log.Error(err)
 		return -1
 	}
+
 	for i, mw := range mws.MaintenanceWindows {
 		fmt.Println("Entry: ", i)
 		data, err := yaml.Marshal(mw)

--- a/command/maintenance_window_list.go
+++ b/command/maintenance_window_list.go
@@ -1,11 +1,18 @@
 package main
 
 import (
-	"github.com/mitchellh/cli"
+	"context"
+	"fmt"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 type MaintenanceWindowList struct {
+	Meta
 }
 
 func MaintenanceWindowListCommand() (cli.Command, error) {
@@ -14,7 +21,15 @@ func MaintenanceWindowListCommand() (cli.Command, error) {
 
 func (c *MaintenanceWindowList) Help() string {
 	helpText := `
-	`
+	pd maintenance-window list List maintenance windows
+
+	Options:
+		-filter     Filter result by state
+		-include    Additional details to include
+		-query      Filter results by query
+		-service-id Filter result by service ids
+		-team-id    Filter results by team ids
+	` + c.Meta.Help()
 	return strings.TrimSpace(helpText)
 }
 
@@ -23,5 +38,46 @@ func (c *MaintenanceWindowList) Synopsis() string {
 }
 
 func (c *MaintenanceWindowList) Run(args []string) int {
+	var includes, serviceIDs, teamIDs []string
+	var query, filter string
+	flags := c.Meta.FlagSet("maintenance-window list")
+	flags.Usage = func() { fmt.Println(c.Help())}
+	flags.Var((*ArrayFlags)(&includes), "includes", "Additional details to include (can be specified multiple times)")
+	flags.Var((*ArrayFlags)(&serviceIDs), "service-id", "Show maintenance windows for the specified services only (can be specified multiple times)")
+	flags.Var((*ArrayFlags)(&teamIDs), "team-id", "Show maintenance windows for the specified teams only (can be specified multiple times)")
+	flags.StringVar(&filter, "filter", "all", "Filter results by maintenance window state (past, future, ongoing, open, all)")
+	flags.StringVar(&query, "query", "", "Filter results showing only tags whose labels match the query")
+
+	if err := flags.Parse(args); err != nil {
+		log.Error(err)
+		return -1
+	}
+	if err := c.Meta.Setup(); err != nil {
+		log.Error(err)
+		return -1
+	}
+	client := c.Meta.Client()
+	opts := pagerduty.ListMaintenanceWindowsOptions{
+		Query:      query,
+		Includes:   includes,
+		TeamIDs:    teamIDs,
+		ServiceIDs: serviceIDs,
+		Filter:     filter,
+	}
+	mws, err := client.ListMaintenanceWindowsWithContext(context.Background(), opts)
+	if err != nil {
+		log.Error(err)
+		return -1
+	}
+	for i, mw := range mws.MaintenanceWindows {
+		fmt.Println("Entry: ", i)
+		data, err := yaml.Marshal(mw)
+		if err != nil {
+			log.Error(err)
+			return -1
+		}
+		fmt.Println(string(data))
+	}
+
 	return 0
 }

--- a/command/maintenance_window_show.go
+++ b/command/maintenance_window_show.go
@@ -38,7 +38,7 @@ func (c *MaintenanceWindowShow) Run(args []string) int {
 	var includes []string
 	var mwID string
 	flags := c.Meta.FlagSet("maintenance-window show")
-	flags.Usage = func() { fmt.Println(c.Help())}
+	flags.Usage = func() { fmt.Println(c.Help()) }
 	flags.Var((*ArrayFlags)(&includes), "includes", "Additional details to include (can be specified multiple times)")
 	flags.StringVar(&mwID, "id", "", "Maintenance window ID")
 
@@ -46,28 +46,34 @@ func (c *MaintenanceWindowShow) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
-	if err := c.Meta.Setup(); err != nil {
-		log.Error(err)
-		return -1
-	}
+
 	if mwID == "" {
 		log.Error("You must provide a maintenance window ID")
 		return -1
 	}
+
+	if err := c.Meta.Setup(); err != nil {
+		log.Error(err)
+		return -1
+	}
+
 	client := c.Meta.Client()
 	opts := pagerduty.GetMaintenanceWindowOptions{
 		Includes: includes,
 	}
+
 	mw, err := client.GetMaintenanceWindowWithContext(context.Background(), mwID, opts)
 	if err != nil {
 		log.Error(err)
 		return -1
 	}
+
 	data, err := yaml.Marshal(mw)
 	if err != nil {
 		log.Error(err)
 		return -1
 	}
+
 	fmt.Println(string(data))
 	return 0
 }

--- a/command/maintenance_window_show.go
+++ b/command/maintenance_window_show.go
@@ -1,11 +1,18 @@
 package main
 
 import (
-	"github.com/mitchellh/cli"
+	"context"
+	"fmt"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 )
 
 type MaintenanceWindowShow struct {
+	Meta
 }
 
 func MaintenanceWindowShowCommand() (cli.Command, error) {
@@ -14,7 +21,12 @@ func MaintenanceWindowShowCommand() (cli.Command, error) {
 
 func (c *MaintenanceWindowShow) Help() string {
 	helpText := `
-	`
+	maintenance-window show Show a maintenance window
+
+	Options:
+		-id      The maintenance window ID
+		-include Additional details to include
+	` + c.Meta.Help()
 	return strings.TrimSpace(helpText)
 }
 
@@ -23,5 +35,39 @@ func (c *MaintenanceWindowShow) Synopsis() string {
 }
 
 func (c *MaintenanceWindowShow) Run(args []string) int {
+	var includes []string
+	var mwID string
+	flags := c.Meta.FlagSet("maintenance-window show")
+	flags.Usage = func() { fmt.Println(c.Help())}
+	flags.Var((*ArrayFlags)(&includes), "includes", "Additional details to include (can be specified multiple times)")
+	flags.StringVar(&mwID, "id", "", "Maintenance window ID")
+
+	if err := flags.Parse(args); err != nil {
+		log.Error(err)
+		return -1
+	}
+	if err := c.Meta.Setup(); err != nil {
+		log.Error(err)
+		return -1
+	}
+	if mwID == "" {
+		log.Error("You must provide a maintenance window ID")
+		return -1
+	}
+	client := c.Meta.Client()
+	opts := pagerduty.GetMaintenanceWindowOptions{
+		Includes: includes,
+	}
+	mw, err := client.GetMaintenanceWindowWithContext(context.Background(), mwID, opts)
+	if err != nil {
+		log.Error(err)
+		return -1
+	}
+	data, err := yaml.Marshal(mw)
+	if err != nil {
+		log.Error(err)
+		return -1
+	}
+	fmt.Println(string(data))
 	return 0
 }

--- a/command/maintenance_window_update.go
+++ b/command/maintenance_window_update.go
@@ -34,15 +34,18 @@ func (c *MaintenanceWindowUpdate) Synopsis() string {
 
 func (c *MaintenanceWindowUpdate) Run(args []string) int {
 	flags := c.Meta.FlagSet("maintenance-window update")
-	flags.Usage = func() { fmt.Println(c.Help())}
+	flags.Usage = func() { fmt.Println(c.Help()) }
+
 	if err := flags.Parse(args); err != nil {
 		log.Error(err)
 		return -1
 	}
+
 	if err := c.Meta.Setup(); err != nil {
 		log.Error(err)
 		return -1
 	}
+
 	client := c.Meta.Client()
 	var mw pagerduty.MaintenanceWindow
 	if len(flags.Args()) != 1 {
@@ -55,16 +58,19 @@ func (c *MaintenanceWindowUpdate) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
+
 	defer f.Close()
 	decoder := json.NewDecoder(f)
 	if err := decoder.Decode(&mw); err != nil {
 		log.Errorln("Failed to decode json. Error:", err)
 		return -1
 	}
+
 	log.Debugf("%#v", mw)
 	if _, err := client.UpdateMaintenanceWindowWithContext(context.Background(), mw); err != nil {
 		log.Error(err)
 		return -1
 	}
+
 	return 0
 }

--- a/command/maintenance_window_update.go
+++ b/command/maintenance_window_update.go
@@ -1,11 +1,20 @@
 package main
 
 import (
-	"github.com/mitchellh/cli"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/mitchellh/cli"
 )
 
 type MaintenanceWindowUpdate struct {
+	Meta
 }
 
 func MaintenanceWindowUpdateCommand() (cli.Command, error) {
@@ -14,7 +23,8 @@ func MaintenanceWindowUpdateCommand() (cli.Command, error) {
 
 func (c *MaintenanceWindowUpdate) Help() string {
 	helpText := `
-	`
+	maintenance-window update <FILE> Update a maintenance window from json file
+	` + c.Meta.Help()
 	return strings.TrimSpace(helpText)
 }
 
@@ -23,5 +33,38 @@ func (c *MaintenanceWindowUpdate) Synopsis() string {
 }
 
 func (c *MaintenanceWindowUpdate) Run(args []string) int {
+	flags := c.Meta.FlagSet("maintenance-window update")
+	flags.Usage = func() { fmt.Println(c.Help())}
+	if err := flags.Parse(args); err != nil {
+		log.Error(err)
+		return -1
+	}
+	if err := c.Meta.Setup(); err != nil {
+		log.Error(err)
+		return -1
+	}
+	client := c.Meta.Client()
+	var mw pagerduty.MaintenanceWindow
+	if len(flags.Args()) != 1 {
+		log.Error("Please specify input json file")
+		return -1
+	}
+	log.Info("Input file is:", flags.Arg(0))
+	f, err := os.Open(flags.Arg(0))
+	if err != nil {
+		log.Error(err)
+		return -1
+	}
+	defer f.Close()
+	decoder := json.NewDecoder(f)
+	if err := decoder.Decode(&mw); err != nil {
+		log.Errorln("Failed to decode json. Error:", err)
+		return -1
+	}
+	log.Debugf("%#v", mw)
+	if _, err := client.UpdateMaintenanceWindowWithContext(context.Background(), mw); err != nil {
+		log.Error(err)
+		return -1
+	}
 	return 0
 }

--- a/command/maintenance_window_update.go
+++ b/command/maintenance_window_update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
+	"io/ioutil"
 	"strings"
 
 	"github.com/PagerDuty/go-pagerduty"
@@ -52,16 +52,15 @@ func (c *MaintenanceWindowUpdate) Run(args []string) int {
 		log.Error("Please specify input json file")
 		return -1
 	}
+
 	log.Info("Input file is:", flags.Arg(0))
-	f, err := os.Open(flags.Arg(0))
+	f, err := ioutil.ReadFile(flags.Arg(0))
 	if err != nil {
 		log.Error(err)
 		return -1
 	}
 
-	defer f.Close()
-	decoder := json.NewDecoder(f)
-	if err := decoder.Decode(&mw); err != nil {
+	if err := json.Unmarshal(f, &mw); err != nil {
 		log.Errorln("Failed to decode json. Error:", err)
 		return -1
 	}


### PR DESCRIPTION
The `pd maintenance-window` command was missing subcommands other than `create`, so I went ahead and implemented them. `create` is also using a deprecated library function so I also addressed that.