### PR TITLE
Fix some mismatches between REST API and struct definitions

### DIFF
--- a/change_events.go
+++ b/change_events.go
@@ -15,23 +15,23 @@ const changeEventPath = "/v2/change/enqueue"
 type ChangeEvent struct {
 	RoutingKey string             `json:"routing_key"`
 	Payload    ChangeEventPayload `json:"payload"`
-	Links      []ChangeEventLink  `json:"links"`
+	Links      []ChangeEventLink  `json:"links,omitempty"`
 }
 
 // ChangeEventPayload ChangeEvent ChangeEventPayload
 // https://developer.pagerduty.com/docs/events-api-v2/send-change-events/#example-request-payload
 type ChangeEventPayload struct {
-	Source        string                 `json:"source"`
 	Summary       string                 `json:"summary"`
-	Timestamp     string                 `json:"timestamp"`
-	CustomDetails map[string]interface{} `json:"custom_details"`
+	Source        string                 `json:"source,omitempty"`
+	Timestamp     string                 `json:"timestamp,omitempty"`
+	CustomDetails map[string]interface{} `json:"custom_details,omitempty"`
 }
 
 // ChangeEventLink represents a single link in a ChangeEvent
 // https://developer.pagerduty.com/docs/events-api-v2/send-change-events/#the-links-property
 type ChangeEventLink struct {
 	Href string `json:"href"`
-	Text string `json:"text"`
+	Text string `json:"text,omitempty"`
 }
 
 // ChangeEventResponse is the json response body for an event

--- a/change_events_test.go
+++ b/change_events_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	expectedChangeCreatePayload = `{"routing_key":"a0000000aa0000a0a000aa0a0a0aa000","payload":{"source":"Test runner",` +
-		`"summary":"Summary can't be blank","timestamp":"2020-10-19T03:06:16.318Z",` +
+	expectedChangeCreatePayload = `{"routing_key":"a0000000aa0000a0a000aa0a0a0aa000","payload":{"summary":"Summary can't be blank",` +
+		`"source":"Test runner","timestamp":"2020-10-19T03:06:16.318Z",` +
 		`"custom_details":{"DetailKey1":"DetailValue1","DetailKey2":"DetailValue2"}},` +
 		`"links":[{"href":"https://acme.pagerduty.dev/build/2","text":"View more details in Acme!"},` +
 		`{"href":"https://acme2.pagerduty.dev/build/2","text":"View more details in Acme2!"}]}`

--- a/escalation_policy.go
+++ b/escalation_policy.go
@@ -28,7 +28,6 @@ type EscalationPolicy struct {
 	NumLoops        uint             `json:"num_loops,omitempty"`
 	Teams           []APIReference   `json:"teams"`
 	Description     string           `json:"description,omitempty"`
-	RepeatEnabled   bool             `json:"repeat_enabled,omitempty"`
 }
 
 // ListEscalationPoliciesResponse is the data structure returned from calling the ListEscalationPolicies API endpoint.


### PR DESCRIPTION
This change includes the first few fixes while reviewing the repo for #389, and
does include one breaking change.

In `change_events.go`, there were a few optional fields that were not set to
`omitempty`, which means we were rendering them in the JSON even when not set.
This also reorders the `ChangeEventPayload` so that the `Summary` field is at
the top, since it's the only required field.

In `escalation_policy.go`, the `EscalationPolicy` type looked to have a field on
it that indicated if repeating the notification rules was enabled. However, this
field is not documented and when looking at the actual API response no such
field was present. Instead, the field to indicate the number of loops is set to
`0` when there is no repeating of the rules.

The removal of this field is the breaking change, although hopefully nobody was
using it. :)

Updates #389