### PR TITLE
fix: return empty list if there are no alertgroupingsettings

### DIFF
--- a/alert_grouping_setting.go
+++ b/alert_grouping_setting.go
@@ -107,6 +107,12 @@ func (c *Client) ListAlertGroupingSettings(ctx context.Context, o ListAlertGroup
 	}
 
 	resp, err := c.get(ctx, "/alert_grouping_settings?"+v.Encode(), nil)
+
+	// If there are no alert grouping settings, return an empty response.
+	if resp.StatusCode == 404 {
+		return &ListAlertGroupingSettingsResponse{}, nil
+	}
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fixes https://github.com/PagerDuty/terraform-provider-pagerduty/issues/944

