### PR TITLE
Add Service and User to LogEntry

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -8,10 +8,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 var (
@@ -56,9 +57,11 @@ func testMethod(t *testing.T, r *http.Request, want string) {
 	}
 }
 
-func testEqual(t *testing.T, expected interface{}, actual interface{}) {
-	if !reflect.DeepEqual(expected, actual) {
-		t.Errorf("returned %#v; want %#v", expected, actual)
+func testEqual(t *testing.T, want interface{}, got interface{}) {
+	t.Helper()
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("values not equal (-want / +got):\n%s", diff)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/PagerDuty/go-pagerduty
 go 1.14
 
 require (
+	github.com/google/go-cmp v0.5.6
 	github.com/google/go-querystring v1.0.0
 	github.com/mitchellh/cli v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
+github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
@@ -34,6 +36,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/log_entry.go
+++ b/log_entry.go
@@ -41,7 +41,9 @@ type CommonLogEntryField struct {
 // LogEntry is a list of all of the events that happened to an incident.
 type LogEntry struct {
 	CommonLogEntryField
-	Incident Incident `json:"incident"`
+	Incident Incident  `json:"incident"`
+	Service  APIObject `json:"service"`
+	User     APIObject `json:"user"`
 }
 
 // ListLogEntryResponse is the response data when calling the ListLogEntry API endpoint.

--- a/log_entry_test.go
+++ b/log_entry_test.go
@@ -83,6 +83,20 @@ func TestChannel_MarhalUnmarshal(t *testing.T) {
 			"type": "web_trigger",
 			"summary": "My new incident",
 			"details_omitted": false
+		},
+		"service": {
+			"type": "service_reference",
+			"id": "abc123",
+			"summary": "xyz890",
+			"self": "http://test.local/api/service/abc123",
+			"html_url": "http://test.local/service/abc123"
+		},
+		"user": {
+			"type": "user_reference",
+			"id": "abc890",
+			"summary": "xyz123",
+			"self": "http://test.local/api/user/abc890",
+			"html_url": "http://test.local/user/abc890"
 		}
 	}`)
 	want := &LogEntry{
@@ -100,6 +114,20 @@ func TestChannel_MarhalUnmarshal(t *testing.T) {
 					"details_omitted": false,
 				},
 			},
+		},
+		Service: APIObject{
+			ID:      "abc123",
+			Type:    "service_reference",
+			Summary: "xyz890",
+			Self:    "http://test.local/api/service/abc123",
+			HTMLURL: "http://test.local/service/abc123",
+		},
+		User: APIObject{
+			ID:      "abc890",
+			Type:    "user_reference",
+			Summary: "xyz123",
+			Self:    "http://test.local/api/user/abc890",
+			HTMLURL: "http://test.local/user/abc890",
 		},
 	}
 


### PR DESCRIPTION
Now that the Service and User fields that are sent with Log Entries are
documented, we can add them to this library.

This also adds the `go-cmp` package to provide actionable test output when
comparing complex values.

Closes #201