### PR TITLE
Initial Support for v3 Webhook Payloads

### DIFF
--- a/examples/webhooks/webhook_server.go
+++ b/examples/webhooks/webhook_server.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"net/http"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/PagerDuty/go-pagerduty/webhookv3"
 )
@@ -35,5 +36,18 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Fprintf(w, "received signed webhook")
+	log.Infof("Received signed webhook")
+
+	payload, err := webhookv3.ReadWebhookPayload(r)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		log.Errorf("%v", err)
+		return
+	}
+
+	event := payload.Event
+	dataType, _ := event.GetEventDataValue("type")
+	log.Infof("Event: %v, Event Type: %v, EventData Type: %v", event.ID, event.EventType, dataType)
+
+	fmt.Fprint(w, "OK\n")
 }

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/mitchellh/cli v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sirupsen/logrus v1.4.2
+	github.com/stretchr/testify v1.2.2
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/webhookv3/webhook_event.go
+++ b/webhookv3/webhook_event.go
@@ -1,0 +1,74 @@
+package webhookv3
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/PagerDuty/go-pagerduty"
+)
+
+type OutboundEventData struct {
+	Object map[string]interface{}
+	// The raw json data for use in structured unmarshalling.
+	RawData json.RawMessage
+}
+
+type OutboundEvent struct {
+	ID           string                  `json:"id"`
+	EventType    string                  `json:"event_type"`
+	ResourceType string                  `json:"resource_type"`
+	OccurredAt   string                  `json:"occurred_at"`
+	Agent        *pagerduty.APIReference `json:"agent"`
+	Data         *OutboundEventData      `json:"data"`
+}
+
+type WebhookPayload struct {
+	Event OutboundEvent `json:"event"`
+}
+
+func (e *OutboundEventData) UnmarshalJSON(data []byte) error {
+	if err := json.Unmarshal(data, &e.Object); err != nil {
+		return err
+	}
+
+	if err := e.RawData.UnmarshalJSON(data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (oe *OutboundEvent) GetEventDataValue(keys ...string) (string, error) {
+	return getDataValue(oe.Data.Object, keys)
+}
+
+func getDataValue(d map[string]interface{}, keys []string) (string, error) {
+	key := keys[0]
+	node := d[key]
+
+	for k := 1; k < len(keys); k++ {
+		key = keys[k]
+
+		switch n := node.(type) {
+		case []interface{}:
+			intKey, err := strconv.Atoi(key)
+			if err != nil {
+				return "", fmt.Errorf("cannot identify array element with key '%s'", key)
+			}
+			node = n[intKey]
+			continue
+		case map[string]interface{}:
+			node = n[key]
+			continue
+		default:
+			break
+		}
+	}
+
+	if node == nil {
+		return "", fmt.Errorf("JSON does not have field '%s'", key)
+	}
+
+	return fmt.Sprintf("%v", node), nil
+}

--- a/webhookv3/webhook_event_test.go
+++ b/webhookv3/webhook_event_test.go
@@ -1,0 +1,58 @@
+package webhookv3
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWebhookPayload_UnmarshallJSON(t *testing.T) {
+	var wp WebhookPayload
+
+	data := `{ "event": { "id": "5ac64822-4adc-4fda-ade0-410becf0de4f", "event_type": "incident.priority_updated", "resource_type": "incident", "occurred_at": "2020-10-02T18:45:22.169Z", "agent": { "html_url": "https://acme.pagerduty.com/users/PLH1HKV", "id": "PLH1HKV", "self": "https://api.pagerduty.com/users/PLH1HKV", "summary": "Tenex Engineer", "type": "user_reference" }, "client": { "name": "PagerDuty" }, "data": { "id": "PGR0VU2", "type": "incident", "self": "https://api.pagerduty.com/incidents/PGR0VU2", "html_url": "https://acme.pagerduty.com/incidents/PGR0VU2", "number": 2, "status": "triggered", "title": "A little bump in the road", "service": { "html_url": "https://acme.pagerduty.com/services/PF9KMXH", "id": "PF9KMXH", "self": "https://api.pagerduty.com/services/PF9KMXH", "summary": "API Service", "type": "service_reference" }, "assignees": [ { "html_url": "https://acme.pagerduty.com/users/PTUXL6G", "id": "PTUXL6G", "self": "https://api.pagerduty.com/users/PTUXL6G", "summary": "User 123", "type": "user_reference" } ], "escalation_policy": { "html_url": "https://acme.pagerduty.com/escalation_policies/PUS0KTE", "id": "PUS0KTE", "self": "https://api.pagerduty.com/escalation_policies/PUS0KTE", "summary": "Default", "type": "escalation_policy_reference" }, "teams": [ { "html_url": "https://acme.pagerduty.com/teams/PFCVPS0", "id": "PFCVPS0", "self": "https://api.pagerduty.com/teams/PFCVPS0", "summary": "Engineering", "type": "team_reference" } ], "priority": { "html_url": "https://acme.pagerduty.com/account/incident_priorities", "id": "PSO75BM", "self": "https://api.pagerduty.com/priorities/PSO75BM", "summary": "P1", "type": "priority_reference" }, "urgency": "high", "conference_bridge": { "conference_number": "+1 1234123412,,987654321#", "conference_url": "https://example.com" }, "resolve_reason": null } } }`
+
+	err := json.Unmarshal([]byte(data), &wp)
+	assert.NoError(t, err)
+
+	oe := wp.Event
+
+	assert.Equal(t, "5ac64822-4adc-4fda-ade0-410becf0de4f", oe.ID)
+	assert.Equal(t, "incident.priority_updated", oe.EventType)
+	assert.Equal(t, "incident", oe.ResourceType)
+	assert.Equal(t, "2020-10-02T18:45:22.169Z", oe.OccurredAt)
+
+	assert.Equal(t, "PLH1HKV", oe.Agent.ID)
+	assert.Equal(t, "user_reference", oe.Agent.Type)
+}
+
+func TestWebhookEvent_GetEventDataValue(t *testing.T) {
+	var wp WebhookPayload
+
+	data := `{ "event": { "id": "5ac64822-4adc-4fda-ade0-410becf0de4f", "event_type": "incident.priority_updated", "resource_type": "incident", "occurred_at": "2020-10-02T18:45:22.169Z", "agent": { "html_url": "https://acme.pagerduty.com/users/PLH1HKV", "id": "PLH1HKV", "self": "https://api.pagerduty.com/users/PLH1HKV", "summary": "Tenex Engineer", "type": "user_reference" }, "client": { "name": "PagerDuty" }, "data": { "id": "PGR0VU2", "type": "incident", "self": "https://api.pagerduty.com/incidents/PGR0VU2", "html_url": "https://acme.pagerduty.com/incidents/PGR0VU2", "number": 2, "status": "triggered", "title": "A little bump in the road", "service": { "html_url": "https://acme.pagerduty.com/services/PF9KMXH", "id": "PF9KMXH", "self": "https://api.pagerduty.com/services/PF9KMXH", "summary": "API Service", "type": "service_reference" }, "assignees": [ { "html_url": "https://acme.pagerduty.com/users/PTUXL6G", "id": "PTUXL6G", "self": "https://api.pagerduty.com/users/PTUXL6G", "summary": "User 123", "type": "user_reference" } ], "escalation_policy": { "html_url": "https://acme.pagerduty.com/escalation_policies/PUS0KTE", "id": "PUS0KTE", "self": "https://api.pagerduty.com/escalation_policies/PUS0KTE", "summary": "Default", "type": "escalation_policy_reference" }, "teams": [ { "html_url": "https://acme.pagerduty.com/teams/PFCVPS0", "id": "PFCVPS0", "self": "https://api.pagerduty.com/teams/PFCVPS0", "summary": "Engineering", "type": "team_reference" } ], "priority": { "html_url": "https://acme.pagerduty.com/account/incident_priorities", "id": "PSO75BM", "self": "https://api.pagerduty.com/priorities/PSO75BM", "summary": "P1", "type": "priority_reference" }, "urgency": "high", "conference_bridge": { "conference_number": "+1 1234123412,,987654321#", "conference_url": "https://example.com" }, "resolve_reason": null } } }`
+
+	err := json.Unmarshal([]byte(data), &wp)
+	assert.NoError(t, err)
+
+	oe := wp.Event
+
+	value, _ := oe.GetEventDataValue("type")
+	assert.Equal(t, "incident", value)
+
+	value, _ = oe.GetEventDataValue("title")
+	assert.Equal(t, "A little bump in the road", value)
+
+	value, _ = oe.GetEventDataValue("service", "summary")
+	assert.Equal(t, "API Service", value)
+
+	value, err = oe.GetEventDataValue("not_a_field")
+	assert.Equal(t, "", value)
+	assert.Error(t, err)
+
+	value, _ = oe.GetEventDataValue("assignees", "0", "summary")
+	assert.Equal(t, "User 123", value)
+
+	value, err = oe.GetEventDataValue("assignees", "not_an_integer")
+	assert.Equal(t, "", value)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Adds some initial support for processing V3 Webhook Payloads. 

Includes the types for the `OutboundEvent` and the `WebhookPayload` wrapper. Also includes a generic method of accessing specific fields inside of `event.data`. This allows consumers to access all fields in `event.data` for any [event type](https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTkw-v3-overview#event-types).

The groundwork is also set for code that handles polymorphic unmarshalling of `event.data` in future updates.