### PR TITLE
fix: accept Urgency in ManageIncidentsOptions

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -225,6 +225,7 @@ type ManageIncidentsOptions struct {
 	Status           string            `json:"status,omitempty"`
 	Title            string            `json:"title,omitempty"`
 	Priority         *APIReference     `json:"priority,omitempty"`
+	Urgency          string            `json:"urgency,omitempty"`
 	Assignments      []Assignee        `json:"assignments,omitempty"`
 	EscalationLevel  uint              `json:"escalation_level,omitempty"`
 	EscalationPolicy *APIReference     `json:"escalation_policy,omitempty"`


### PR DESCRIPTION
This is allowed in the API docs and works in my local testing.

https://developer.pagerduty.com/api-reference/8a0e1aa2ec666-update-an-incident#request-body