### PR TITLE
Add raw incidents metrics

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -17,6 +17,8 @@ type AnalyticsRequest struct {
 	TimeZone      string           `json:"time_zone,omitempty"`
 }
 
+// RawDataRequest represents the request to be sent to PagerDuty when you want
+// raw analytics.
 type RawDataRequest struct {
 	Filters       *AnalyticsFilter `json:"filters,omitempty"`
 	StartingAfter string           `json:"starting_after,omitempty"`
@@ -35,6 +37,7 @@ type AnalyticsResponse struct {
 	TimeZone      string           `json:"time_zone,omitempty"`
 }
 
+// RawDataResponse represents the response from the PagerDuty API.
 type RawDataResponse struct {
 	First    string           `json:"first,omitempty"`
 	Last     string           `json:"last,omitempty"`
@@ -60,7 +63,7 @@ type AnalyticsFilter struct {
 	PriorityNames  []string `json:"priority_names,omitempty"`
 }
 
-// AnalyticsData represents the structure of the analytics we have available.
+// AnalyticsData represents the structure of the aggregated analytics we have available.
 type AnalyticsData struct {
 	ServiceID                      string  `json:"service_id,omitempty"`
 	ServiceName                    string  `json:"service_name,omitempty"`
@@ -85,6 +88,7 @@ type AnalyticsData struct {
 	RangeStart                     string  `json:"range_start,omitempty"`
 }
 
+// RawData represents the structure of the raw analytics we have available.
 type RawData struct {
 	AssignmentCount           int    `json:"assignment_count,omitempty"`
 	BusinessHourInterruptions int    `json:"business_hour_interruptions,omitempty"`
@@ -148,6 +152,7 @@ func (c *Client) getAggregatedData(ctx context.Context, analytics AnalyticsReque
 	return analyticsResponse, nil
 }
 
+// GetRawDataSingleIncident gets the raw analytics for the requested incident.
 func (c *Client) GetRawDataSingleIncident(ctx context.Context, id string) (RawData, error) {
 	h := map[string]string{
 		"X-EARLY-ACCESS": "analytics-v2",
@@ -168,6 +173,7 @@ func (c *Client) GetRawDataSingleIncident(ctx context.Context, id string) (RawDa
 	return rawData, nil
 }
 
+// GetRawDataMultipleIncidents gets the raw analytics for the requested data.
 func (c *Client) GetRawDataMultipleIncidents(ctx context.Context, rawDataReq RawDataRequest) (RawDataResponse, error) {
 	h := map[string]string{
 		"X-EARLY-ACCESS": "analytics-v2",

--- a/analytics.go
+++ b/analytics.go
@@ -154,7 +154,7 @@ func (c *Client) getAggregatedData(ctx context.Context, analytics AnalyticsReque
 // GetAnalyticsIncidentsById gets the raw analytics for the requested incident.
 func (c *Client) GetAnalyticsIncidentsById(ctx context.Context, id string) (*AnalyticsRawIncident, error) {
 	path := fmt.Sprintf("%s/%s/%s", rawDataBaseURL, "incidents", id)
-	resp, err := c.get(ctx, path)
+	resp, err := c.get(ctx, path, nil)
 
 	if err != nil {
 		return &AnalyticsRawIncident{}, err

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -3,6 +3,7 @@ package pagerduty
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 )
@@ -133,6 +134,146 @@ func TestAnalytics_GetAggregatedTeamData(t *testing.T) {
 		Filters:       &analyticsFilterWanted,
 		AggregateUnit: "day",
 		TimeZone:      "Etc/UTC",
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+func TestAnalytics_GetRawDataSingleIncident(t *testing.T) {
+	setup()
+	defer teardown()
+
+	id := "PFGEDX0"
+	rawDataWanted := RawData{
+		AssignmentCount:           10,
+		BusinessHourInterruptions: 1,
+		CreatedAt:                 "2021-01-06T00:00:00.000000",
+		Description:               "Test Alert Description",
+		EngagedSeconds:            404,
+		EngagedUserCount:          2,
+		EscalationCount:           1,
+		ID:                        id,
+		IncidentNumber:            324,
+		IsMajor:                   true,
+		OffHourInterruptions:      1,
+		PriorityID:                "PSVSDF3",
+		PriorityName:              "Urgent",
+		ResolvedAt:                "2021-01-06T08:23:21.000000",
+		SecondsToEngage:           3453,
+		SecondsToFirstAck:         123,
+		SecondsToMobilize:         435,
+		SecondsToResolve:          324524,
+		ServiceID:                 "PA4DFYS",
+		ServiceName:               "My Test Service",
+		SleepHourInterruptions:    0,
+		SnoozedSeconds:            0,
+		TeamID:                    "PCDYDX0",
+		TeamName:                  "My Team",
+		Urgency:                   "Urgent",
+		UserDefinedEffortSeconds:  0,
+	}
+
+	bytesRawDataWanted, err := json.Marshal(rawDataWanted)
+	testErrCheck(t, "json.Marshal()", "", err)
+
+	url := fmt.Sprintf("%s/%s", "/analytics/raw/incidents", id)
+	mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, _ = w.Write(bytesRawDataWanted)
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+
+	res, err := client.GetRawDataSingleIncident(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, rawDataWanted, res)
+}
+
+func TestAnalytics_GetRawDataMultipleIncidents(t *testing.T) {
+	setup()
+	defer teardown()
+
+	id := "PFGEDX0"
+	rawDataWanted := RawData{
+		AssignmentCount:           10,
+		BusinessHourInterruptions: 1,
+		CreatedAt:                 "2021-01-06T00:00:00.000000",
+		Description:               "Test Alert Description",
+		EngagedSeconds:            404,
+		EngagedUserCount:          2,
+		EscalationCount:           1,
+		ID:                        id,
+		IncidentNumber:            324,
+		IsMajor:                   true,
+		OffHourInterruptions:      1,
+		PriorityID:                "PSVSDF3",
+		PriorityName:              "Urgent",
+		ResolvedAt:                "2021-01-06T08:23:21.000000",
+		SecondsToEngage:           3453,
+		SecondsToFirstAck:         123,
+		SecondsToMobilize:         435,
+		SecondsToResolve:          324524,
+		ServiceID:                 "PA4DFYS",
+		ServiceName:               "My Test Service",
+		SleepHourInterruptions:    0,
+		SnoozedSeconds:            0,
+		TeamID:                    "PCDYDX0",
+		TeamName:                  "My Team",
+		Urgency:                   "Urgent",
+		UserDefinedEffortSeconds:  0,
+	}
+
+	rawDataRequest := RawDataRequest{
+		Filters: &AnalyticsFilter{
+			CreatedAtStart: "2021-01-01T15:00:32Z",
+			CreatedAtEnd:   "2021-01-08T15:00:32Z",
+			TeamIDs:        []string{"PCDYDX0"},
+		},
+		StartingAfter: "eyJpZCI6IlEwTUlFTUtXTVNYOFZFIiwib3JkZXJfYnkiOiJjcmVhdGVkX2F0IiwidmFsdWUiOiIyMDIzLTA0LTMwVDA4OjU0OjAzIn0=",
+		EndingBefore:  "eyJpZCI6IlEzQU1DSlhWU05HTjZEIiwib3JkZXJfYnkiOiJjcmVhdGVkX2F0IiwidmFsdWUiOiIyMDIzLTA0LTI2VDE4OjA3OjIyIn0=",
+		Limit:         100,
+		Order:         "asc",
+		OrderBy:       "created_at",
+		TimeZone:      "Etc/UTC",
+	}
+	rawFilterWanted := AnalyticsFilter{CreatedAtStart: "2021-01-06T09:21:41Z", CreatedAtEnd: "2021-01-13T09:21:41Z", TeamIDs: []string{"PCDYDX0"}}
+	rawDataResponse := RawDataResponse{
+		Data:     []RawData{rawDataWanted},
+		Filters:  &rawFilterWanted,
+		First:    "eyJpZCI6IlEwTUlFTUtXTVNYOFZFIiwib3JkZXJfYnkiOiJjcmVhdGVkX2F0IiwidmFsdWUiOiIyMDIzLTA0LTMwVDA4OjU0OjAzIn0=",
+		Last:     "eyJpZCI6IlEzQU1DSlhWU05HTjZEIiwib3JkZXJfYnkiOiJjcmVhdGVkX2F0IiwidmFsdWUiOiIyMDIzLTA0LTI2VDE4OjA3OjIyIn0=",
+		Limit:    100,
+		More:     true,
+		Order:    "asc",
+		OrderBy:  "created_at",
+		TimeZone: "Etc/UTC",
+	}
+
+	bytesRawDataWanted, err := json.Marshal(rawDataResponse)
+	testErrCheck(t, "json.Marshal()", "", err)
+
+	mux.HandleFunc("/analytics/raw/incidents", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		_, _ = w.Write(bytesRawDataWanted)
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+
+	res, err := client.GetRawDataMultipleIncidents(context.Background(), rawDataRequest)
+	want := RawDataResponse{
+		Data:     []RawData{rawDataWanted},
+		Filters:  &rawFilterWanted,
+		First:    "eyJpZCI6IlEwTUlFTUtXTVNYOFZFIiwib3JkZXJfYnkiOiJjcmVhdGVkX2F0IiwidmFsdWUiOiIyMDIzLTA0LTMwVDA4OjU0OjAzIn0=",
+		Last:     "eyJpZCI6IlEzQU1DSlhWU05HTjZEIiwib3JkZXJfYnkiOiJjcmVhdGVkX2F0IiwidmFsdWUiOiIyMDIzLTA0LTI2VDE4OjA3OjIyIn0=",
+		Limit:    100,
+		More:     true,
+		Order:    "asc",
+		OrderBy:  "created_at",
+		TimeZone: "Etc/UTC",
 	}
 	if err != nil {
 		t.Fatal(err)

--- a/analytics_test.go
+++ b/analytics_test.go
@@ -141,12 +141,12 @@ func TestAnalytics_GetAggregatedTeamData(t *testing.T) {
 	testEqual(t, want, res)
 }
 
-func TestAnalytics_GetRawDataSingleIncident(t *testing.T) {
+func TestAnalytics_GetAnalyticsIncidentsById(t *testing.T) {
 	setup()
 	defer teardown()
 
 	id := "PFGEDX0"
-	rawDataWanted := RawData{
+	rawDataWanted := AnalyticsRawIncident{
 		AssignmentCount:           10,
 		BusinessHourInterruptions: 1,
 		CreatedAt:                 "2021-01-06T00:00:00.000000",
@@ -186,19 +186,19 @@ func TestAnalytics_GetRawDataSingleIncident(t *testing.T) {
 
 	client := defaultTestClient(server.URL, "foo")
 
-	res, err := client.GetRawDataSingleIncident(context.Background(), id)
+	res, err := client.GetAnalyticsIncidentsById(context.Background(), id)
 	if err != nil {
 		t.Fatal(err)
 	}
-	testEqual(t, rawDataWanted, res)
+	testEqual(t, &rawDataWanted, res)
 }
 
-func TestAnalytics_GetRawDataMultipleIncidents(t *testing.T) {
+func TestAnalytics_GetAnalyticsIncidents(t *testing.T) {
 	setup()
 	defer teardown()
 
 	id := "PFGEDX0"
-	rawDataWanted := RawData{
+	rawDataWanted := AnalyticsRawIncident{
 		AssignmentCount:           10,
 		BusinessHourInterruptions: 1,
 		CreatedAt:                 "2021-01-06T00:00:00.000000",
@@ -227,7 +227,7 @@ func TestAnalytics_GetRawDataMultipleIncidents(t *testing.T) {
 		UserDefinedEffortSeconds:  0,
 	}
 
-	rawDataRequest := RawDataRequest{
+	rawDataRequest := AnalyticsRawIncidentsRequest{
 		Filters: &AnalyticsFilter{
 			CreatedAtStart: "2021-01-01T15:00:32Z",
 			CreatedAtEnd:   "2021-01-08T15:00:32Z",
@@ -241,8 +241,8 @@ func TestAnalytics_GetRawDataMultipleIncidents(t *testing.T) {
 		TimeZone:      "Etc/UTC",
 	}
 	rawFilterWanted := AnalyticsFilter{CreatedAtStart: "2021-01-06T09:21:41Z", CreatedAtEnd: "2021-01-13T09:21:41Z", TeamIDs: []string{"PCDYDX0"}}
-	rawDataResponse := RawDataResponse{
-		Data:     []RawData{rawDataWanted},
+	rawDataResponse := AnalyticsRawIncidentsResponse{
+		Data:     []AnalyticsRawIncident{rawDataWanted},
 		Filters:  &rawFilterWanted,
 		First:    "eyJpZCI6IlEwTUlFTUtXTVNYOFZFIiwib3JkZXJfYnkiOiJjcmVhdGVkX2F0IiwidmFsdWUiOiIyMDIzLTA0LTMwVDA4OjU0OjAzIn0=",
 		Last:     "eyJpZCI6IlEzQU1DSlhWU05HTjZEIiwib3JkZXJfYnkiOiJjcmVhdGVkX2F0IiwidmFsdWUiOiIyMDIzLTA0LTI2VDE4OjA3OjIyIn0=",
@@ -263,9 +263,9 @@ func TestAnalytics_GetRawDataMultipleIncidents(t *testing.T) {
 
 	client := defaultTestClient(server.URL, "foo")
 
-	res, err := client.GetRawDataMultipleIncidents(context.Background(), rawDataRequest)
-	want := RawDataResponse{
-		Data:     []RawData{rawDataWanted},
+	res, err := client.GetAnalyticsIncidents(context.Background(), rawDataRequest)
+	want := &AnalyticsRawIncidentsResponse{
+		Data:     []AnalyticsRawIncident{rawDataWanted},
 		Filters:  &rawFilterWanted,
 		First:    "eyJpZCI6IlEwTUlFTUtXTVNYOFZFIiwib3JkZXJfYnkiOiJjcmVhdGVkX2F0IiwidmFsdWUiOiIyMDIzLTA0LTMwVDA4OjU0OjAzIn0=",
 		Last:     "eyJpZCI6IlEzQU1DSlhWU05HTjZEIiwib3JkZXJfYnkiOiJjcmVhdGVkX2F0IiwidmFsdWUiOiIyMDIzLTA0LTI2VDE4OjA3OjIyIn0=",


### PR DESCRIPTION
Implement endpoints for single and multiple raw incident metrics

https://developer.pagerduty.com/api-reference/b3A6Mjc0ODExMw-get-raw-data-single-incident

https://developer.pagerduty.com/api-reference/c2d493e995071-get-raw-data-multiple-incidents

This was previously done in PRs #347 and #422 which have gone stale.