### PR TITLE
Fix memory leak

### DIFF
--- a/change_events.go
+++ b/change_events.go
@@ -72,6 +72,7 @@ func (c *Client) CreateChangeEventWithContext(ctx context.Context, e ChangeEvent
 		bytes.NewBuffer(data),
 		nil,
 	)
+	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/event_v2.go
+++ b/event_v2.go
@@ -238,6 +238,7 @@ func (c *Client) ManageEventWithContext(ctx context.Context, e *V2Event) (*V2Eve
 	}
 
 	resp, err := c.doWithEndpoint(ctx, c.v2EventsAPIEndpoint, http.MethodPost, "/v2/enqueue", false, bytes.NewBuffer(data), nil)
+	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit fixes a memory leak that happens if the PagerDuty endpoint returns a 429 HTTP status code. It was not verified whether the error happens with other status codes as well.

I verified the correctness of this fix by running the following test:

```go
func TestMemoryLeak(t *testing.T) {
	evt := &pagerduty.V2Event{
		RoutingKey: routingKey,
		Action:     "trigger",
		Payload: &pagerduty.V2Payload{
			Summary:   "foo",
			Source:    "bar",
			Component: serviceName,
			Severity:  "critical",
			Class:     "",
			Details:   nil,
		},
	}

	for i := 0; i < 100; i++ {
		client.ManageEvent(evt)
		fmt.Printf("num goroutines: %d\n", runtime.NumGoroutine())
		time.Sleep(time.Millisecond * 50)
	}
}
```

Without the fix, this produces the following output:

```
num goroutines: 6
num goroutines: 8
num goroutines: 10
num goroutines: 12
num goroutines: 14
num goroutines: 16
num goroutines: 18
num goroutines: 20
num goroutines: 22
num goroutines: 24
...
```

With the fix, this produces the following output:

```
num goroutines: 8
num goroutines: 8
num goroutines: 8
num goroutines: 8
num goroutines: 8
num goroutines: 8
num goroutines: 6
num goroutines: 6
num goroutines: 6
num goroutines: 6
num goroutines: 5
num goroutines: 6
...
```
```