### PR TITLE
Add json field incidents_responders to Incident struct

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -89,6 +89,7 @@ type Incident struct {
 	Body                 IncidentBody         `json:"body,omitempty"`
 	IsMergeable          bool                 `json:"is_mergeable,omitempty"`
 	ConferenceBridge     *ConferenceBridge    `json:"conference_bridge,omitempty"`
+	IncidentResponders   []IncidentResponders `json:"incidents_responders,omitempty"`
 }
 
 // ListIncidentsResponse is the response structure when calling the ListIncident API endpoint.

--- a/incident_test.go
+++ b/incident_test.go
@@ -237,7 +237,7 @@ func TestIncident_Get(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		_, _ = w.Write([]byte(`{"incident": {"id": "1"}}`))
+		_, _ = w.Write([]byte(`{"incident": {"id": "1", "incidents_responders": [{"incident": {"id": "1"}}]}}`))
 	})
 
 	client := defaultTestClient(server.URL, "foo")
@@ -245,7 +245,7 @@ func TestIncident_Get(t *testing.T) {
 	id := "1"
 	res, err := client.GetIncident(id)
 
-	want := &Incident{Id: "1"}
+	want := &Incident{Id: "1", IncidentResponders: []IncidentResponders{{Incident: APIObject{ID: "1"}}}}
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Add json:"incidents_responders,omitempty" to Incident struct in order to get
"incident": {"incidents_responders": []} from func GetIncident(ctx context.Context, client *pagerduty.Client, id string) (*pagerduty.Incident, error)