### PR TITLE
Added support for auto_pause_notifications_parameters

### DIFF
--- a/service.go
+++ b/service.go
@@ -78,25 +78,32 @@ type ServiceRuleActions struct {
 // Service represents something you monitor (like a web service, email service, or database service).
 type Service struct {
 	APIObject
-	Name                    string                   `json:"name,omitempty"`
-	Description             string                   `json:"description,omitempty"`
-	AutoResolveTimeout      *uint                    `json:"auto_resolve_timeout,omitempty"`
-	AcknowledgementTimeout  *uint                    `json:"acknowledgement_timeout,omitempty"`
-	CreateAt                string                   `json:"created_at,omitempty"`
-	Status                  string                   `json:"status,omitempty"`
-	LastIncidentTimestamp   string                   `json:"last_incident_timestamp,omitempty"`
-	Integrations            []Integration            `json:"integrations,omitempty"`
-	EscalationPolicy        EscalationPolicy         `json:"escalation_policy,omitempty"`
-	Teams                   []Team                   `json:"teams,omitempty"`
-	IncidentUrgencyRule     *IncidentUrgencyRule     `json:"incident_urgency_rule,omitempty"`
-	SupportHours            *SupportHours            `json:"support_hours,omitempty"`
-	ScheduledActions        []ScheduledAction        `json:"scheduled_actions,omitempty"`
-	AlertCreation           string                   `json:"alert_creation,omitempty"`
-	AlertGrouping           string                   `json:"alert_grouping,omitempty"`
-	AlertGroupingTimeout    *uint                    `json:"alert_grouping_timeout,omitempty"`
-	AlertGroupingParameters *AlertGroupingParameters `json:"alert_grouping_parameters,omitempty"`
-	ResponsePlay            *APIObject               `json:"response_play,omitempty"`
-	Addons                  []Addon                  `json:"addons,omitempty"`
+	Name                             string                            `json:"name,omitempty"`
+	Description                      string                            `json:"description,omitempty"`
+	AutoResolveTimeout               *uint                             `json:"auto_resolve_timeout,omitempty"`
+	AcknowledgementTimeout           *uint                             `json:"acknowledgement_timeout,omitempty"`
+	CreateAt                         string                            `json:"created_at,omitempty"`
+	Status                           string                            `json:"status,omitempty"`
+	LastIncidentTimestamp            string                            `json:"last_incident_timestamp,omitempty"`
+	Integrations                     []Integration                     `json:"integrations,omitempty"`
+	EscalationPolicy                 EscalationPolicy                  `json:"escalation_policy,omitempty"`
+	Teams                            []Team                            `json:"teams,omitempty"`
+	IncidentUrgencyRule              *IncidentUrgencyRule              `json:"incident_urgency_rule,omitempty"`
+	SupportHours                     *SupportHours                     `json:"support_hours,omitempty"`
+	ScheduledActions                 []ScheduledAction                 `json:"scheduled_actions,omitempty"`
+	AlertCreation                    string                            `json:"alert_creation,omitempty"`
+	AlertGrouping                    string                            `json:"alert_grouping,omitempty"`
+	AlertGroupingTimeout             *uint                             `json:"alert_grouping_timeout,omitempty"`
+	AlertGroupingParameters          *AlertGroupingParameters          `json:"alert_grouping_parameters,omitempty"`
+	ResponsePlay                     *APIObject                        `json:"response_play,omitempty"`
+	Addons                           []Addon                           `json:"addons,omitempty"`
+	AutoPauseNotificationsParameters *AutoPauseNotificationsParameters `json:"auto_pause_notifications_parameters,omitempty"`
+}
+
+// AutoPauseNotificationsParameters defines how alerts on the service will be automatically paused
+type AutoPauseNotificationsParameters struct {
+	Enabled bool `json:"enabled"`
+	Timeout uint `json:"timeout,omitempty"`
 }
 
 // AlertGroupingParameters defines how alerts on the service will be automatically grouped into incidents

--- a/service_test.go
+++ b/service_test.go
@@ -266,6 +266,39 @@ func TestService_CreateWithAlertGroupParamsIntelligent(t *testing.T) {
 	testEqual(t, want, res)
 }
 
+// Create Service with AutoPauseNotificationsParameters
+func TestService_CreateWithAutoPauseNotificationsParameters(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		_, _ = w.Write([]byte(`{"service": {"id": "1","name":"foo"}}`))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	input := Service{
+		Name: "foo",
+		AutoPauseNotificationsParameters: &AutoPauseNotificationsParameters{
+			Enabled: true,
+			Timeout: 60,
+		},
+	}
+	res, err := client.CreateService(input)
+
+	want := &Service{
+		APIObject: APIObject{
+			ID: "1",
+		},
+		Name: "foo",
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
 // Update Service
 func TestService_Update(t *testing.T) {
 	setup()


### PR DESCRIPTION
Updated Service struct to support auto_pause_notifications_parameters as per https://developer.pagerduty.com/api-reference/165ad96a22ffd-get-a-service.
 I'm guessing this is a newer feature that got released but never made its way into this go lib code.