### PR TITLE
command: selectable output formats (JSON/YAML)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,25 @@ Example of config file:
 authtoken: fooBar
 ```
 
+#### Output formats
+
+YAML and JSON output formats are supported. The default is YAML.
+
+The key `outputformat` can be set in `.pd.yml`:
+
+```yaml
+authtoken: yourtokenhere
+outputformat: json
+```
+
+Alternatively, the `--outputformat` command line flag can be used:
+
+```
+pd incident list --outputformat=json
+```
+
 #### Commands
+
 `pd` command provides a single entrypoint for all the API endpoints, with individual
 API represented by their own sub commands. For an exhaustive list of sub-commands, try:
 ```

--- a/command/addon_install.go
+++ b/command/addon_install.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mitchellh/cli"
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/command/addon_list.go
+++ b/command/addon_list.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
-	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type AddonList struct {
@@ -62,9 +62,8 @@ func (c *AddonList) Run(args []string) int {
 		log.Error(err)
 		return -1
 	} else {
-		for i, addon := range addonList.Addons {
-			fmt.Println("Entry: ", i)
-			data, err := yaml.Marshal(addon)
+		for _, addon := range addonList.Addons {
+			data, err := c.Marshaler(addon)
 			if err != nil {
 				log.Error(err)
 				return -1

--- a/command/addon_show.go
+++ b/command/addon_show.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
 	"strings"
 )
 
@@ -48,7 +47,7 @@ func (c *AddonShow) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
-	data, err := yaml.Marshal(a)
+	data, err := c.Marshaler(a)
 	if err != nil {
 		log.Error(err)
 		return -1

--- a/command/addon_update.go
+++ b/command/addon_update.go
@@ -3,10 +3,11 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
-	"github.com/mitchellh/cli"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type AddonUpdate struct {

--- a/command/analytics_incident_show.go
+++ b/command/analytics_incident_show.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -99,7 +98,7 @@ func (c *AnalyticsShow) Run(args []string) int {
 		return -1
 	}
 
-	aggregatedIncidentDataBytes, err := json.Marshal(aggregatedIncidentData)
+	aggregatedIncidentDataBytes, err := c.Marshaler(aggregatedIncidentData)
 	if err != nil {
 		log.Error(err)
 		return -1

--- a/command/analytics_service_show.go
+++ b/command/analytics_service_show.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -97,7 +96,7 @@ func (c *AnalyticsServiceShow) Run(args []string) int {
 		return -1
 	}
 
-	aggregatedServiceDataBytes, err := json.Marshal(aggregatedServiceData)
+	aggregatedServiceDataBytes, err := c.Marshaler(aggregatedServiceData)
 	if err != nil {
 		log.Error(err)
 		return -1

--- a/command/analytics_team_show.go
+++ b/command/analytics_team_show.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -97,7 +96,7 @@ func (c *AnalyticsTeamShow) Run(args []string) int {
 		return -1
 	}
 
-	aggregatedTeamDataBytes, err := json.Marshal(aggregatedTeamData)
+	aggregatedTeamDataBytes, err := c.Marshaler(aggregatedTeamData)
 	if err != nil {
 		log.Error(err)
 		return -1

--- a/command/escalation_policy_create.go
+++ b/command/escalation_policy_create.go
@@ -3,11 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
-	"github.com/mitchellh/cli"
 	"os"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type EscalationPolicyCreate struct {

--- a/command/escalation_policy_list.go
+++ b/command/escalation_policy_list.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
-	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type EscalationPolicyList struct {
@@ -72,9 +72,8 @@ func (c *EscalationPolicyList) Run(args []string) int {
 		log.Error(err)
 		return -1
 	} else {
-		for i, p := range eps.EscalationPolicies {
-			fmt.Println("Entry: ", i)
-			data, err := yaml.Marshal(p)
+		for _, p := range eps.EscalationPolicies {
+			data, err := c.Marshaler(p)
 			if err != nil {
 				log.Error(err)
 				return -1

--- a/command/escalation_policy_show.go
+++ b/command/escalation_policy_show.go
@@ -5,7 +5,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
 	"strings"
 )
 
@@ -62,7 +61,7 @@ func (c *EscalationPolicyShow) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
-	data, err := yaml.Marshal(ep)
+	data, err := c.Marshaler(ep)
 	if err != nil {
 		log.Error(err)
 		return -1

--- a/command/event_orchestration_list.go
+++ b/command/event_orchestration_list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type EventOrchestrationList struct {
@@ -62,7 +61,7 @@ func (c *EventOrchestrationList) Run(args []string) int {
 			if i > 0 {
 				fmt.Println("---")
 			}
-			data, err := yaml.Marshal(p)
+			data, err := c.Marshaler(p)
 			if err != nil {
 				log.Error(err)
 				return -1

--- a/command/event_orchestration_show.go
+++ b/command/event_orchestration_show.go
@@ -8,7 +8,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type EventOrchestrationShow struct {
@@ -59,7 +58,7 @@ func (c *EventOrchestrationShow) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
-	data, err := yaml.Marshal(ep)
+	data, err := c.Marshaler(ep)
 	if err != nil {
 		log.Error(err)
 		return -1
@@ -73,7 +72,7 @@ func (c *EventOrchestrationShow) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
-	data, err = yaml.Marshal(rules)
+	data, err = c.Marshaler(rules)
 	if err != nil {
 		log.Error(err)
 		return -1

--- a/command/event_v2_manage.go
+++ b/command/event_v2_manage.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	pagerduty "github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type EventV2Manage struct {

--- a/command/incident_list.go
+++ b/command/incident_list.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
-	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type IncidentList struct {
@@ -60,9 +60,8 @@ func (c *IncidentList) Run(args []string) int {
 		log.Error(err)
 		return -1
 	} else {
-		for i, incident := range incidentList.Incidents {
-			fmt.Println("Entry: ", i+1)
-			data, err := yaml.Marshal(incident)
+		for _, incident := range incidentList.Incidents {
+			data, err := c.Marshaler(incident)
 			if err != nil {
 				log.Error(err)
 				return -1

--- a/command/maintenance_window_create.go
+++ b/command/maintenance_window_create.go
@@ -3,11 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
-	"github.com/mitchellh/cli"
 	"os"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type MaintenanceWindowCreate struct {

--- a/command/maintenance_window_list.go
+++ b/command/maintenance_window_list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type MaintenanceWindowList struct {
@@ -73,9 +72,8 @@ func (c *MaintenanceWindowList) Run(args []string) int {
 		return -1
 	}
 
-	for i, mw := range mws.MaintenanceWindows {
-		fmt.Println("Entry: ", i)
-		data, err := yaml.Marshal(mw)
+	for _, mw := range mws.MaintenanceWindows {
+		data, err := c.Marshaler(mw)
 		if err != nil {
 			log.Error(err)
 			return -1

--- a/command/maintenance_window_show.go
+++ b/command/maintenance_window_show.go
@@ -8,7 +8,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type MaintenanceWindowShow struct {
@@ -68,7 +67,7 @@ func (c *MaintenanceWindowShow) Run(args []string) int {
 		return -1
 	}
 
-	data, err := yaml.Marshal(mw)
+	data, err := c.Marshaler(mw)
 	if err != nil {
 		log.Error(err)
 		return -1

--- a/command/oncall_list.go
+++ b/command/oncall_list.go
@@ -7,7 +7,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
 )
 
 type OncallList struct {
@@ -74,7 +73,7 @@ func (c *OncallList) Run(args []string) int {
 		log.Error(err)
 		return -1
 	} else {
-		data, err := yaml.Marshal(oncs.OnCalls)
+		data, err := c.Marshaler(oncs.OnCalls)
 		if err != nil {
 			log.Error(err)
 			return -1

--- a/command/schedule_create.go
+++ b/command/schedule_create.go
@@ -3,11 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
-	"github.com/mitchellh/cli"
 	"os"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type ScheduleCreate struct {

--- a/command/schedule_list.go
+++ b/command/schedule_list.go
@@ -4,11 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
-
 	pagerduty "github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type ScheduleList struct {
@@ -54,9 +52,8 @@ func (c *ScheduleList) Run(args []string) int {
 		log.Error(err)
 		return -1
 	} else {
-		for i, schedule := range scheduleList.Schedules {
-			fmt.Println("Entry: ", i+1)
-			data, err := yaml.Marshal(schedule)
+		for _, schedule := range scheduleList.Schedules {
+			data, err := c.Marshaler(schedule)
 			if err != nil {
 				log.Error(err)
 				return -1

--- a/command/schedule_override_create.go
+++ b/command/schedule_override_create.go
@@ -3,11 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"os"
-	"strings"
 )
 
 type ScheduleOverrideCreate struct {

--- a/command/service_create.go
+++ b/command/service_create.go
@@ -3,11 +3,12 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
-	"github.com/mitchellh/cli"
 	"os"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type ServiceCreate struct {

--- a/command/service_integration_create.go
+++ b/command/service_integration_create.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/mitchellh/cli"
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/command/service_list.go
+++ b/command/service_list.go
@@ -7,7 +7,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type ServiceList struct {
@@ -69,9 +68,8 @@ func (c *ServiceList) Run(args []string) int {
 		log.Error(err)
 		return -1
 	} else {
-		for i, service := range serviceList.Services {
-			fmt.Println("Entry: ", i+1)
-			data, err := yaml.Marshal(service)
+		for _, service := range serviceList.Services {
+			data, err := c.Marshaler(service)
 			if err != nil {
 				log.Error(err)
 				return -1

--- a/command/service_rule_list.go
+++ b/command/service_rule_list.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type ServiceRuleList struct {
@@ -51,9 +50,8 @@ func (c *ServiceRuleList) Run(args []string) int {
 		log.Error(err)
 		return -1
 	} else {
-		for i, rule := range rulesList {
-			fmt.Println("Entry: ", i+1)
-			data, err := yaml.Marshal(rule)
+		for _, rule := range rulesList {
+			data, err := c.Marshaler(rule)
 			if err != nil {
 				log.Error(err)
 				return -1

--- a/command/service_rule_show.go
+++ b/command/service_rule_show.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type ServiceRuleShow struct {
@@ -53,7 +52,7 @@ func (c *ServiceRuleShow) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
-	data, err := yaml.Marshal(rule)
+	data, err := c.Marshaler(rule)
 	if err != nil {
 		log.Error(err)
 		return -1

--- a/command/service_show.go
+++ b/command/service_show.go
@@ -5,7 +5,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
 	"strings"
 )
 
@@ -61,7 +60,7 @@ func (c *ServiceShow) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
-	data, err := yaml.Marshal(servicerecord)
+	data, err := c.Marshaler(servicerecord)
 	if err != nil {
 		log.Error(err)
 		return -1

--- a/command/standard_list.go
+++ b/command/standard_list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type StandardList struct {
@@ -66,7 +65,7 @@ func (c *StandardList) Run(args []string) int {
 			if i > 0 {
 				fmt.Println("---")
 			}
-			data, err := yaml.Marshal(r)
+			data, err := c.Marshaler(r)
 			if err != nil {
 				log.Error(err)
 				return -1

--- a/command/standard_multi_resources_scores_list.go
+++ b/command/standard_multi_resources_scores_list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type StandardListMultiResourcesScores struct {
@@ -65,7 +64,7 @@ func (c *StandardListMultiResourcesScores) Run(args []string) int {
 			if i > 0 {
 				fmt.Println("---")
 			}
-			data, err := yaml.Marshal(r)
+			data, err := c.Marshaler(r)
 			if err != nil {
 				log.Error(err)
 				return -1

--- a/command/standard_resource_scores_list.go
+++ b/command/standard_resource_scores_list.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type StandardListResourceScores struct {
@@ -57,7 +56,7 @@ func (c *StandardListResourceScores) Run(args []string) int {
 		log.Error(err)
 		return -1
 	} else {
-		data, err := yaml.Marshal(res)
+		data, err := c.Marshaler(res)
 		if err != nil {
 			log.Error(err)
 			return -1

--- a/command/team_list.go
+++ b/command/team_list.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
-	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
 	"strings"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/cli"
+	log "github.com/sirupsen/logrus"
 )
 
 type TeamList struct {
@@ -53,9 +53,8 @@ func (c *TeamList) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
-	for i, p := range result.Teams {
-		fmt.Println("Entry: ", i)
-		data, err := yaml.Marshal(p)
+	for _, p := range result.Teams {
+		data, err := c.Marshaler(p)
 		if err != nil {
 			log.Error(err)
 			return -1

--- a/command/team_show.go
+++ b/command/team_show.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
 	"strings"
 )
 
@@ -52,7 +51,7 @@ func (c *TeamShow) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
-	data, err := yaml.Marshal(result)
+	data, err := c.Marshaler(result)
 	if err != nil {
 		log.Error(err)
 		return -1

--- a/command/user_list.go
+++ b/command/user_list.go
@@ -5,9 +5,8 @@ import (
 	"strings"
 
 	"github.com/PagerDuty/go-pagerduty"
-	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	log "github.com/sirupsen/logrus"
 )
 
 type UserList struct {
@@ -65,9 +64,8 @@ func (c *UserList) Run(args []string) int {
 		log.Error(err)
 		return -1
 	} else {
-		for i, p := range resp.Users {
-			fmt.Println("Entry: ", i)
-			data, err := yaml.Marshal(p)
+		for _, p := range resp.Users {
+			data, err := c.Marshaler(p)
 			if err != nil {
 				log.Error(err)
 				return -1

--- a/command/vendor_list.go
+++ b/command/vendor_list.go
@@ -7,7 +7,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
 )
 
 type VendorList struct {
@@ -55,9 +54,8 @@ func (c *VendorList) Run(args []string) int {
 		log.Error(err)
 		return -1
 	} else {
-		for i, p := range resp.Vendors {
-			fmt.Println("Entry: ", i)
-			data, err := yaml.Marshal(p)
+		for _, p := range resp.Vendors {
+			data, err := c.Marshaler(p)
 			if err != nil {
 				log.Error(err)
 				return -1

--- a/command/vendor_show.go
+++ b/command/vendor_show.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
 	"strings"
 )
 
@@ -53,7 +52,7 @@ func (c *VendorShow) Run(args []string) int {
 		log.Error(err)
 		return -1
 	}
-	data, err := yaml.Marshal(result)
+	data, err := c.Marshaler(result)
 	if err != nil {
 		log.Error(err)
 		return -1


### PR DESCRIPTION
Give the user a choice of YAML or JSON output for all commands that emit either format. I have left the default format as YAML.

I have also removed the `Entry: 123` output lines which seemed like they were intended for debugging. I'm happy to be wrong here and restore them (for YAML output only, as it's clearly incompatible with JSON).

As-implemented, this will break scripted usage for the below commands that default to JSON. Given the breakdown of YAML vs. JSON usage here I think this is the least-bad option.

The other options I considered were:

* default to JSON (break most usage)
* default to nothing and require a flag (break everyone's usage)
* have a third 'auto' state that maintained the current behaviour (breaks rule of least surprise)

Commands emitting JSON (with this change they will emit YAML):

    $ grep -l json.Marshal command/*go
    command/addon_update.go
    command/analytics_incident_show.go
    command/analytics_service_show.go
    command/analytics_team_show.go

Commands emitting YAML:

    $ grep -l 'yaml\.Marshal' command/*go
    command/addon_list.go
    command/addon_show.go
    command/escalation_policy_list.go
    command/escalation_policy_show.go
    command/event_orchestration_list.go
    command/event_orchestration_show.go
    command/incident_list.go
    command/maintenance_window_list.go
    command/maintenance_window_show.go
    command/oncall_list.go
    command/schedule_list.go
    command/service_list.go
    command/service_rule_list.go
    command/service_rule_show.go
    command/service_show.go
    command/standard_list.go
    command/standard_multi_resources_scores_list.go
    command/standard_resource_scores_list.go
    command/team_list.go
    command/team_show.go
    command/user_list.go
    command/vendor_list.go
    command/vendor_show.go