### PR TITLE
Find a way to gracefully avoid one breaking change in #405

### DIFF
--- a/priorites.go
+++ b/priorites.go
@@ -6,19 +6,24 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-// PriorityProperty is a single priorty object returned from the Priorities endpoint
-type PriorityProperty struct {
-	APIObject
-	Name        string `json:"name"`
-	Description string `json:"description"`
-}
+// PriorityProperty is the original type name and is retained as an alias for API
+// compatibility.
+//
+// Deprecated: Use type Priority instead; will be removed in V2
+type PriorityProperty = Priority
 
 // ListPrioritiesResponse repreents the API response from PagerDuty when listing
 // the configured priorities.
 type ListPrioritiesResponse struct {
 	APIListObject
-	Priorities []PriorityProperty `json:"priorities"`
+	Priorities []Priority `json:"priorities"`
 }
+
+// Priorities is the original type name and is retained as an alias for API
+// compatibility.
+//
+// Deprecated: Use type ListPrioritiesResponse instead; will be removed in V2
+type Priorities = ListPrioritiesResponse
 
 // ListPrioritiesOptions is the data structure used when calling the
 // ListPriorities API endpoint.

--- a/priorities_test.go
+++ b/priorities_test.go
@@ -23,7 +23,7 @@ func TestPriorities_List(t *testing.T) {
 
 	want := &ListPrioritiesResponse{
 		APIListObject: listObj,
-		Priorities: []PriorityProperty{
+		Priorities: []Priority{
 			{
 				APIObject: APIObject{
 					ID:      "1",


### PR DESCRIPTION
In #405 I opted to rename one of the types to be more consistent, and in the
moment totally forgot about type aliases. A type alias allows you to rename a
type in a non-breaking way, by converting the old name to be an alias to the new
one.

This change does that, and effectively removes one breaking change from v1.5.0.

I also do the sane thing to unify the Priority type into one.