### PR TITLE
Refactor nil *string initialization

### DIFF
--- a/service_integration.go
+++ b/service_integration.go
@@ -241,27 +241,25 @@ func (i *IntegrationEmailFilterRule) UnmarshalJSON(b []byte) error {
 
 	// if the *string is nil, set it to a *string with value ""
 	if ief.SubjectRegex == nil {
-		i.SubjectRegex = strPtr("")
+		i.SubjectRegex = new(string)
 	} else {
 		i.SubjectRegex = ief.SubjectRegex
 	}
 
 	if ief.BodyRegex == nil {
-		i.BodyRegex = strPtr("")
+		i.BodyRegex = new(string)
 	} else {
 		i.BodyRegex = ief.BodyRegex
 	}
 
 	if ief.FromEmailRegex == nil {
-		i.FromEmailRegex = strPtr("")
+		i.FromEmailRegex = new(string)
 	} else {
 		i.FromEmailRegex = ief.FromEmailRegex
 	}
 
 	return nil
 }
-
-func strPtr(s string) *string { return &s }
 
 type integrationEmailFilterRule struct {
 	SubjectMode    IntegrationEmailFilterRuleMode `json:"subject_mode"`

--- a/service_integration_test.go
+++ b/service_integration_test.go
@@ -294,6 +294,10 @@ func TestIntegrationEmailFilterRule(t *testing.T) {
 }
 
 func TestIntegrationEmailFilterRule_UnmarshalJSON(t *testing.T) {
+	subjectRegex := ""
+	bodyRegex := "testbody"
+	fromEmailRegex := "testform"
+
 	tests := []struct {
 		name  string
 		input string
@@ -302,14 +306,14 @@ func TestIntegrationEmailFilterRule_UnmarshalJSON(t *testing.T) {
 	}{
 		{
 			name:  "full",
-			input: `{"subject_mode":"always", "subject_regex":"", "body_mode":"match", "body_regex":"testbody", "from_email_mode":"no-match", "from_email_regex":"testfrom"}`,
+			input: fmt.Sprintf(`{"subject_mode":"always", "subject_regex":"%s", "body_mode":"match", "body_regex":"%s", "from_email_mode":"no-match", "from_email_regex":"%s"}`, subjectRegex, bodyRegex, fromEmailRegex),
 			want: IntegrationEmailFilterRule{
 				SubjectMode:    EmailFilterRuleModeAlways,
-				SubjectRegex:   strPtr(""),
+				SubjectRegex:   &subjectRegex,
 				BodyMode:       EmailFilterRuleModeMatch,
-				BodyRegex:      strPtr("testbody"),
+				BodyRegex:      &bodyRegex,
 				FromEmailMode:  EmailFilterRuleModeNoMatch,
-				FromEmailRegex: strPtr("testfrom"),
+				FromEmailRegex: &fromEmailRegex,
 			},
 		},
 
@@ -318,11 +322,11 @@ func TestIntegrationEmailFilterRule_UnmarshalJSON(t *testing.T) {
 			input: `{}`,
 			want: IntegrationEmailFilterRule{
 				SubjectMode:    EmailFilterRuleModeInvalid,
-				SubjectRegex:   strPtr(""),
+				SubjectRegex:   new(string),
 				BodyMode:       EmailFilterRuleModeInvalid,
-				BodyRegex:      strPtr(""),
+				BodyRegex:      new(string),
 				FromEmailMode:  EmailFilterRuleModeInvalid,
-				FromEmailRegex: strPtr(""),
+				FromEmailRegex: new(string),
 			},
 		},
 	}


### PR DESCRIPTION
**What's the purpose of this PR?** 

- This PR removes the `strPtr` helper function, as it is not necessary and was missleading.

**Why?**

- The `strPtr` function was used to initialize a string and get its pointer in a single line.  As this was only used for initializing empty strings and returning their pointer, it's equivalent to `new(string)`. For unit tests, it makes sense to reference the same values for the created json and the unmarshalled output.
- The `strPtr` function was missleading because it took a string by copy instead of reference, meaning that it would not return the pointer to the passed string, but to the copy. 
