### PR TITLE
Fix unmarshaling error with AlertGroupingParameters timeout

### DIFF
--- a/service.go
+++ b/service.go
@@ -107,7 +107,7 @@ type AlertGroupingParameters struct {
 
 // AlertGroupParamsConfig is the config object on alert_grouping_parameters
 type AlertGroupParamsConfig struct {
-	Timeout   uint     `json:"timeout,omitempty"`
+	Timeout   *uint    `json:"timeout,omitempty"`
 	Aggregate string   `json:"aggregate,omitempty"`
 	Fields    []string `json:"fields,omitempty"`
 }

--- a/service_test.go
+++ b/service_test.go
@@ -179,7 +179,7 @@ func TestService_CreateWithAlertGroupParamsTime(t *testing.T) {
 		AlertGroupingParameters: &AlertGroupingParameters{
 			Type: "time",
 			Config: &AlertGroupParamsConfig{
-				Timeout: 2,
+				Timeout: new(uint),
 			},
 		},
 	}


### PR DESCRIPTION
Fixes #458 by allowing `Timeout` to be successfully unmarshalled and sent as a 0 when needed instead of being omitted as a default value.