### PR TITLE
Add omitempty JSON tag to User slice fields

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -458,7 +458,7 @@ func TestClient_LastAPIRequest(t *testing.T) {
 	})
 
 	t.Run("integration", func(t *testing.T) {
-		const requestBody = `{"user":{"id":"1","name":"","summary":"","email":"foo@bar.com","contact_methods":null,"notification_rules":null,"Teams":null}}`
+		const requestBody = `{"user":{"id":"1","name":"","summary":"","email":"foo@bar.com"}}`
 
 		setup()
 		defer teardown()

--- a/user.go
+++ b/user.go
@@ -30,10 +30,10 @@ type User struct {
 	AvatarURL         string             `json:"avatar_url,omitempty"`
 	Description       string             `json:"description,omitempty"`
 	InvitationSent    bool               `json:"invitation_sent,omitempty"`
-	ContactMethods    []ContactMethod    `json:"contact_methods"`
-	NotificationRules []NotificationRule `json:"notification_rules"`
+	ContactMethods    []ContactMethod    `json:"contact_methods,omitempty"`
+	NotificationRules []NotificationRule `json:"notification_rules,omitempty"`
 	JobTitle          string             `json:"job_title,omitempty"`
-	Teams             []Team
+	Teams             []Team             `json:"teams,omitempty"`
 }
 
 // ContactMethod is a way of contacting the user.


### PR DESCRIPTION
These fields aren't actually updated by posting a User object (partial or full)
to the REST API, as other REST endpoints are used to mutate that data. As such,
there really isn't a reason to send these fields on any outbound requests that
make use of the `User` struct.

Closes #343