### PR TITLE
Add missing required parameeter to ManageIncidentAlerts

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -632,15 +632,12 @@ func (c *Client) GetIncidentAlertWithContext(ctx context.Context, incidentID, al
 }
 
 // ManageIncidentAlerts allows you to manage the alerts of an incident.
-//
-// Deprecated: Use ManageIncidentAlertsWithContext instead.
-func (c *Client) ManageIncidentAlerts(incidentID string, alerts *IncidentAlertList) (*ListAlertsResponse, error) {
-	return c.ManageIncidentAlertsWithContext(context.Background(), incidentID, alerts)
-}
+func (c *Client) ManageIncidentAlerts(ctx context.Context, incidentID, from string, alerts *IncidentAlertList) (*ListAlertsResponse, error) {
+	h := map[string]string{
+		"From": from,
+	}
 
-// ManageIncidentAlertsWithContext allows you to manage the alerts of an incident.
-func (c *Client) ManageIncidentAlertsWithContext(ctx context.Context, incidentID string, alerts *IncidentAlertList) (*ListAlertsResponse, error) {
-	resp, err := c.put(ctx, "/incidents/"+incidentID+"/alerts/", alerts, nil)
+	resp, err := c.put(ctx, "/incidents/"+incidentID+"/alerts/", alerts, h)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When making a call to the REST API[1] endpoint to manage alerts for incidents,
an HTTP header ("From") indicating who made the request is required. As a
result, these methods may not have ever worked properly.

So while we're breaking the API, let's remove the deprecated non-context version
to have fewer breaking changes in v2.

Closes #338

[1] https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE0NA-manage-alerts