### PR TITLE
Add mechanism to list more than 100 incidents

### DIFF
--- a/incident_test.go
+++ b/incident_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 	"testing"
 )
 
@@ -31,6 +32,59 @@ func TestIncident_List(t *testing.T) {
 				APIObject: APIObject{
 					ID: "1",
 				},
+			},
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+func TestIncident_ListPaginated(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incidents", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		offsetStr := r.URL.Query()["offset"][0]
+		offset, _ := strconv.ParseInt(offsetStr, 10, 32)
+
+		var more string
+		if offset == 0 {
+			more = "true"
+		} else {
+			more = "false"
+		}
+		resp := fmt.Sprintf(`{"incidents": [{"id": "%d"}],
+                          "More": %s,
+                          "Offset": %d,
+                          "Limit": 1}`, offset, more, offset)
+		_, _ = w.Write([]byte(resp))
+	})
+
+	listObj := APIListObject{Limit: 1, Offset: 0, More: false, Total: 0}
+	client := defaultTestClient(server.URL, "foo")
+	opts := ListIncidentsOptions{
+		Limit:    listObj.Limit,
+		Offset:   listObj.Offset,
+		TeamIDs:  []string{},
+		TimeZone: "foo",
+		SortBy:   "bar",
+		Includes: []string{},
+	}
+	res, err := client.ListIncidentsPaginated(opts)
+
+	want := []Incident{
+		{
+			APIObject: APIObject{
+				ID: "0",
+			},
+		},
+		{
+			APIObject: APIObject{
+				ID: "1",
 			},
 		},
 	}


### PR DESCRIPTION
By default we can reach only 100 elements from a given range, if we have more than 100 elements
between `Since` and `Until`, we need to use an offeset to get the 101st element and so on.