### PR TITLE
Fix the formatting of the ResponderRequest input and output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,6 @@ require (
 	github.com/mitchellh/cli v1.0.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sirupsen/logrus v1.4.2
+	golang.org/x/sys v0.0.0-20220412211240-33da011f77ad // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,9 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
+golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/incident.go
+++ b/incident.go
@@ -666,12 +666,18 @@ type ResponderRequestTarget struct {
 	Responders IncidentResponders `json:"incident_responders"`
 }
 
+// ResponderRequestTargetInput sets up the payload structure to request a responder
+// for the specific incident.
+type ResponderRequestTargetInput struct {
+	Target APIObject `json:"responder_request_target"`
+}
+
 // ResponderRequestOptions defines the input options for the Create Responder function.
 type ResponderRequestOptions struct {
-	From        string                   `json:"-"`
-	Message     string                   `json:"message"`
-	RequesterID string                   `json:"requester_id"`
-	Targets     []ResponderRequestTarget `json:"responder_request_targets"`
+	From        string                        `json:"-"`
+	Message     string                        `json:"message"`
+	RequesterID string                        `json:"requester_id"`
+	Targets     []ResponderRequestTargetInput `json:"responder_request_targets"`
 }
 
 // ResponderRequest contains the API structure for an incident responder request.

--- a/incident.go
+++ b/incident.go
@@ -654,6 +654,8 @@ type ResponderRequestResponse struct {
 	ResponderRequest ResponderRequest `json:"responder_request"`
 }
 
+// ResponderRequestTargetList will wrap each result in the returned responder request
+// API call, nesting the content under this key within the JSON.
 type ResponderRequestTargetList struct {
 	Target ResponderRequestTarget `json:"responder_request_target"`
 }

--- a/incident.go
+++ b/incident.go
@@ -654,6 +654,10 @@ type ResponderRequestResponse struct {
 	ResponderRequest ResponderRequest `json:"responder_request"`
 }
 
+type ResponderRequestTargetList struct {
+	Target ResponderRequestTarget `json:"responder_request_target"`
+}
+
 // ResponderRequestTarget specifies an individual target for the responder request.
 type ResponderRequestTarget struct {
 	APIObject
@@ -670,11 +674,11 @@ type ResponderRequestOptions struct {
 
 // ResponderRequest contains the API structure for an incident responder request.
 type ResponderRequest struct {
-	Incident    Incident                 `json:"incident"`
-	Requester   User                     `json:"requester,omitempty"`
-	RequestedAt string                   `json:"request_at,omitempty"`
-	Message     string                   `json:"message,omitempty"`
-	Targets     []ResponderRequestTarget `json:"responder_request_targets"`
+	Incident    Incident                     `json:"incident"`
+	Requester   User                         `json:"requester,omitempty"`
+	RequestedAt string                       `json:"request_at,omitempty"`
+	Message     string                       `json:"message,omitempty"`
+	Targets     []ResponderRequestTargetList `json:"responder_request_targets"`
 }
 
 // ResponderRequest will submit a request to have a responder join an incident.

--- a/incident.go
+++ b/incident.go
@@ -663,21 +663,15 @@ type ResponderRequestTargetList struct {
 // ResponderRequestTarget specifies an individual target for the responder request.
 type ResponderRequestTarget struct {
 	APIObject
-	Responders IncidentResponders `json:"incident_responders"`
-}
-
-// ResponderRequestTargetInput sets up the payload structure to request a responder
-// for the specific incident.
-type ResponderRequestTargetInput struct {
-	Target APIObject `json:"responder_request_target"`
+	Responders IncidentResponders `json:"incident_responders,omitempty"`
 }
 
 // ResponderRequestOptions defines the input options for the Create Responder function.
 type ResponderRequestOptions struct {
-	From        string                        `json:"-"`
-	Message     string                        `json:"message"`
-	RequesterID string                        `json:"requester_id"`
-	Targets     []ResponderRequestTargetInput `json:"responder_request_targets"`
+	From        string                       `json:"-"`
+	Message     string                       `json:"message"`
+	RequesterID string                       `json:"requester_id"`
+	Targets     []ResponderRequestTargetList `json:"responder_request_targets"`
 }
 
 // ResponderRequest contains the API structure for an incident responder request.

--- a/incident_test.go
+++ b/incident_test.go
@@ -830,7 +830,9 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	r.ID = "PJ25ZYX"
 	r.Type = "user_reference"
 
-	targets := []ResponderRequestTarget{r}
+	targets := []ResponderRequestTargetInput{
+		ResponderRequestTargetInput{Target: APIObject{ID: "PJ25ZYX", Type: "user_reference"}},
+	}
 
 	input := ResponderRequestOptions{
 		From:        from,

--- a/incident_test.go
+++ b/incident_test.go
@@ -830,9 +830,10 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	r.ID = "PJ25ZYX"
 	r.Type = "user_reference"
 
-	targets := []ResponderRequestTargetInput{
-		ResponderRequestTargetInput{Target: APIObject{ID: "PJ25ZYX", Type: "user_reference"}},
-	}
+	targ := ResponderRequestTargetList{Target: ResponderRequestTarget{}}
+	targ.Target.ID = "PJ25ZYX"
+	targ.Target.Type = "user_reference"
+	targets := []ResponderRequestTargetList{targ}
 
 	input := ResponderRequestOptions{
 		From:        from,

--- a/incident_test.go
+++ b/incident_test.go
@@ -826,10 +826,10 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	client := defaultTestClient(server.URL, "foo")
 	from := "foo@bar.com"
 
-	targ := ResponderRequestTargetList{Target: ResponderRequestTarget{}}
-	targ.Target.ID = "PJ25ZYX"
-	targ.Target.Type = "user_reference"
-	targets := []ResponderRequestTargetList{targ}
+	target := ResponderRequestTargetList{Target: ResponderRequestTarget{}}
+	target.Target.ID = "PJ25ZYX"
+	target.Target.Type = "user_reference"
+	targets := []ResponderRequestTargetList{target}
 
 	input := ResponderRequestOptions{
 		From:        from,
@@ -842,17 +842,17 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	user.ID = "PL1JMK5"
 	user.Type = "user_reference"
 
-	targ.Target.Responders.State = "pending"
-	targ.Target.Responders.User.ID = "PJ25ZYX"
-	targ.Target.Responders.User.Type = "user_reference"
-	targets_out := []ResponderRequestTargetList{targ}
+	target.Target.Responders.State = "pending"
+	target.Target.Responders.User.ID = "PJ25ZYX"
+	target.Target.Responders.User.Type = "user_reference"
+	targets = []ResponderRequestTargetList{target}
 
 	want := &ResponderRequestResponse{
 		ResponderRequest: ResponderRequest{
 			Incident:  Incident{},
 			Requester: user,
 			Message:   "Help",
-			Targets:   targets_out,
+			Targets:   targets,
 		},
 	}
 	res, err := client.ResponderRequest(id, input)

--- a/incident_test.go
+++ b/incident_test.go
@@ -808,12 +808,15 @@ func TestIncident_ResponderRequest(t *testing.T) {
 		},
 		"message": "Help",
 		"responder_request_targets": [{
-			"id": "PJ25ZYX",
-			"type": "user_reference",
-			"incident_responders": {
-				"state": "pending",
-				"user": {
-					"id": "PJ25ZYX"
+			"responder_request_target": {
+				"id": "PJ25ZYX",
+				"type": "user_reference",
+				"incident_responders": {
+					"state": "pending",
+					"user": {
+						"id": "PJ25ZYX",
+						"type": "user_reference"
+					}
 				}
 			}
 		}]
@@ -840,20 +843,21 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	user.ID = "PL1JMK5"
 	user.Type = "user_reference"
 
-	target := ResponderRequestTarget{}
-	target.ID = "PJ25ZYX"
-	target.Type = "user_reference"
-	target.Responders.State = "pending"
-	target.Responders.User.ID = "PJ25ZYX"
+	target := ResponderRequestTargetList{Target: ResponderRequestTarget{}}
+	target.Target.ID = "PJ25ZYX"
+	target.Target.Type = "user_reference"
+	target.Target.Responders.State = "pending"
+	target.Target.Responders.User.ID = "PJ25ZYX"
+	target.Target.Responders.User.Type = "user_reference"
 
-	targets = []ResponderRequestTarget{target}
+	targets_out := []ResponderRequestTargetList{target}
 
 	want := &ResponderRequestResponse{
 		ResponderRequest: ResponderRequest{
 			Incident:  Incident{},
 			Requester: user,
 			Message:   "Help",
-			Targets:   targets,
+			Targets:   targets_out,
 		},
 	}
 	res, err := client.ResponderRequest(id, input)

--- a/incident_test.go
+++ b/incident_test.go
@@ -826,10 +826,6 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	client := defaultTestClient(server.URL, "foo")
 	from := "foo@bar.com"
 
-	r := ResponderRequestTarget{}
-	r.ID = "PJ25ZYX"
-	r.Type = "user_reference"
-
 	targ := ResponderRequestTargetList{Target: ResponderRequestTarget{}}
 	targ.Target.ID = "PJ25ZYX"
 	targ.Target.Type = "user_reference"
@@ -846,14 +842,10 @@ func TestIncident_ResponderRequest(t *testing.T) {
 	user.ID = "PL1JMK5"
 	user.Type = "user_reference"
 
-	target := ResponderRequestTargetList{Target: ResponderRequestTarget{}}
-	target.Target.ID = "PJ25ZYX"
-	target.Target.Type = "user_reference"
-	target.Target.Responders.State = "pending"
-	target.Target.Responders.User.ID = "PJ25ZYX"
-	target.Target.Responders.User.Type = "user_reference"
-
-	targets_out := []ResponderRequestTargetList{target}
+	targ.Target.Responders.State = "pending"
+	targ.Target.Responders.User.ID = "PJ25ZYX"
+	targ.Target.Responders.User.Type = "user_reference"
+	targets_out := []ResponderRequestTargetList{targ}
 
 	want := &ResponderRequestResponse{
 		ResponderRequest: ResponderRequest{


### PR DESCRIPTION
The [documentation](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODE1MQ-create-a-responder-request-for-an-incident) has 2 different ways to structure this code, where the doc and the example are different. Previously the code here had worked with the doc formatting, however this is currently not working as intended.

The main change here is within the ``responder_request_targets`` portion of the payload, where the array content is an object that then contains a key ``responder_request_target`` with the actual object, rather than just this object itself. i.e. It's nested one key deeper in the tree. Originally I'd thought this was different for the input and the output, turns out the only difference is that the ``incident_responders`` is not provided in the input, and populated in the output.

This PR also includes the 3 line change to update the ``go.*`` files as this was tested on an M1 mac, so a newer version of the ``golang.org/x/sys`` library is needed that supports ``arm64``.