### PR TITLE
Fix parsing bug for AlertGroupingParameters

### DIFF
--- a/service.go
+++ b/service.go
@@ -99,10 +99,10 @@ type Service struct {
 	Addons                  []Addon                  `json:"addons,omitempty"`
 }
 
-// AlertGroupingParameters defines how alerts on the servicewill be automatically grouped into incidents
+// AlertGroupingParameters defines how alerts on the service will be automatically grouped into incidents
 type AlertGroupingParameters struct {
-	Type   string                 `json:"type"`
-	Config AlertGroupParamsConfig `json:"config"`
+	Type   string                  `json:"type,omitempty"`
+	Config *AlertGroupParamsConfig `json:"config,omitempty"`
 }
 
 // AlertGroupParamsConfig is the config object on alert_grouping_parameters

--- a/service_test.go
+++ b/service_test.go
@@ -178,7 +178,7 @@ func TestService_CreateWithAlertGroupParamsTime(t *testing.T) {
 		Name: "foo",
 		AlertGroupingParameters: &AlertGroupingParameters{
 			Type: "time",
-			Config: AlertGroupParamsConfig{
+			Config: &AlertGroupParamsConfig{
 				Timeout: 2,
 			},
 		},
@@ -213,7 +213,7 @@ func TestService_CreateWithAlertGroupParamsContentBased(t *testing.T) {
 		Name: "foo",
 		AlertGroupingParameters: &AlertGroupingParameters{
 			Type: "content_based",
-			Config: AlertGroupParamsConfig{
+			Config: &AlertGroupParamsConfig{
 				Aggregate: "any",
 				Fields:    []string{"source", "component"},
 			},


### PR DESCRIPTION
The PagerDuty API is happy when only `Type` is set to `omitempty`, but I think it makes sense to do the same for `AlertGroupParamsConfig` as well as change it to be a pointer so that it gets a nil value instead of the zero value for all the config values in case the api checks those values in the future.

```go
func main() {
	client := pagerduty.NewClient(authToken)
	svc, err := client.GetServiceWithContext(context.TODO(), serviceId, nil)
	if err != nil {
		panic(err)
	}

        // Whether there's no value from GetService or if it's set
	svc.AlertGroupingParameters.Type = ""

	_, err := client.UpdateServiceWithContext(context.TODO(), *svc)
	if err != nil {
                 // Results in panic: HTTP response failed with status code 400,
                 // message: Invalid Input Provided (code: 2001): Alert grouping parameters is invalid.
		panic(err)
	}
}
```

Fixes #438 