### PR TITLE
Fix version flag to use git tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 
 .PHONY: build
 build: build-deps
-	go build -mod=vendor -o pd ./command
+	go build -mod=vendor -ldflags "-X main.version=$$(git describe --tags --abbrev=0)" -o pd ./command
 
 .PHONY: build-deps
 build-deps:

--- a/command/main.go
+++ b/command/main.go
@@ -7,9 +7,7 @@ import (
 	"github.com/mitchellh/cli"
 )
 
-const (
-	version = "0.0.0"
-)
+var version = "0.0.0"
 
 func loadCommands() map[string]cli.CommandFactory {
 	return map[string]cli.CommandFactory{


### PR DESCRIPTION
May be intentional but `pd --version` will always return `0.0.0.` as `version` is a constant not a var.