### PR TITLE
Added total incident count as a param to ListIncidentsOptions

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -112,6 +112,7 @@ type ListIncidentsOptions struct {
 	TimeZone    string   `url:"time_zone,omitempty"`
 	SortBy      string   `url:"sort_by,omitempty"`
 	Includes    []string `url:"include,omitempty,brackets"`
+	Total       bool     `url:"total,omitempty"`
 }
 
 // ConferenceBridge is a struct for the conference_bridge object on an incident


### PR DESCRIPTION
Pagerduty api to list incidents `https://api.pagerduty.com/incidents?total=true` allows passing in of total as a query param which returns the total count of incidents in the response. If total is not passed in the api or is false, the total count returned in response is null.

Currently there is no option to pass in total as a query param in list incidents api since ListIncidentsOptions does not have a total field.
I've added total as property in ListIncidentsOptions to enable this functionality,