### PR TITLE
Add PagerDuty Enablements API support with consistent naming conventions

### DIFF
--- a/enablement_test.go
+++ b/enablement_test.go
@@ -1,0 +1,740 @@
+package pagerduty
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+// Test data for enablements
+var (
+	testEnablementFeatureAIOps = "aiops"
+	testServiceID              = "PABCDEF"
+	testEventOrchestrationID   = "1b49abe7-26db-4439-a715-c6d883acfb3e"
+)
+
+// Mock response data based on API examples
+const (
+	mockServiceEnablementsSuccessResponse = `{
+		"enablements": [
+			{
+				"feature": "aiops",
+				"enabled": true
+			}
+		]
+	}`
+
+	mockServiceEnablementsWithWarningResponse = `{
+		"enablements": [
+			{
+				"feature": "aiops",
+				"enabled": true
+			}
+		],
+		"warnings": ["Your account is not entitled to use AIOps features for this Service."]
+	}`
+
+	mockServiceEnablementsDisabledResponse = `{
+		"enablements": [
+			{
+				"feature": "aiops",
+				"enabled": false
+			}
+		]
+	}`
+
+	mockEventOrchestrationEnablementsSuccessResponse = `{
+		"enablements": [
+			{
+				"feature": "aiops",
+				"enabled": true
+			}
+		]
+	}`
+
+	mockEventOrchestrationEnablementsWithWarningResponse = `{
+		"enablements": [
+			{
+				"feature": "aiops",
+				"enabled": true
+			}
+		],
+		"warnings": ["You can't use AIOps functionality with this Orchestration because your account hasn't purchased AIOps"]
+	}`
+
+	mockUpdateEnablementSuccessResponse = `{
+		"enablement": {
+			"feature": "aiops",
+			"enabled": false
+		}
+	}`
+
+	mockUpdateEnablementEnabledResponse = `{
+		"enablement": {
+			"feature": "aiops",
+			"enabled": true
+		}
+	}`
+
+	mockErrorResponse400 = `{
+		"error": {
+			"code": 2001,
+			"message": "Invalid Input Provided",
+			"errors": ["The feature name 'invalid' is not supported"]
+		}
+	}`
+
+	mockErrorResponse403 = `{
+		"error": {
+			"code": 2003,
+			"message": "Forbidden",
+			"errors": ["You are not authorized to access this resource"]
+		}
+	}`
+
+	mockErrorResponse404 = `{
+		"error": {
+			"code": 2100,
+			"message": "Not Found",
+			"errors": ["The specified service does not exist"]
+		}
+	}`
+
+	mockErrorResponse500 = `{
+		"error": {
+			"code": 3001,
+			"message": "Internal Server Error",
+			"errors": ["An unexpected error occurred"]
+		}
+	}`
+)
+
+// ListServiceEnablements - Success Response
+func TestService_ListEnablements(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockServiceEnablementsSuccessResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListServiceEnablementsWithContext(context.Background(), testServiceID)
+
+	want := []Enablement{
+		{
+			Feature: testEnablementFeatureAIOps,
+			Enabled: true,
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+// ListServiceEnablements - Success Response with Warning (warnings are logged, not returned in result)
+func TestService_ListEnablementsWithWarning(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockServiceEnablementsWithWarningResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListServiceEnablementsWithContext(context.Background(), testServiceID)
+
+	want := []Enablement{
+		{
+			Feature: testEnablementFeatureAIOps,
+			Enabled: true,
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+// ListServiceEnablements - Disabled Response
+func TestService_ListEnablementsDisabled(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockServiceEnablementsDisabledResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListServiceEnablementsWithContext(context.Background(), testServiceID)
+
+	want := []Enablement{
+		{
+			Feature: testEnablementFeatureAIOps,
+			Enabled: false,
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+// ListServiceEnablements - 403 Forbidden Error
+func TestService_ListEnablements403Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(mockErrorResponse403))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.ListServiceEnablementsWithContext(context.Background(), testServiceID)
+
+	if !testErrCheck(t, "ListServiceEnablements", "access forbidden", err) {
+		return
+	}
+}
+
+// ListServiceEnablements - 404 Not Found Error
+func TestService_ListEnablements404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockErrorResponse404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.ListServiceEnablementsWithContext(context.Background(), testServiceID)
+
+	if !testErrCheck(t, "ListServiceEnablements", "not found", err) {
+		return
+	}
+}
+
+// ListServiceEnablements - 500 Internal Server Error
+func TestService_ListEnablements500Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(mockErrorResponse500))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.ListServiceEnablementsWithContext(context.Background(), testServiceID)
+
+	if !testErrCheck(t, "ListServiceEnablements", "server error", err) {
+		return
+	}
+}
+
+// UpdateServiceEnablement - Success Response (Disable)
+func TestService_UpdateEnablement(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockUpdateEnablementSuccessResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.UpdateServiceEnablementWithContext(context.Background(), testServiceID, testEnablementFeatureAIOps, false)
+
+	want := &Enablement{
+		Feature: testEnablementFeatureAIOps,
+		Enabled: false,
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+// UpdateServiceEnablement - Success Response (Enable)
+func TestService_UpdateEnablementEnable(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockUpdateEnablementEnabledResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.UpdateServiceEnablementWithContext(context.Background(), testServiceID, testEnablementFeatureAIOps, true)
+
+	want := &Enablement{
+		Feature: testEnablementFeatureAIOps,
+		Enabled: true,
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+// UpdateServiceEnablement - Invalid Feature Error
+func TestService_UpdateEnablementInvalidFeature(t *testing.T) {
+	setup()
+	defer teardown()
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateServiceEnablementWithContext(context.Background(), testServiceID, "invalid_feature", false)
+
+	if !testErrCheck(t, "UpdateServiceEnablement", "unsupported feature", err) {
+		return
+	}
+}
+
+// UpdateServiceEnablement - Empty Service ID Error
+func TestService_UpdateEnablementEmptyServiceID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateServiceEnablementWithContext(context.Background(), "", testEnablementFeatureAIOps, false)
+
+	if !testErrCheck(t, "UpdateServiceEnablement", "entity ID cannot be empty", err) {
+		return
+	}
+}
+
+// UpdateServiceEnablement - 403 Forbidden Error
+func TestService_UpdateEnablement403Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(mockErrorResponse403))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateServiceEnablementWithContext(context.Background(), testServiceID, testEnablementFeatureAIOps, false)
+
+	if !testErrCheck(t, "UpdateServiceEnablement", "access forbidden", err) {
+		return
+	}
+}
+
+// UpdateServiceEnablement - 404 Not Found Error
+func TestService_UpdateEnablement404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockErrorResponse404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateServiceEnablementWithContext(context.Background(), testServiceID, testEnablementFeatureAIOps, false)
+
+	if !testErrCheck(t, "UpdateServiceEnablement", "not found", err) {
+		return
+	}
+}
+
+// UpdateServiceEnablement - 500 Internal Server Error
+func TestService_UpdateEnablement500Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(mockErrorResponse500))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateServiceEnablementWithContext(context.Background(), testServiceID, testEnablementFeatureAIOps, false)
+
+	if !testErrCheck(t, "UpdateServiceEnablement", "server error", err) {
+		return
+	}
+}
+
+// ListEventOrchestrationEnablements - Success Response
+func TestEventOrchestration_ListEnablements(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockEventOrchestrationEnablementsSuccessResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListEventOrchestrationEnablementsWithContext(context.Background(), testEventOrchestrationID)
+
+	want := []Enablement{
+		{
+			Feature: testEnablementFeatureAIOps,
+			Enabled: true,
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+// ListEventOrchestrationEnablements - Success Response with Warning
+func TestEventOrchestration_ListEnablementsWithWarning(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockEventOrchestrationEnablementsWithWarningResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListEventOrchestrationEnablementsWithContext(context.Background(), testEventOrchestrationID)
+
+	want := []Enablement{
+		{
+			Feature: testEnablementFeatureAIOps,
+			Enabled: true,
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+// ListEventOrchestrationEnablements - 403 Forbidden Error
+func TestEventOrchestration_ListEnablements403Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(mockErrorResponse403))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.ListEventOrchestrationEnablementsWithContext(context.Background(), testEventOrchestrationID)
+
+	if !testErrCheck(t, "ListEventOrchestrationEnablements", "access forbidden", err) {
+		return
+	}
+}
+
+// ListEventOrchestrationEnablements - 404 Not Found Error
+func TestEventOrchestration_ListEnablements404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockErrorResponse404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.ListEventOrchestrationEnablementsWithContext(context.Background(), testEventOrchestrationID)
+
+	if !testErrCheck(t, "ListEventOrchestrationEnablements", "not found", err) {
+		return
+	}
+}
+
+// ListEventOrchestrationEnablements - 500 Internal Server Error
+func TestEventOrchestration_ListEnablements500Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(mockErrorResponse500))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.ListEventOrchestrationEnablementsWithContext(context.Background(), testEventOrchestrationID)
+
+	if !testErrCheck(t, "ListEventOrchestrationEnablements", "server error", err) {
+		return
+	}
+}
+
+// UpdateEventOrchestrationEnablement - Success Response
+func TestEventOrchestration_UpdateEnablement(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockUpdateEnablementSuccessResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.UpdateEventOrchestrationEnablementWithContext(context.Background(), testEventOrchestrationID, testEnablementFeatureAIOps, false)
+
+	want := &Enablement{
+		Feature: testEnablementFeatureAIOps,
+		Enabled: false,
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+// UpdateEventOrchestrationEnablement - Success Response (Enable)
+func TestEventOrchestration_UpdateEnablementEnable(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockUpdateEnablementEnabledResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.UpdateEventOrchestrationEnablementWithContext(context.Background(), testEventOrchestrationID, testEnablementFeatureAIOps, true)
+
+	want := &Enablement{
+		Feature: testEnablementFeatureAIOps,
+		Enabled: true,
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+// UpdateEventOrchestrationEnablement - Invalid Feature Error
+func TestEventOrchestration_UpdateEnablementInvalidFeature(t *testing.T) {
+	setup()
+	defer teardown()
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateEventOrchestrationEnablementWithContext(context.Background(), testEventOrchestrationID, "invalid_feature", false)
+
+	if !testErrCheck(t, "UpdateEventOrchestrationEnablement", "unsupported feature", err) {
+		return
+	}
+}
+
+// UpdateEventOrchestrationEnablement - Empty Orchestration ID Error
+func TestEventOrchestration_UpdateEnablementEmptyOrchestrationID(t *testing.T) {
+	setup()
+	defer teardown()
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateEventOrchestrationEnablementWithContext(context.Background(), "", testEnablementFeatureAIOps, false)
+
+	if !testErrCheck(t, "UpdateEventOrchestrationEnablement", "entity ID cannot be empty", err) {
+		return
+	}
+}
+
+// UpdateEventOrchestrationEnablement - 403 Forbidden Error
+func TestEventOrchestration_UpdateEnablement403Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(mockErrorResponse403))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateEventOrchestrationEnablementWithContext(context.Background(), testEventOrchestrationID, testEnablementFeatureAIOps, false)
+
+	if !testErrCheck(t, "UpdateEventOrchestrationEnablement", "access forbidden", err) {
+		return
+	}
+}
+
+// UpdateEventOrchestrationEnablement - 404 Not Found Error
+func TestEventOrchestration_UpdateEnablement404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockErrorResponse404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateEventOrchestrationEnablementWithContext(context.Background(), testEventOrchestrationID, testEnablementFeatureAIOps, false)
+
+	if !testErrCheck(t, "UpdateEventOrchestrationEnablement", "not found", err) {
+		return
+	}
+}
+
+// UpdateEventOrchestrationEnablement - 500 Internal Server Error
+func TestEventOrchestration_UpdateEnablement500Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(mockErrorResponse500))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateEventOrchestrationEnablementWithContext(context.Background(), testEventOrchestrationID, testEnablementFeatureAIOps, false)
+
+	if !testErrCheck(t, "UpdateEventOrchestrationEnablement", "server error", err) {
+		return
+	}
+}
+
+// Context-based tests
+func TestService_ListEnablementsWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockServiceEnablementsSuccessResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListServiceEnablementsWithContext(context.Background(), testServiceID)
+
+	want := []Enablement{
+		{
+			Feature: testEnablementFeatureAIOps,
+			Enabled: true,
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+func TestService_UpdateEnablementWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/services/"+testServiceID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockUpdateEnablementSuccessResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.UpdateServiceEnablementWithContext(context.Background(), testServiceID, testEnablementFeatureAIOps, false)
+
+	want := &Enablement{
+		Feature: testEnablementFeatureAIOps,
+		Enabled: false,
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+func TestEventOrchestration_ListEnablementsWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockEventOrchestrationEnablementsSuccessResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListEventOrchestrationEnablementsWithContext(context.Background(), testEventOrchestrationID)
+
+	want := []Enablement{
+		{
+			Feature: testEnablementFeatureAIOps,
+			Enabled: true,
+		},
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+func TestEventOrchestration_UpdateEnablementWithContext(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/event_orchestrations/"+testEventOrchestrationID+"/enablements/"+testEnablementFeatureAIOps, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockUpdateEnablementSuccessResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.UpdateEventOrchestrationEnablementWithContext(context.Background(), testEventOrchestrationID, testEnablementFeatureAIOps, false)
+
+	want := &Enablement{
+		Feature: testEnablementFeatureAIOps,
+		Enabled: false,
+	}
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	testEqual(t, want, res)
+}
+
+

--- a/enablements.go
+++ b/enablements.go
@@ -1,0 +1,301 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+)
+
+// Enablement represents a feature enablement for a PagerDuty entity
+type Enablement struct {
+	Feature string `json:"feature,omitempty"`
+	Enabled bool   `json:"enabled"`
+}
+
+// EnablementRequest represents a request to update an enablement
+type EnablementRequest struct {
+	Enablement Enablement `json:"enablement"`
+}
+
+// EnablementResponse represents the response from an enablement API call
+type EnablementResponse struct {
+	Enablement Enablement `json:"enablement"`
+}
+
+// ListEnablementsResponse represents the response from listing enablements
+type ListEnablementsResponse struct {
+	Enablements []Enablement `json:"enablements,omitempty"`
+	Warnings    []string     `json:"warnings,omitempty"`
+}
+
+// validateEntityID validates that the entity ID is not empty
+func validateEntityID(entityID string) error {
+	if strings.TrimSpace(entityID) == "" {
+		return fmt.Errorf("entity ID cannot be empty")
+	}
+	return nil
+}
+
+// validateFeatureName validates the feature name
+func validateFeatureName(feature string) error {
+	if strings.TrimSpace(feature) == "" {
+		return fmt.Errorf("feature name cannot be empty")
+	}
+
+	// Currently only "aiops" is supported
+	validFeatures := []string{"aiops"}
+	for _, validFeature := range validFeatures {
+		if strings.ToLower(strings.TrimSpace(feature)) == validFeature {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unsupported feature: %s. Supported features: %s",
+		feature, strings.Join(validFeatures, ", "))
+}
+
+// validateEntityType validates the entity type
+func validateEntityType(entityType string) error {
+	if strings.TrimSpace(entityType) == "" {
+		return fmt.Errorf("entity type cannot be empty")
+	}
+
+	validTypes := []string{"service", "event_orchestration"}
+	for _, validType := range validTypes {
+		if strings.ToLower(strings.TrimSpace(entityType)) == validType {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unsupported entity type: %s. Supported types: %s",
+		entityType, strings.Join(validTypes, ", "))
+}
+
+// validateEnablementRequest validates the enablement request structure
+func validateEnablementRequest(req *EnablementRequest) error {
+	if req == nil {
+		return fmt.Errorf("enablement request cannot be nil")
+	}
+
+	return validateFeatureName(req.Enablement.Feature)
+}
+
+// handleAPIWarnings logs warnings from API responses without treating them as errors
+func handleAPIWarnings(warnings []string) {
+	if len(warnings) > 0 {
+		for _, warning := range warnings {
+			log.Printf("[WARN] PagerDuty API warning: %s", warning)
+		}
+	}
+}
+
+// getEnablementPath constructs the API path for enablements based on entity type
+func getEnablementPath(entityType, entityID string) (string, error) {
+	if err := validateEntityType(entityType); err != nil {
+		return "", err
+	}
+	if err := validateEntityID(entityID); err != nil {
+		return "", err
+	}
+
+	switch strings.ToLower(strings.TrimSpace(entityType)) {
+	case "service":
+		return fmt.Sprintf("/services/%s/enablements", entityID), nil
+	case "event_orchestration":
+		return fmt.Sprintf("/event_orchestrations/%s/enablements", entityID), nil
+	default:
+		return "", fmt.Errorf("unsupported entity type: %s", entityType)
+	}
+}
+
+// getEnablementFeaturePath constructs the API path for a specific enablement feature
+func getEnablementFeaturePath(entityType, entityID, feature string) (string, error) {
+	basePath, err := getEnablementPath(entityType, entityID)
+	if err != nil {
+		return "", err
+	}
+
+	if err := validateFeatureName(feature); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s/%s", basePath, strings.ToLower(strings.TrimSpace(feature))), nil
+}
+
+// handleEnablementError provides enhanced error handling for enablement-specific scenarios
+func handleEnablementError(err error, operation, entityType, entityID string) error {
+	if err == nil {
+		return nil
+	}
+
+	// Check if it's an APIError for more specific handling
+	if apiErr, ok := err.(APIError); ok {
+		switch apiErr.StatusCode {
+		case http.StatusBadRequest:
+			return fmt.Errorf("bad request when %s enablement for %s %s: %w",
+				operation, entityType, entityID, err)
+		case http.StatusForbidden:
+			return fmt.Errorf("access forbidden when %s enablement for %s %s (check permissions and account entitlements): %w",
+				operation, entityType, entityID, err)
+		case http.StatusNotFound:
+			return fmt.Errorf("%s %s not found when %s enablement: %w",
+				entityType, entityID, operation, err)
+		case http.StatusTooManyRequests:
+			return fmt.Errorf("rate limited when %s enablement for %s %s (retry after rate limit reset): %w",
+				operation, entityType, entityID, err)
+		case http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+			return fmt.Errorf("server error when %s enablement for %s %s (temporary issue, retry recommended): %w",
+				operation, entityType, entityID, err)
+		default:
+			return fmt.Errorf("API error when %s enablement for %s %s: %w",
+				operation, entityType, entityID, err)
+		}
+	}
+
+	// Handle network and other errors
+	if strings.Contains(err.Error(), "connection") || strings.Contains(err.Error(), "timeout") {
+		return fmt.Errorf("network error when %s enablement for %s %s (check connectivity): %w",
+			operation, entityType, entityID, err)
+	}
+
+	if strings.Contains(err.Error(), "JSON") || strings.Contains(err.Error(), "unmarshal") {
+		return fmt.Errorf("JSON parsing error when %s enablement for %s %s (malformed API response): %w",
+			operation, entityType, entityID, err)
+	}
+
+	// Generic error handling
+	return fmt.Errorf("error when %s enablement for %s %s: %w",
+		operation, entityType, entityID, err)
+}
+
+// getEnablementsFromResponse processes the response from list enablements API
+func getEnablementsFromResponse(c *Client, resp *http.Response, err error, entityType, entityID string) ([]Enablement, error) {
+	if err != nil {
+		return nil, handleEnablementError(err, "listing", entityType, entityID)
+	}
+
+	var target ListEnablementsResponse
+	if dErr := c.decodeJSON(resp, &target); dErr != nil {
+		return nil, handleEnablementError(
+			fmt.Errorf("could not decode JSON response: %w", dErr),
+			"listing", entityType, entityID)
+	}
+
+	// Handle warnings without failing the operation
+	handleAPIWarnings(target.Warnings)
+
+	return target.Enablements, nil
+}
+
+// getEnablementFromResponse processes the response from update enablement API
+func getEnablementFromResponse(c *Client, resp *http.Response, err error, entityType, entityID, feature string) (*Enablement, error) {
+	if err != nil {
+		return nil, handleEnablementError(err, "updating", entityType, entityID)
+	}
+
+	var target EnablementResponse
+	if dErr := c.decodeJSON(resp, &target); dErr != nil {
+		return nil, handleEnablementError(
+			fmt.Errorf("could not decode JSON response: %w", dErr),
+			"updating", entityType, entityID)
+	}
+
+	return &target.Enablement, nil
+}
+
+
+// ListServiceEnablementsWithContext lists all enablements for a service.
+func (c *Client) ListServiceEnablementsWithContext(ctx context.Context, serviceID string) ([]Enablement, error) {
+	if err := validateEntityID(serviceID); err != nil {
+		return nil, handleEnablementError(err, "listing", "service", serviceID)
+	}
+
+	path, err := getEnablementPath("service", serviceID)
+	if err != nil {
+		return nil, handleEnablementError(err, "listing", "service", serviceID)
+	}
+
+	resp, err := c.get(ctx, path, nil)
+	return getEnablementsFromResponse(c, resp, err, "service", serviceID)
+}
+
+
+// ListEventOrchestrationEnablementsWithContext lists all enablements for an event orchestration.
+func (c *Client) ListEventOrchestrationEnablementsWithContext(ctx context.Context, orchestrationID string) ([]Enablement, error) {
+	if err := validateEntityID(orchestrationID); err != nil {
+		return nil, handleEnablementError(err, "listing", "event_orchestration", orchestrationID)
+	}
+
+	path, err := getEnablementPath("event_orchestration", orchestrationID)
+	if err != nil {
+		return nil, handleEnablementError(err, "listing", "event_orchestration", orchestrationID)
+	}
+
+	resp, err := c.get(ctx, path, nil)
+	return getEnablementsFromResponse(c, resp, err, "event_orchestration", orchestrationID)
+}
+
+
+// UpdateServiceEnablementWithContext updates a specific enablement for a service.
+func (c *Client) UpdateServiceEnablementWithContext(ctx context.Context, serviceID, feature string, enabled bool) (*Enablement, error) {
+	if err := validateEntityID(serviceID); err != nil {
+		return nil, handleEnablementError(err, "updating", "service", serviceID)
+	}
+
+	if err := validateFeatureName(feature); err != nil {
+		return nil, handleEnablementError(err, "updating", "service", serviceID)
+	}
+
+	path, err := getEnablementFeaturePath("service", serviceID, feature)
+	if err != nil {
+		return nil, handleEnablementError(err, "updating", "service", serviceID)
+	}
+
+	req := EnablementRequest{
+		Enablement: Enablement{
+			Feature: feature,
+			Enabled: enabled,
+		},
+	}
+
+	if err := validateEnablementRequest(&req); err != nil {
+		return nil, handleEnablementError(err, "updating", "service", serviceID)
+	}
+
+	resp, err := c.put(ctx, path, req, nil)
+	return getEnablementFromResponse(c, resp, err, "service", serviceID, feature)
+}
+
+
+// UpdateEventOrchestrationEnablementWithContext updates a specific enablement for an event orchestration.
+func (c *Client) UpdateEventOrchestrationEnablementWithContext(ctx context.Context, orchestrationID, feature string, enabled bool) (*Enablement, error) {
+	if err := validateEntityID(orchestrationID); err != nil {
+		return nil, handleEnablementError(err, "updating", "event_orchestration", orchestrationID)
+	}
+
+	if err := validateFeatureName(feature); err != nil {
+		return nil, handleEnablementError(err, "updating", "event_orchestration", orchestrationID)
+	}
+
+	path, err := getEnablementFeaturePath("event_orchestration", orchestrationID, feature)
+	if err != nil {
+		return nil, handleEnablementError(err, "updating", "event_orchestration", orchestrationID)
+	}
+
+	req := EnablementRequest{
+		Enablement: Enablement{
+			Feature: feature,
+			Enabled: enabled,
+		},
+	}
+
+	if err := validateEnablementRequest(&req); err != nil {
+		return nil, handleEnablementError(err, "updating", "event_orchestration", orchestrationID)
+	}
+
+	resp, err := c.put(ctx, path, req, nil)
+	return getEnablementFromResponse(c, resp, err, "event_orchestration", orchestrationID, feature)
+}
+


### PR DESCRIPTION
 API Endpoints Supported

  - GET /services/{id}/enablements - List service enablements
  - PUT /services/{id}/enablements/{feature} - Update service enablement
  - GET /event_orchestrations/{id}/enablements - List event orchestration enablements
  - PUT /event_orchestrations/{id}/enablements/{feature} - Update event orchestration enablement