### PR TITLE
command: accept API key in environment var

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ go get github.com/PagerDuty/go-pagerduty@latest
 ### CLI
 
 The CLI requires an [authentication token](https://v2.developer.pagerduty.com/docs/authentication), which can be specified in `.pd.yml`
-file in the home directory of the user, or passed as a command-line argument.
+file in the home directory of the user, set in the `PAGERDUTY_API_KEY` environment variable, or passed as a command-line argument.
+
 Example of config file:
 
 ```yaml
@@ -30,7 +31,10 @@ authtoken: fooBar
 
 #### Commands
 `pd` command provides a single entrypoint for all the API endpoints, with individual
-API represented by their own sub commands. For an exhaustive list of sub-commands, try:
+API represented by their own sub commands. It requires an API token; you can provide
+this in the environment variable `PAGERDUTY_API_KEY`, or via the `-authtoken` flag.
+
+For an exhaustive list of sub-commands, try:
 ```
 pd --help
 ```

--- a/command/meta.go
+++ b/command/meta.go
@@ -102,8 +102,14 @@ func (m *Meta) loadConfig() error {
 	if err := yaml.Unmarshal(data, other); err != nil {
 		return err
 	}
+	// precedence:
+	// 1. CLI flag
+	// 2. environment variable
+	// 3. config file
 	if m.Authtoken == "" {
-		m.Authtoken = other.Authtoken
+		if m.Authtoken = os.Getenv("PAGERDUTY_API_KEY"); m.Authtoken == "" {
+			m.Authtoken = other.Authtoken
+		}
 	}
 	if m.Loglevel == "" {
 		m.Loglevel = other.Loglevel


### PR DESCRIPTION
Accept PagerDuty API key in `$PAGERDUTY_API_KEY`.

Precedence:

1. CLI flag
2. environment variable
3. config file