### PR TITLE
Update client.go

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,6 +51,7 @@ type APIObject struct {
 	Summary string `json:"summary,omitempty"`
 	Self    string `json:"self,omitempty"`
 	HTMLURL string `json:"html_url,omitempty"`
+	DeletedAt string `json:"deleted_at,omitempty"`
 }
 
 // APIListObject are the fields used to control pagination when listing objects.


### PR DESCRIPTION
Adding the 'deleted_at' variable for a user. This will return the date/time a user was deleted from an escalation policy and is returned by /oncalls Pagerduty API today.