### PR TITLE
Add title to ManageIncidentOptions

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -169,6 +169,7 @@ type ManageIncidentsOptions struct {
 	ID               string        `json:"id"`
 	Type             string        `json:"type"`
 	Status           string        `json:"status,omitempty"`
+	Title            string        `json:"title,omitempty"`
 	Priority         *APIReference `json:"priority,omitempty"`
 	Assignments      []Assignee    `json:"assignments,omitempty"`
 	EscalationPolicy *APIReference `json:"escalation_policy,omitempty"`


### PR DESCRIPTION
Looking at PagerDuty API doc it seems that the `title` attribute is missing from `ManageIncidentOptions`
https://developer.pagerduty.com/api-reference/b3A6Mjc0ODEzOQ-manage-incidents