### PR TITLE
fix: Support the From header when snoozing an incident

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -540,21 +540,29 @@ func (c *Client) CreateIncidentNote(id string, note IncidentNote) error {
 	return err
 }
 
+type SnoozeIncidentOptions struct {
+	From     string
+	Duration uint
+}
+
 // SnoozeIncidentWithResponse sets an incident to not alert for a specified
 // period of time.
 //
 // Deprecated: Use SnoozeIncidentWithContext instead.
-func (c *Client) SnoozeIncidentWithResponse(id string, duration uint) (*Incident, error) {
-	return c.SnoozeIncidentWithContext(context.Background(), id, duration)
+func (c *Client) SnoozeIncidentWithResponse(id string, o SnoozeIncidentOptions) (*Incident, error) {
+	return c.SnoozeIncidentWithContext(context.Background(), id, o)
 }
 
 // SnoozeIncidentWithContext sets an incident to not alert for a specified period of time.
-func (c *Client) SnoozeIncidentWithContext(ctx context.Context, id string, duration uint) (*Incident, error) {
-	d := map[string]uint{
-		"duration": duration,
+func (c *Client) SnoozeIncidentWithContext(ctx context.Context, id string, o SnoozeIncidentOptions) (*Incident, error) {
+	headers := map[string]string{
+		"From": o.From,
+	}
+	body := map[string]uint{
+		"duration": o.Duration,
 	}
 
-	resp, err := c.post(ctx, "/incidents/"+id+"/snooze", d, nil)
+	resp, err := c.post(ctx, "/incidents/"+id+"/snooze", body, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -570,10 +578,13 @@ func (c *Client) SnoozeIncidentWithContext(ctx context.Context, id string, durat
 // SnoozeIncident sets an incident to not alert for a specified period of time.
 //
 // Deprecated: Use SnoozeIncidentWithContext instead.
-func (c *Client) SnoozeIncident(id string, duration uint) error {
+func (c *Client) SnoozeIncident(id string, o SnoozeIncidentOptions) error {
+	headers := make(map[string]string)
+	headers["From"] = o.From
 	data := make(map[string]uint)
-	data["duration"] = duration
-	_, err := c.post(context.Background(), "/incidents/"+id+"/snooze", data, nil)
+	data["duration"] = o.Duration
+
+	_, err := c.post(context.Background(), "/incidents/"+id+"/snooze", data, headers)
 	return err
 }
 

--- a/incident_test.go
+++ b/incident_test.go
@@ -664,13 +664,18 @@ func TestIncident_SnoozeIncident(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1/snooze", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
+		testEqual(t, r.Header.Get("From"), "from")
+
 		_, _ = w.Write([]byte(`{"incident": {"id": "1", "pending_actions": [{"type": "unacknowledge", "at":"2019-12-31T16:58:35Z"}]}}`))
 	})
 	client := defaultTestClient(server.URL, "foo")
 	var duration uint = 3600
 	id := "1"
 
-	err := client.SnoozeIncident(id, duration)
+	err := client.SnoozeIncident(id, SnoozeIncidentOptions{
+		From:     "from",
+		Duration: duration,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -683,13 +688,18 @@ func TestIncident_SnoozeIncidentWithResponse(t *testing.T) {
 
 	mux.HandleFunc("/incidents/1/snooze", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
+		testEqual(t, r.Header.Get("From"), "from")
+
 		_, _ = w.Write([]byte(`{"incident": {"id": "1", "pending_actions": [{"type": "unacknowledge", "at":"2019-12-31T16:58:35Z"}]}}`))
 	})
 	client := defaultTestClient(server.URL, "foo")
 	var duration uint = 3600
 	id := "1"
 
-	res, err := client.SnoozeIncidentWithResponse(id, duration)
+	res, err := client.SnoozeIncidentWithResponse(id, SnoozeIncidentOptions{
+		From:     "from",
+		Duration: duration,
+	})
 
 	want := &Incident{
 		APIObject: APIObject{


### PR DESCRIPTION
The API docs list From as a required header.

https://developer.pagerduty.com/api-reference/fc871396fb23f-snooze-an-incident#request-headers