### PR TITLE
Add support for incident custom fields

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -904,7 +904,7 @@ func (c *Client) UpdateIncidentCustomFieldsWithContext(ctx context.Context, id s
 		"custom_fields": fields,
 	}
 
-	resp, err := c.post(ctx, "/incidents/"+id+"/custom_fields/values", d, nil)
+	resp, err := c.put(ctx, "/incidents/"+id+"/custom_fields/values", d, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/incident.go
+++ b/incident.go
@@ -667,18 +667,18 @@ type ResponderRequestTargetWrapper struct {
 
 // ResponderRequestOptions defines the input options for the Create Responder function.
 type ResponderRequestOptions struct {
-	From        string                   `json:"-"`
-	Message     string                   `json:"message"`
-	RequesterID string                   `json:"requester_id"`
+	From        string                          `json:"-"`
+	Message     string                          `json:"message"`
+	RequesterID string                          `json:"requester_id"`
 	Targets     []ResponderRequestTargetWrapper `json:"responder_request_targets"`
 }
 
 // ResponderRequest contains the API structure for an incident responder request.
 type ResponderRequest struct {
-	Incident    Incident                 `json:"incident"`
-	Requester   User                     `json:"requester,omitempty"`
-	RequestedAt string                   `json:"request_at,omitempty"`
-	Message     string                   `json:"message,omitempty"`
+	Incident    Incident                        `json:"incident"`
+	Requester   User                            `json:"requester,omitempty"`
+	RequestedAt string                          `json:"request_at,omitempty"`
+	Message     string                          `json:"message,omitempty"`
 	Targets     []ResponderRequestTargetWrapper `json:"responder_request_targets"`
 }
 
@@ -868,6 +868,62 @@ func (c *Client) RemoveIncidentNotificationSubscribersWithContext(ctx context.Co
 	}
 
 	var result RemoveIncidentNotificationSubscribersResponse
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+type IncidentCustomFieldUpdateOption struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type IncidentCustomField struct {
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	Name        string `json:"name"`
+	DisplayName string `json:"display_name"`
+	Description string `json:"description"`
+	DataType    string `json:"data_type"`
+	FieldType   string `json:"field_type"`
+	Value       string `json:"value"`
+}
+
+type UpdateIncidentCustomFieldsResponse struct {
+	CustomFields []IncidentCustomField `json:"custom_fields"`
+}
+
+type ListIncidentCustomFieldsResponse struct {
+	CustomFields []IncidentCustomField `json:"custom_fields"`
+}
+
+func (c *Client) UpdateIncidentCustomFieldsWithContext(ctx context.Context, id string, fields []IncidentCustomFieldUpdateOption) (*UpdateIncidentCustomFieldsResponse, error) {
+	d := map[string][]IncidentCustomFieldUpdateOption{
+		"custom_fields": fields,
+	}
+
+	resp, err := c.post(ctx, "/incidents/"+id+"/custom_fields/values", d, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result UpdateIncidentCustomFieldsResponse
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+func (c *Client) ListIncidentCustomFieldsWithContext(ctx context.Context, id string) (*ListIncidentCustomFieldsResponse, error) {
+	resp, err := c.get(ctx, "/incidents/"+id+"/custom_fields/values")
+	if err != nil {
+		return nil, err
+	}
+
+	var result ListIncidentCustomFieldsResponse
 	if err = c.decodeJSON(resp, &result); err != nil {
 		return nil, err
 	}

--- a/incident_test.go
+++ b/incident_test.go
@@ -1111,3 +1111,74 @@ func TestIncident_RemoveIncidentNotificationSubscribersWithContext(t *testing.T)
 	}
 	testEqual(t, want, res)
 }
+
+func TestIncident_UpdateIncidentCustomFieldsWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	input := []IncidentCustomFieldUpdateOption{
+		{
+			Name:  "account_id",
+			Value: "fba35a45-ee19-4480-b903-74f354033980",
+		},
+	}
+
+	mux.HandleFunc("/incidents/1/custom_fields/values", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		_, _ = w.Write([]byte(`{"custom_fields":[{"data_type":"string","description":"account id of the incident reporter","display_name":"Account ID","field_type":"single_value","id":"P8BCDGH","name":"account_id","type":"field_value","value":"fba35a45-ee19-4480-b903-74f354033980"}]}`))
+	})
+	client := defaultTestClient(server.URL, "foo")
+	id := "1"
+	res, err := client.UpdateIncidentCustomFieldsWithContext(context.Background(), id, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &UpdateIncidentCustomFieldsResponse{
+		CustomFields: []IncidentCustomField{
+			{
+				ID:          "P8BCDGH",
+				Type:        "field_value",
+				Name:        "account_id",
+				DisplayName: "Account ID",
+				Description: "account id of the incident reporter",
+				DataType:    "string",
+				FieldType:   "single_value",
+				Value:       "fba35a45-ee19-4480-b903-74f354033980",
+			},
+		},
+	}
+	testEqual(t, want, res)
+}
+
+func TestIncident_ListIncidentCustomFieldsWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/incidents/1/custom_fields/values", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, _ = w.Write([]byte(`{"custom_fields":[{"data_type":"string","description":"account id of the incident reporter","display_name":"Account ID","field_type":"single_value","id":"P8BCDGH","name":"account_id","type":"field_value","value":"fba35a45-ee19-4480-b903-74f354033980"}]}`))
+	})
+	client := defaultTestClient(server.URL, "foo")
+	id := "1"
+	res, err := client.ListIncidentCustomFieldsWithContext(context.Background(), id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListIncidentCustomFieldsResponse{
+		CustomFields: []IncidentCustomField{
+			{
+				ID:          "P8BCDGH",
+				Type:        "field_value",
+				Name:        "account_id",
+				DisplayName: "Account ID",
+				Description: "account id of the incident reporter",
+				DataType:    "string",
+				FieldType:   "single_value",
+				Value:       "fba35a45-ee19-4480-b903-74f354033980",
+			},
+		},
+	}
+	testEqual(t, want, res)
+}


### PR DESCRIPTION
## Why

- support for listing/setting custom fields for an incident
- Reference: 
      - https://developer.pagerduty.com/api-reference/85a33d421d50b-get-custom-field-values
      - https://developer.pagerduty.com/api-reference/0f6094f852517-update-custom-field-values