### PR TITLE
Drop team parent attribute

### DIFF
--- a/team.go
+++ b/team.go
@@ -13,7 +13,6 @@ type Team struct {
 	APIObject
 	Name        string     `json:"name,omitempty"`
 	Description string     `json:"description,omitempty"`
-	Parent      *APIObject `json:"parent,omitempty"`
 	DefaultRole string     `json:"default_role,omitempty"`
 }
 


### PR DESCRIPTION
https://developer.pagerduty.com/api-reference/1c8181e57cc60-get-a-team

It looks like there's no reference at the API documentation regarding a Team parent, but the code has this field. This PR cleans up this seemly stale reference.