### PR TITLE
Fix list notifications options

### DIFF
--- a/notification.go
+++ b/notification.go
@@ -42,7 +42,7 @@ type ListNotificationOptions struct {
 	Since    string   `url:"since,omitempty"`
 	Until    string   `url:"until,omitempty"`
 	Filter   string   `url:"filter,omitempty"`
-	Includes []string `url:"include,omitempty"`
+	Includes []string `url:"include,omitempty,brackets"`
 }
 
 // ListNotificationsResponse is the data structure returned from the ListNotifications API endpoint.


### PR DESCRIPTION
The missing `brackets` keyword makes an unexpected encoded URI at request time which makes the API return an error

`code 400, message: Invalid Input Provided (code: 2001): Include must be a Array`

when calling ListNotifications method.