### PR TITLE
Add Overflow option to GetScheduleOptions

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -182,6 +182,7 @@ type GetScheduleOptions struct {
 	TimeZone string `url:"time_zone,omitempty"`
 	Since    string `url:"since,omitempty"`
 	Until    string `url:"until,omitempty"`
+	Overflow bool   `url:"overflow,omitempty"`
 }
 
 // GetSchedule shows detailed information about a schedule, including entries


### PR DESCRIPTION
GetScheduleOptions is missing the overflow option which is documented here: https://developer.pagerduty.com/api-reference/3f03afb2c84a4-get-a-schedule
