### PR TITLE
Add support for escalation_policy.on_call_handoff_notifications field

### DIFF
--- a/escalation_policy.go
+++ b/escalation_policy.go
@@ -22,12 +22,13 @@ type EscalationRule struct {
 // EscalationPolicy is a collection of escalation rules.
 type EscalationPolicy struct {
 	APIObject
-	Name            string           `json:"name,omitempty"`
-	EscalationRules []EscalationRule `json:"escalation_rules,omitempty"`
-	Services        []APIObject      `json:"services,omitempty"`
-	NumLoops        uint             `json:"num_loops,omitempty"`
-	Teams           []APIReference   `json:"teams"`
-	Description     string           `json:"description,omitempty"`
+	Name                       string           `json:"name,omitempty"`
+	EscalationRules            []EscalationRule `json:"escalation_rules,omitempty"`
+	Services                   []APIObject      `json:"services,omitempty"`
+	NumLoops                   uint             `json:"num_loops,omitempty"`
+	Teams                      []APIReference   `json:"teams"`
+	Description                string           `json:"description,omitempty"`
+	OnCallHandoffNotifications string           `json:"on_call_handoff_notifications,omitempty"`
 }
 
 // ListEscalationPoliciesResponse is the data structure returned from calling the ListEscalationPolicies API endpoint.

--- a/escalation_policy_test.go
+++ b/escalation_policy_test.go
@@ -158,3 +158,28 @@ func TestEscalationPolicy_UpdateTeams(t *testing.T) {
 	}
 	testEqual(t, want, res)
 }
+
+func TestEscalationPolicy_GetOnCallHandoffNotifications(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/escalation_policies/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, _ = w.Write([]byte(`{"escalation_policy": {"id": "1", "on_call_handoff_notifications": "if_has_services"}}`))
+	})
+	client := defaultTestClient(server.URL, "foo")
+	var opts *GetEscalationPolicyOptions
+	res, err := client.GetEscalationPolicy("1", opts)
+
+	want := &EscalationPolicy{
+		APIObject: APIObject{
+			ID: "1",
+		},
+		OnCallHandoffNotifications: "if_has_services",
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}


### PR DESCRIPTION
Closes https://github.com/PagerDuty/go-pagerduty/issues/395

I added a test, just in case, but it basically checks JSON Unmarshal.

As CLI uses JSON files as input no changes on that side are needed.

Not sure if any docs need an update.