### PR TITLE
Add support for user handoff notification rule API CRUD

### DIFF
--- a/user.go
+++ b/user.go
@@ -54,6 +54,14 @@ type ContactMethod struct {
 	Enabled        bool   `json:"enabled,omitempty"`
 }
 
+// OncallHandoffNotificationRule is a handoff notification rule
+type OncallHandoffNotificationRule struct {
+	ID                     string        `json:"id,omitempty"`
+	HandoffType            string        `json:"handoff_type,omitempty"`
+	NotifyAdvanceInMinutes int           `json:"notify_advance_in_minutes"`
+	ContactMethod          ContactMethod `json:"contact_method"`
+}
+
 // ListUsersResponse is the data structure returned from calling the ListUsers API endpoint.
 type ListUsersResponse struct {
 	APIListObject
@@ -435,6 +443,58 @@ func getUserNotificationRuleFromResponse(c *Client, resp *http.Response, err err
 	}
 
 	const rootNode = "notification_rule"
+
+	t, nodeOK := target[rootNode]
+	if !nodeOK {
+		return nil, fmt.Errorf("JSON response does not have %s field", rootNode)
+	}
+
+	return &t, nil
+}
+
+// GetUserOncallHandoffNotificationRule gets details about an oncall handoff notification rule.
+func (c *Client) GetUserOncallHandoffNotificationRuleWithContext(ctx context.Context, userID, ruleID string) (*OncallHandoffNotificationRule, error) {
+	resp, err := c.get(ctx, "/users/"+userID+"/oncall_handoff_notification_rules/"+ruleID, nil)
+	return getUserOncallHandoffNotificationRuleFromResponse(c, resp, err)
+}
+
+// CreateUserOncallHandoffNotificationRule creates a new oncall handoff notification rule for a user.
+func (c *Client) CreateUserOncallHandoffNotificationRuleWithContext(ctx context.Context, userID string, rule OncallHandoffNotificationRule) (*OncallHandoffNotificationRule, error) {
+	d := map[string]OncallHandoffNotificationRule{
+		"oncall_handoff_notification_rule": rule,
+	}
+
+	resp, err := c.post(ctx, "/users/"+userID+"/oncall_handoff_notification_rules", d, nil)
+	return getUserOncallHandoffNotificationRuleFromResponse(c, resp, err)
+}
+
+// UpdateUserOncallHandoffNotificationRuleWithContext updates an oncall handoff notification rule for a user.
+func (c *Client) UpdateUserOncallHandoffNotificationRuleWithContext(ctx context.Context, userID string, rule OncallHandoffNotificationRule) (*OncallHandoffNotificationRule, error) {
+	d := map[string]OncallHandoffNotificationRule{
+		"oncall_handoff_notification_rule": rule,
+	}
+
+	resp, err := c.put(ctx, "/users/"+userID+"/oncall_handoff_notification_rules/"+rule.ID, d, nil)
+	return getUserOncallHandoffNotificationRuleFromResponse(c, resp, err)
+}
+
+// DeleteUserOncallHandoffNotificationRuleWithContext deletes an oncall handoff notification rule for a user.
+func (c *Client) DeleteUserOncallHandoffNotificationRuleWithContext(ctx context.Context, userID, ruleID string) error {
+	_, err := c.delete(ctx, "/users/"+userID+"/oncall_handoff_notification_rules/"+ruleID)
+	return err
+}
+
+func getUserOncallHandoffNotificationRuleFromResponse(c *Client, resp *http.Response, err error) (*OncallHandoffNotificationRule, error) {
+	if err != nil {
+		return nil, err
+	}
+
+	var target map[string]OncallHandoffNotificationRule
+	if dErr := c.decodeJSON(resp, &target); dErr != nil {
+		return nil, fmt.Errorf("Could not decode JSON response: %v", dErr)
+	}
+
+	const rootNode = "oncall_handoff_notification_rule"
 
 	t, nodeOK := target[rootNode]
 	if !nodeOK {

--- a/user_test.go
+++ b/user_test.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"context"
 	"net/http"
 	"testing"
 )
@@ -458,6 +459,140 @@ func TestUser_DeleteUserNotificationRule(t *testing.T) {
 
 	client := defaultTestClient(server.URL, "foo")
 	if err := client.DeleteUserNotificationRule(userID, ruleID); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Get user Oncall Handoff NotificationRule
+func TestUser_GetUserOncallHandoffNotificationRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/1/oncall_handoff_notification_rules/PXPGF42", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, _ = w.Write([]byte(`{"oncall_handoff_notification_rule":{"id":"PXPGF42","handoff_type":"both","notify_advance_in_minutes":180,"contact_method":{"id":"PXPGF42","type":"email_contact_method_reference","summary":"Work","self":"https://api.pagerduty.com/users/PXPGF42/contact_methods/PXPGF42"}}}`))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	ruleID := "PXPGF42"
+	userID := "1"
+
+	res, err := client.GetUserOncallHandoffNotificationRuleWithContext(context.TODO(), userID, ruleID)
+
+	want := &OncallHandoffNotificationRule{
+		ID:                     "PXPGF42",
+		HandoffType:            "both",
+		NotifyAdvanceInMinutes: 180,
+		ContactMethod: ContactMethod{
+			ID:      "PXPGF42",
+			Type:    "email_contact_method_reference",
+			Summary: "Work",
+			Self:    "https://api.pagerduty.com/users/PXPGF42/contact_methods/PXPGF42",
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+// Create user Oncall Handoff NotificationRule
+func TestUser_CreateUserOncallHandoffNotificationRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/1/oncall_handoff_notification_rules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		_, _ = w.Write([]byte(`{"oncall_handoff_notification_rule":{"id":"PXPGF42","handoff_type":"both","notify_advance_in_minutes":180,"contact_method":{"id":"PXPGF42","type":"email_contact_method_reference","summary":"Work","self":"https://api.pagerduty.com/users/PXPGF42/contact_methods/PXPGF42"}}}`))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	userID := "1"
+	rule := OncallHandoffNotificationRule{
+		HandoffType:            "both",
+		NotifyAdvanceInMinutes: 180,
+		ContactMethod: ContactMethod{
+			ID:      "PXPGF42",
+			Type:    "email_contact_method_reference",
+			Summary: "Work",
+			Self:    "https://api.pagerduty.com/users/PXPGF42/contact_methods/PXPGF42",
+		},
+	}
+	res, err := client.CreateUserOncallHandoffNotificationRuleWithContext(context.TODO(), userID, rule)
+
+	want := &OncallHandoffNotificationRule{
+		ID:                     "PXPGF42",
+		HandoffType:            "both",
+		NotifyAdvanceInMinutes: 180,
+		ContactMethod: ContactMethod{
+			ID:      "PXPGF42",
+			Type:    "email_contact_method_reference",
+			Summary: "Work",
+			Self:    "https://api.pagerduty.com/users/PXPGF42/contact_methods/PXPGF42",
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+func TestUser_UpdateUserOncallHandoffNotificationRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/1/oncall_handoff_notification_rules/PXPGF42", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		_, _ = w.Write([]byte(`{"oncall_handoff_notification_rule":{"id":"PXPGF42","handoff_type":"oncall","notify_advance_in_minutes":30,"contact_method":{"id":"PXPGF42","type":"email_contact_method_reference","summary":"Work","self":"https://api.pagerduty.com/users/PXPGF42/contact_methods/PXPGF42"}}}`))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	userID := "1"
+	rule := OncallHandoffNotificationRule{
+		ID:                     "PXPGF42",
+		HandoffType:            "oncall",
+		NotifyAdvanceInMinutes: 30,
+		ContactMethod: ContactMethod{
+			ID:      "PXPGF42",
+			Type:    "email_contact_method_reference",
+			Summary: "Work",
+			Self:    "https://api.pagerduty.com/users/PXPGF42/contact_methods/PXPGF42",
+		},
+	}
+	res, err := client.UpdateUserOncallHandoffNotificationRuleWithContext(context.TODO(), userID, rule)
+
+	want := &OncallHandoffNotificationRule{
+		ID:                     "PXPGF42",
+		HandoffType:            "oncall",
+		NotifyAdvanceInMinutes: 30,
+		ContactMethod: ContactMethod{
+			ID:      "PXPGF42",
+			Type:    "email_contact_method_reference",
+			Summary: "Work",
+			Self:    "https://api.pagerduty.com/users/PXPGF42/contact_methods/PXPGF42",
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+func TestUser_DeleteUserOncallHandoffNotificationRule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/users/1/oncall_handoff_notification_rules/1", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+	userID := "1"
+	ruleID := "1"
+
+	client := defaultTestClient(server.URL, "foo")
+	if err := client.DeleteUserOncallHandoffNotificationRuleWithContext(context.Background(), userID, ruleID); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Add support for...

* `GET /users/{id}/oncall_handoff_notification_rules/{oncall_handoff_notification_rule_id}` - [Ref](https://developer.pagerduty.com/api-reference/75af831a1efcc-get-a-user-s-handoff-notification-rule)
* `POST /users/{id}/oncall_handoff_notification_rules` - [Ref](https://developer.pagerduty.com/api-reference/f2ab7a3c1418a-create-a-user-handoff-notification-rule)
* `UPDATE /users/{id}/oncall_handoff_notification_rules/{oncall_handoff_notification_rule_id}` - [Ref](https://developer.pagerduty.com/api-reference/10a7f6d4896ac-update-a-user-s-handoff-notification-rule)
* `DELETE /users/{id}/oncall_handoff_notification_rules/{oncall_handoff_notification_rule_id}` - [Ref](https://developer.pagerduty.com/api-reference/3b5ab76dc35d0-delete-a-user-s-handoff-notification-rule)