### PR TITLE
add createStatusUpdate

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -653,4 +653,35 @@ func (c *Client) ManageIncidentAlertsWithContext(ctx context.Context, incidentID
 	return &result, nil
 }
 
-/* TODO: Create Status Updates */
+// IncidentStatusUpdate is a status update for the specified incident.
+type IncidentStatusUpdate struct {
+	ID        string	`json:"id"`
+	Message   string	`json:"message"`
+	CreatedAt string	`json:"created_at"`
+	Sender    APIObject	`json:"sender"`
+}
+
+// CreateIncidentStatusUpdate creates a new status update for the specified incident.
+func (c *Client) CreateIncidentStatusUpdate(ctx context.Context, id string, from string, message string) (IncidentStatusUpdate, error) {
+	d := map[string]string{
+		"message": message,
+	}
+
+	h := map[string]string{
+		"From": from,
+	}
+
+	resp, err := c.post(ctx, "/incidents/"+id+"/status_updates", d, h)
+	if err != nil {
+		return IncidentStatusUpdate{}, err
+	}
+
+	var result struct {
+		IncidentStatusUpdate IncidentStatusUpdate `json:"status_update"`
+	}
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return IncidentStatusUpdate{}, err
+	}
+
+	return result.IncidentStatusUpdate, nil
+}


### PR DESCRIPTION
API has the action to create status updates. But `go-pagerduty` does not have the function for this yet.
I add some new functions to solve this issue.
https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE1Mw-create-a-status-update-on-an-incident