### PR TITLE
Add device_type to Contact Method

### DIFF
--- a/user.go
+++ b/user.go
@@ -52,6 +52,7 @@ type ContactMethod struct {
 	Blacklisted    bool   `json:"blacklisted,omitempty"`
 	CountryCode    int    `json:"country_code,omitempty"`
 	Enabled        bool   `json:"enabled,omitempty"`
+	DeviceType     string `json:"device_type,omitempty"`
 }
 
 // OncallHandoffNotificationRule is a handoff notification rule


### PR DESCRIPTION
Required for creation of PushContactMethods

`Error: POST API call to https://api.pagerduty.com/users/P123456/contact_methods failed 400 Bad Request. Code: 2001, Errors: [Device type can't be blank Device type is not included in the list]`