### PR TITLE
[CSGI-2365] Add client User Agent overwrite capability

### DIFF
--- a/client.go
+++ b/client.go
@@ -285,6 +285,8 @@ type Client struct {
 	// PagerDuty API. You can use either *http.Client here, or your own
 	// implementation.
 	HTTPClient HTTPClient
+
+	userAgent string
 }
 
 // NewClient creates an API client using an account/user API token
@@ -319,6 +321,14 @@ type ClientOptions func(*Client)
 func WithAPIEndpoint(endpoint string) ClientOptions {
 	return func(c *Client) {
 		c.apiEndpoint = endpoint
+	}
+}
+
+// WithTerraformProvider configures the client to be used as the PagerDuty
+// Terraform provider
+func WithTerraformProvider(version string) ClientOptions {
+	return func(c *Client) {
+		c.userAgent = fmt.Sprintf("(%s %s) Terraform/%s", runtime.GOOS, runtime.GOARCH, version)
 	}
 }
 
@@ -498,7 +508,13 @@ func (c *Client) prepRequest(req *http.Request, authRequired bool, headers map[s
 		}
 	}
 
-	req.Header.Set("User-Agent", userAgentHeader)
+	var userAgent string
+	if c.userAgent != "" {
+		userAgent = c.userAgent
+	} else {
+		userAgent = userAgentHeader
+	}
+	req.Header.Set("User-Agent", userAgent)
 	req.Header.Set("Content-Type", contentTypeHeader)
 }
 


### PR DESCRIPTION

## Test cases introduced...

```sh
$ go test -count=1 -v -run TestClient_UserAgent
=== RUN   TestClient_UserAgentDefault
--- PASS: TestClient_UserAgentDefault (0.00s)
=== RUN   TestClient_UserAgentOverwrite
--- PASS: TestClient_UserAgentOverwrite (0.00s)
PASS
ok      github.com/PagerDuty/go-pagerduty       0.667s

```