### PR TITLE
Fix test after merging #332 (2f47dfc62321b)

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -455,7 +455,7 @@ func TestClient_LastAPIRequest(t *testing.T) {
 	})
 
 	t.Run("integration", func(t *testing.T) {
-		const requestBody = `{"user":{"id":"1","type":"","name":"","summary":"","email":"foo@bar.com","contact_methods":null,"notification_rules":null,"Teams":null}}`
+		const requestBody = `{"user":{"id":"1","name":"","summary":"","email":"foo@bar.com","contact_methods":null,"notification_rules":null,"Teams":null}}`
 
 		setup()
 		defer teardown()


### PR DESCRIPTION
In between raising #332 and merging it, there were changes to the master branch
that resulted in the tests in this PR breaking after the merge.

In hindsight, this branch should have been rebased against master before merging
the PR.