### PR TITLE
feat: add escalation policy ids to AnalyticsFilter

### DIFF
--- a/analytics.go
+++ b/analytics.go
@@ -57,6 +57,7 @@ type AnalyticsFilter struct {
 	Urgency        string   `json:"urgency,omitempty"`
 	Major          bool     `json:"major,omitempty"`
 	ServiceIDs     []string `json:"service_ids,omitempty"`
+	EscalationIDs  []string `json:"escalation_policy_ids,omitempty"`
 	TeamIDs        []string `json:"team_ids,omitempty"`
 	PriorityIDs    []string `json:"priority_ids,omitempty"`
 	PriorityNames  []string `json:"priority_names,omitempty"`


### PR DESCRIPTION
Add support for escalation policy id in AnalyticsFilter

https://developer.pagerduty.com/api-reference/25800c343e344-get-aggregated-incident-data


<img width="977" alt="Screenshot 2024-04-08 at 12 58 34 PM" src="https://github.com/PagerDuty/go-pagerduty/assets/5973248/15b97caf-e97a-4530-afbe-913401923b0b">
