### PR TITLE
Fix Jira Cloud accounts mapping Update

### DIFF
--- a/jira_cloud_accounts_mapping.go
+++ b/jira_cloud_accounts_mapping.go
@@ -31,8 +31,8 @@ type PagerDutyAccount struct {
 	Subdomain string `json:"subdomain"`
 }
 
-// JiraCloudAccountsMappingRule configures the bidirectional synchronization between Jira
-// issues and PagerDuty incidents
+// JiraCloudAccountsMappingRule configures the bidirectional synchronization
+// between Jira issues and PagerDuty incidents
 type JiraCloudAccountsMappingRule struct {
 	AccountsMapping             *APIObject                         `json:"account_mapping,omitempty"`
 	AutocreateJqlDisabledReason string                             `json:"autocreate_jql_disabled_reason,omitempty"`
@@ -44,15 +44,14 @@ type JiraCloudAccountsMappingRule struct {
 	UpdatedAt                   string                             `json:"updated_at,omitempty"`
 }
 
-// JiraCloudAccountsMappingRuleConfig is the configuration for bidirectional synchronization
-// between Jira issues and PagerDuty incidents
+// JiraCloudAccountsMappingRuleConfig is the configuration for bidirectional
+// synchronization between Jira issues and PagerDuty incidents
 type JiraCloudAccountsMappingRuleConfig struct {
 	Jira    JiraCloudSettings `json:"jira"`
 	Service APIObject         `json:"service"`
 }
 
-// JiraCloudSettings are settings for the Jira aspect of the
-// synchronization
+// JiraCloudSettings are settings for the Jira aspect of the synchronization
 type JiraCloudSettings struct {
 	AutocreateJQL                *string                `json:"autocreate_jql"`
 	CreateIssueOnIncidentTrigger bool                   `json:"create_issue_on_incident_trigger"`
@@ -246,9 +245,49 @@ func (c *Client) DeleteJiraCloudAccountsMappingRule(ctx context.Context, id, rul
 	return err
 }
 
+// updateJiraCloudAccountsMappingRuleBody is the body for the call to the
+// UpdateJiraCloudAccountsMappingRule API endpoint
+type updateJiraCloudAccountsMappingRuleBody struct {
+	Config updateJiraCloudAccountsMappingRuleConfig `json:"config"`
+	Name   string                                   `json:"name"`
+}
+
+// updateJiraCloudAccountsMappingRuleOptionsConfig is an special representation
+// of a configuration used for updating a rule.
+type updateJiraCloudAccountsMappingRuleConfig struct {
+	Jira updateJiraCloudSettings `json:"jira"`
+}
+
+// updateJiraCloudSettings are settings to update the Jira aspect of the
+// synchronization
+type updateJiraCloudSettings struct {
+	AutocreateJQL                *string                `json:"autocreate_jql"`
+	CreateIssueOnIncidentTrigger bool                   `json:"create_issue_on_incident_trigger"`
+	CustomFields                 []JiraCloudCustomField `json:"custom_fields"`
+	IssueType                    JiraCloudReference     `json:"issue_type"`
+	Priorities                   []JiraCloudPriority    `json:"priorities"`
+	StatusMapping                JiraCloudStatusMapping `json:"status_mapping"`
+	SyncNotesUser                *UserJiraCloud         `json:"sync_notes_user"`
+}
+
 // UpdateJiraCloudAccountsMappingRule updates an existing rule in Jira Cloud's integration
-func (c *Client) UpdateJiraCloudAccountsMappingRule(ctx context.Context, id string, rule JiraCloudAccountsMappingRule) (*JiraCloudAccountsMappingRule, error) {
-	resp, err := c.put(ctx, "/integration-jira-cloud/accounts_mappings/"+id+"/rules/"+rule.ID, rule, nil)
+func (c *Client) UpdateJiraCloudAccountsMappingRule(ctx context.Context, accountMappingID string, rule JiraCloudAccountsMappingRule) (*JiraCloudAccountsMappingRule, error) {
+	o := updateJiraCloudAccountsMappingRuleBody{
+		Config: updateJiraCloudAccountsMappingRuleConfig{
+			Jira: updateJiraCloudSettings{
+				AutocreateJQL:                rule.Config.Jira.AutocreateJQL,
+				CreateIssueOnIncidentTrigger: rule.Config.Jira.CreateIssueOnIncidentTrigger,
+				CustomFields:                 rule.Config.Jira.CustomFields,
+				IssueType:                    rule.Config.Jira.IssueType,
+				Priorities:                   rule.Config.Jira.Priorities,
+				StatusMapping:                rule.Config.Jira.StatusMapping,
+				SyncNotesUser:                rule.Config.Jira.SyncNotesUser,
+			},
+		},
+		Name: rule.Name,
+	}
+
+	resp, err := c.put(ctx, "/integration-jira-cloud/accounts_mappings/"+accountMappingID+"/rules/"+rule.ID, o, nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes the Update call for Jira Cloud's account mapping Rule, because the API expect the body of the PUT method to be different to the body of the Create call (e.g. must not have `.config.service`) but currently they are equal.

## [Create](https://developer.pagerduty.com/api-reference/85dc30ba966a6-create-a-rule):
<img width="780" alt="image" src="https://github.com/user-attachments/assets/1e29fccc-e363-4a8c-a4a9-7ec01450cbc2">

## [Update](https://developer.pagerduty.com/api-reference/bce6c10fa07d7-update-a-rule):
<img width="762" alt="image" src="https://github.com/user-attachments/assets/ff6a6bb3-ef7a-401c-b6a8-56c18e1f0f6e">
