### PR TITLE
auth: add support for Classic and Scoped OAuth

### DIFF
--- a/command/auth.go
+++ b/command/auth.go
@@ -1,0 +1,322 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/mitchellh/cli"
+	"github.com/mitchellh/go-homedir"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/oauth2"
+)
+
+// OAuth endpoints for Classic and Scoped OAuth apps
+const (
+	// Classic OAuth endpoints (app.pagerduty.com)
+	classicAuthURL  = "https://app.pagerduty.com/oauth/authorize"
+	classicTokenURL = "https://app.pagerduty.com/oauth/token"
+
+	// Scoped OAuth endpoints (identity.pagerduty.com)
+	scopedAuthURL  = "https://identity.pagerduty.com/oauth/authorize"
+	scopedTokenURL = "https://identity.pagerduty.com/oauth/token"
+)
+
+// getOAuthEndpoints returns the appropriate auth and token URLs for the given OAuth type
+func getOAuthEndpoints(oauthType OAuthType) (authURL, tokenURL string) {
+	switch oauthType {
+	case OAuthTypeScoped:
+		return scopedAuthURL, scopedTokenURL
+	default:
+		return classicAuthURL, classicTokenURL
+	}
+}
+
+type AuthLoginCommand struct {
+	Meta
+}
+
+func NewAuthLoginCommand() (cli.Command, error) {
+	return &AuthLoginCommand{}, nil
+}
+
+func (c *AuthLoginCommand) Help() string {
+	helpText := `
+Usage: pd auth login [options]
+
+	Authenticate with PagerDuty using OAuth. Opens a browser for you to log in
+	and authorize the application.
+
+Options:
+
+	-client-id      OAuth client ID (required)
+	-client-secret  OAuth client secret (required)
+	-scope          OAuth scope (can be specified multiple times)
+	-token-file     Path to store OAuth token (defaults to ~/.pd-token.json)
+	-port           Local port for OAuth callback (default: 8080)
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *AuthLoginCommand) Synopsis() string {
+	return "Authenticate with PagerDuty using OAuth"
+}
+
+func (c *AuthLoginCommand) Run(args []string) int {
+	var port int
+	flags := c.Meta.FlagSet("auth login")
+	flags.IntVar(&port, "port", 8080, "Local port for OAuth callback")
+	if err := flags.Parse(args); err != nil {
+		log.Error(err)
+		return 1
+	}
+
+	if err := c.Meta.loadConfig(); err != nil {
+		log.Debug(err)
+	}
+
+	if c.Meta.ClientID == "" || c.Meta.ClientSecret == "" {
+		log.Error("OAuth client-id and client-secret are required")
+		return 1
+	}
+
+	if len(c.Meta.Scopes) == 0 {
+		log.Error("At least one OAuth scope is required")
+		return 1
+	}
+
+	tokenFile := c.Meta.TokenFile
+	if tokenFile == "" {
+		path, err := homedir.Dir()
+		if err != nil {
+			log.Warnf("Failed to get home directory: %v, using current directory", err)
+			tokenFile = ".pd-token.json"
+		} else {
+			tokenFile = filepath.Join(path, ".pd-token.json")
+		}
+	}
+
+	redirectURL := fmt.Sprintf("http://localhost:%d/callback", port)
+
+	authURL, tokenURL := getOAuthEndpoints(c.Meta.OAuthType)
+	config := &oauth2.Config{
+		ClientID:     c.Meta.ClientID,
+		ClientSecret: c.Meta.ClientSecret,
+		Scopes:       c.Meta.Scopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   authURL,
+			TokenURL:  tokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+		RedirectURL: redirectURL,
+	}
+
+	codeChan := make(chan string, 1)
+	errChan := make(chan error, 1)
+
+	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	if err != nil {
+		log.Errorf("Failed to start local server: %v", err)
+		return 1
+	}
+
+	server := &http.Server{
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	http.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
+		code := r.URL.Query().Get("code")
+		if code == "" {
+			errMsg := r.URL.Query().Get("error")
+			errDesc := r.URL.Query().Get("error_description")
+			if errMsg != "" {
+				errChan <- fmt.Errorf("OAuth error: %s - %s", errMsg, errDesc)
+			} else {
+				errChan <- fmt.Errorf("no authorization code received")
+			}
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintf(w, "<html><body><h1>Authentication Failed</h1><p>You can close this window.</p></body></html>")
+			return
+		}
+
+		codeChan <- code
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, "<html><body><h1>Authentication Successful!</h1><p>You can close this window and return to the terminal.</p></body></html>")
+	})
+
+	go func() {
+		if err := server.Serve(listener); err != http.ErrServerClosed {
+			errChan <- fmt.Errorf("server error: %v", err)
+		}
+	}()
+
+	state := fmt.Sprintf("%d", time.Now().UnixNano())
+	authorizeURL := config.AuthCodeURL(state)
+
+	fmt.Printf("Opening browser for authentication...\n")
+	fmt.Printf("If the browser doesn't open, visit this URL:\n%s\n\n", authorizeURL)
+
+	if err := openBrowser(authorizeURL); err != nil {
+		log.Warnf("Failed to open browser: %v", err)
+	}
+
+	fmt.Println("Waiting for authentication...")
+
+	var code string
+	select {
+	case code = <-codeChan:
+	case err := <-errChan:
+		log.Error(err)
+		server.Close()
+		return 1
+	case <-time.After(5 * time.Minute):
+		log.Error("Authentication timed out")
+		server.Close()
+		return 1
+	}
+
+	server.Close()
+
+	ctx := context.Background()
+	token, err := config.Exchange(ctx, code)
+	if err != nil {
+		log.Errorf("Failed to exchange code for token: %v", err)
+		return 1
+	}
+
+	if err := saveAuthToken(tokenFile, token, c.Meta.ClientID, c.Meta.Scopes); err != nil {
+		log.Errorf("Failed to save token: %v", err)
+		return 1
+	}
+
+	fmt.Printf("\nAuthentication successful! Token saved to %s\n", tokenFile)
+	return 0
+}
+
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("cmd", "/c", "start", url)
+	default:
+		return fmt.Errorf("unsupported platform")
+	}
+	return cmd.Start()
+}
+
+// AuthToken extends oauth2.Token with metadata for validation
+type AuthToken struct {
+	*oauth2.Token
+	ClientID string   `json:"client_id"`
+	Scopes   []string `json:"scopes"`
+}
+
+func saveAuthToken(path string, token *oauth2.Token, clientID string, scopes []string) error {
+	authToken := AuthToken{
+		Token:    token,
+		ClientID: clientID,
+		Scopes:   scopes,
+	}
+
+	data, err := json.MarshalIndent(authToken, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal token: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("failed to write token file: %w", err)
+	}
+
+	return nil
+}
+
+func loadAuthToken(path string) (*AuthToken, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var token AuthToken
+	if err := json.Unmarshal(data, &token); err != nil {
+		return nil, fmt.Errorf("failed to parse token file: %w", err)
+	}
+
+	return &token, nil
+}
+
+// authCodeTokenSource implements oauth2.TokenSource for Authorization Code flow
+// with automatic token refresh and file persistence.
+type authCodeTokenSource struct {
+	config       *oauth2.Config
+	tokenFile    string
+	clientID     string
+	scopes       []string
+	currentToken *oauth2.Token
+}
+
+// NewAuthCodeTokenSource creates a token source that loads tokens from file
+// and refreshes them automatically using the refresh token.
+func NewAuthCodeTokenSource(oauthType OAuthType, clientID, clientSecret string, scopes []string, tokenFile string) (oauth2.TokenSource, error) {
+	authURL, tokenURL := getOAuthEndpoints(oauthType)
+	config := &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Scopes:       scopes,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:   authURL,
+			TokenURL:  tokenURL,
+			AuthStyle: oauth2.AuthStyleInParams,
+		},
+	}
+
+	ts := &authCodeTokenSource{
+		config:    config,
+		tokenFile: tokenFile,
+		clientID:  clientID,
+		scopes:    scopes,
+	}
+
+	authToken, err := loadAuthToken(tokenFile)
+	if err != nil {
+		return nil, fmt.Errorf("no valid token found, run 'pd auth login' first: %w", err)
+	}
+
+	if authToken.ClientID != clientID {
+		return nil, fmt.Errorf("token was created with different client ID, run 'pd auth login' again")
+	}
+
+	ts.currentToken = authToken.Token
+
+	return oauth2.ReuseTokenSource(ts.currentToken, ts), nil
+}
+
+func (ts *authCodeTokenSource) Token() (*oauth2.Token, error) {
+	if ts.currentToken.RefreshToken == "" {
+		return nil, fmt.Errorf("no refresh token available, run 'pd auth login' again")
+	}
+
+	ctx := context.Background()
+	newToken, err := ts.config.TokenSource(ctx, ts.currentToken).Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to refresh token: %w (run 'pd auth login' to re-authenticate)", err)
+	}
+
+	if err := saveAuthToken(ts.tokenFile, newToken, ts.clientID, ts.scopes); err != nil {
+		log.Warnf("Failed to save refreshed token: %v", err)
+	}
+
+	ts.currentToken = newToken
+	return newToken, nil
+}

--- a/command/auth_test.go
+++ b/command/auth_test.go
@@ -1,0 +1,43 @@
+package main
+
+import "testing"
+
+func TestGetOAuthEndpoints(t *testing.T) {
+	tests := []struct {
+		name      string
+		oauthType OAuthType
+		wantAuth  string
+		wantToken string
+	}{
+		{
+			name:      "classic",
+			oauthType: OAuthTypeClassic,
+			wantAuth:  classicAuthURL,
+			wantToken: classicTokenURL,
+		},
+		{
+			name:      "scoped",
+			oauthType: OAuthTypeScoped,
+			wantAuth:  scopedAuthURL,
+			wantToken: scopedTokenURL,
+		},
+		{
+			name:      "default",
+			oauthType: "",
+			wantAuth:  classicAuthURL,
+			wantToken: classicTokenURL,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAuth, gotToken := getOAuthEndpoints(tt.oauthType)
+			if gotAuth != tt.wantAuth {
+				t.Errorf("auth URL = %q, want %q", gotAuth, tt.wantAuth)
+			}
+			if gotToken != tt.wantToken {
+				t.Errorf("token URL = %q, want %q", gotToken, tt.wantToken)
+			}
+		})
+	}
+}

--- a/command/meta.go
+++ b/command/meta.go
@@ -3,13 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
@@ -28,9 +27,25 @@ func (a *ArrayFlags) Set(v string) error {
 	return nil
 }
 
+// OAuthType represents the type of OAuth app being used
+type OAuthType string
+
+const (
+	// OAuthTypeClassic uses broad read/write scopes via app.pagerduty.com
+	OAuthTypeClassic OAuthType = "classic"
+
+	// OAuthTypeScoped uses granular scopes via identity.pagerduty.com
+	OAuthTypeScoped OAuthType = "scoped"
+)
+
 type Meta struct {
-	Authtoken string
-	Loglevel  string
+	Authtoken    string
+	Loglevel     string
+	OAuthType    OAuthType  `yaml:"oauth_type"`
+	ClientID     string     `yaml:"client_id"`
+	ClientSecret string     `yaml:"client_secret"`
+	Scopes       ArrayFlags `yaml:"scopes"`
+	TokenFile    string     `yaml:"token_file"`
 }
 
 type FlagSetFlags uint
@@ -39,27 +54,128 @@ func (m *Meta) FlagSet(n string) *flag.FlagSet {
 	f := flag.NewFlagSet(n, flag.ContinueOnError)
 	f.StringVar(&m.Authtoken, "authtoken", "", "PagerDuty API authentication token")
 	f.StringVar(&m.Loglevel, "loglevel", "", "Logging level")
+	f.StringVar((*string)(&m.OAuthType), "oauth-type", "", "OAuth app type: 'classic' or 'scoped'")
+	f.StringVar(&m.ClientID, "client-id", "", "OAuth client ID")
+	f.StringVar(&m.ClientSecret, "client-secret", "", "OAuth client secret")
+	f.Var(&m.Scopes, "scope", "OAuth scope (can be specified multiple times)")
+	f.StringVar(&m.TokenFile, "token-file", "", "Path to store OAuth token (defaults to ~/.pd-token.json)")
 	return f
 }
 
 func (m *Meta) Client() *pagerduty.Client {
+	if m.useOAuth() {
+		tokenFile := m.getTokenFilePath()
+
+		tokenSource, err := NewAuthCodeTokenSource(m.OAuthType, m.ClientID, m.ClientSecret, m.Scopes, tokenFile)
+		if err != nil {
+			log.Fatalf("OAuth error: %v", err)
+		}
+
+		// Use appropriate client option based on OAuth type
+		switch m.OAuthType {
+		case OAuthTypeScoped:
+			return pagerduty.NewClient("", pagerduty.WithScopedOAuthAppTokenSource(tokenSource))
+		default:
+			// Classic OAuth - token is already obtained, use it directly
+			return pagerduty.NewClient("", pagerduty.WithScopedOAuthAppTokenSource(tokenSource))
+		}
+	}
 	return pagerduty.NewClient(m.Authtoken)
+}
+
+func (m *Meta) getTokenFilePath() string {
+	if m.TokenFile != "" {
+		return m.TokenFile
+	}
+	path, err := homedir.Dir()
+	if err != nil {
+		log.Warnf("Failed to get home directory: %v, using current directory for token file", err)
+		return ".pd-token.json"
+	}
+	return filepath.Join(path, ".pd-token.json")
+}
+
+func (m *Meta) useOAuth() bool {
+	return m.OAuthType != "" && m.ClientID != "" && m.ClientSecret != "" && len(m.Scopes) > 0
 }
 
 func (m *Meta) Help() string {
 	helpText := `
 	Common options:
 
-	-authtoken PagerDuty API authentication token
-	-loglevel Logging level
+	-authtoken      PagerDuty API authentication token
+	-loglevel       Logging level
+
+	OAuth options (alternative to -authtoken):
+
+	-oauth-type     OAuth app type: 'classic' or 'scoped'
+	                  classic: uses broad read/write scopes
+	                  scoped:  uses granular resource-based scopes
+	-client-id      OAuth client ID
+	-client-secret  OAuth client secret
+	-scope          OAuth scope (can be specified multiple times)
+	                  Classic scopes: read, write
+	                  Scoped scopes:  incidents.read, services.write, etc.
+	-token-file     Path to store OAuth token (defaults to ~/.pd-token.json)
 `
 	return strings.TrimSpace(helpText)
 }
 
 func (m *Meta) validate() error {
-	if m.Authtoken == "" {
-		return fmt.Errorf("Authtoken can not be blank")
+	hasAuthtoken := m.Authtoken != ""
+	hasOAuth := m.useOAuth()
+	hasPartialOAuth := (m.ClientID != "" || m.ClientSecret != "" || len(m.Scopes) > 0 || m.OAuthType != "") && !hasOAuth
+
+	if hasPartialOAuth {
+		var missing []string
+		if m.OAuthType == "" {
+			missing = append(missing, "-oauth-type")
+		}
+		if m.ClientID == "" {
+			missing = append(missing, "-client-id")
+		}
+		if m.ClientSecret == "" {
+			missing = append(missing, "-client-secret")
+		}
+		if len(m.Scopes) == 0 {
+			missing = append(missing, "-scope")
+		}
+		return fmt.Errorf("incomplete OAuth configuration, missing: %s", strings.Join(missing, ", "))
 	}
+
+	if !hasAuthtoken && !hasOAuth {
+		return fmt.Errorf("authentication required: provide either -authtoken or OAuth credentials (-oauth-type, -client-id, -client-secret, -scope)")
+	}
+
+	// Validate OAuth type
+	if hasOAuth {
+		if m.OAuthType != OAuthTypeClassic && m.OAuthType != OAuthTypeScoped {
+			return fmt.Errorf("invalid oauth-type %q: must be 'classic' or 'scoped'", m.OAuthType)
+		}
+
+		// Validate scopes match OAuth type
+		if err := m.validateScopes(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *Meta) validateScopes() error {
+	scopes := []string(m.Scopes)
+
+	switch m.OAuthType {
+	case OAuthTypeClassic:
+		if err := pagerduty.ValidateClassicScopes(scopes); err != nil {
+			return fmt.Errorf("scope validation failed: %w", err)
+		}
+	case OAuthTypeScoped:
+		if err := pagerduty.ValidateScopedOAuthScopes(scopes); err != nil {
+			return fmt.Errorf("scope validation failed: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -94,7 +210,7 @@ func (m *Meta) loadConfig() error {
 	if _, err := os.Stat(configFile); err != nil {
 		return err
 	}
-	data, err := ioutil.ReadFile(configFile)
+	data, err := os.ReadFile(configFile)
 	if err != nil {
 		return err
 	}
@@ -107,6 +223,21 @@ func (m *Meta) loadConfig() error {
 	}
 	if m.Loglevel == "" {
 		m.Loglevel = other.Loglevel
+	}
+	if m.OAuthType == "" {
+		m.OAuthType = other.OAuthType
+	}
+	if m.ClientID == "" {
+		m.ClientID = other.ClientID
+	}
+	if m.ClientSecret == "" {
+		m.ClientSecret = other.ClientSecret
+	}
+	if len(m.Scopes) == 0 {
+		m.Scopes = other.Scopes
+	}
+	if m.TokenFile == "" {
+		m.TokenFile = other.TokenFile
 	}
 	return nil
 }

--- a/oauth_scopes.go
+++ b/oauth_scopes.go
@@ -1,0 +1,85 @@
+package pagerduty
+
+import "strings"
+
+// ClassicScope represents scopes for Classic OAuth apps.
+// Classic OAuth only supports two broad permission levels: read and write.
+// These scopes grant access to all resources the authenticated user can access.
+type ClassicScope string
+
+const (
+	// ClassicScopeRead grants read access to all resources the user can access.
+	ClassicScopeRead ClassicScope = "read"
+
+	// ClassicScopeWrite grants write access to all resources the user can modify.
+	ClassicScopeWrite ClassicScope = "write"
+)
+
+// String returns the string representation of the ClassicScope.
+func (s ClassicScope) String() string {
+	return string(s)
+}
+
+// ClassicScopesToStrings converts a slice of ClassicScope to []string for oauth2 compatibility.
+func ClassicScopesToStrings(scopes []ClassicScope) []string {
+	result := make([]string, len(scopes))
+	for i, s := range scopes {
+		result[i] = s.String()
+	}
+	return result
+}
+
+// ValidateClassicScopes checks if the provided string scopes are valid Classic OAuth scopes.
+// Returns an error if any scope is not "read" or "write".
+func ValidateClassicScopes(scopes []string) error {
+	for _, s := range scopes {
+		switch s {
+		case "read", "write":
+		default:
+			return &InvalidScopeError{
+				Scope:     s,
+				OAuthType: "Classic",
+				Hint:      "Classic OAuth only supports 'read' and 'write' scopes",
+			}
+		}
+	}
+	return nil
+}
+
+// ValidateScopedOAuthScopes checks if the provided scopes are valid for Scoped OAuth.
+// Returns an error if a classic scope ("read" or "write") is detected.
+func ValidateScopedOAuthScopes(scopes []string) error {
+	for _, s := range scopes {
+		if s == "read" || s == "write" {
+			return &InvalidScopeError{
+				Scope:     s,
+				OAuthType: "Scoped",
+				Hint:      "Use granular scopes like 'incidents.read' or 'services.write' for Scoped OAuth apps",
+			}
+		}
+
+		if strings.HasPrefix(s, "as_account-") {
+			continue
+		}
+
+		if !strings.Contains(s, ".") && s != "openid" {
+			return &InvalidScopeError{
+				Scope:     s,
+				OAuthType: "Scoped",
+				Hint:      "Scoped OAuth scopes should follow the pattern 'resource.permission' (e.g., 'incidents.read')",
+			}
+		}
+	}
+	return nil
+}
+
+// InvalidScopeError is returned when an invalid scope is used for an OAuth type.
+type InvalidScopeError struct {
+	Scope     string
+	OAuthType string
+	Hint      string
+}
+
+func (e *InvalidScopeError) Error() string {
+	return "invalid scope '" + e.Scope + "' for " + e.OAuthType + " OAuth: " + e.Hint
+}

--- a/oauth_scopes_test.go
+++ b/oauth_scopes_test.go
@@ -1,0 +1,222 @@
+package pagerduty
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestClassicScope_String(t *testing.T) {
+	tests := []struct {
+		name  string
+		scope ClassicScope
+		want  string
+	}{
+		{
+			name:  "read",
+			scope: ClassicScopeRead,
+			want:  "read",
+		},
+		{
+			name:  "write",
+			scope: ClassicScopeWrite,
+			want:  "write",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.scope.String(); got != tt.want {
+				t.Errorf("ClassicScope.String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassicScopesToStrings(t *testing.T) {
+	tests := []struct {
+		name   string
+		scopes []ClassicScope
+		want   []string
+	}{
+		{
+			name:   "empty",
+			scopes: []ClassicScope{},
+			want:   []string{},
+		},
+		{
+			name:   "read_only",
+			scopes: []ClassicScope{ClassicScopeRead},
+			want:   []string{"read"},
+		},
+		{
+			name:   "both",
+			scopes: []ClassicScope{ClassicScopeRead, ClassicScopeWrite},
+			want:   []string{"read", "write"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassicScopesToStrings(tt.scopes)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("ClassicScopesToStrings() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestValidateClassicScopes(t *testing.T) {
+	tests := []struct {
+		name    string
+		scopes  []string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid_read",
+			scopes:  []string{"read"},
+			wantErr: false,
+		},
+		{
+			name:    "valid_write",
+			scopes:  []string{"write"},
+			wantErr: false,
+		},
+		{
+			name:    "valid_both",
+			scopes:  []string{"read", "write"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid_scoped_oauth_scope",
+			scopes:  []string{"incidents.read"},
+			wantErr: true,
+			errMsg:  "invalid scope 'incidents.read' for Classic OAuth",
+		},
+		{
+			name:    "invalid_mixed",
+			scopes:  []string{"read", "incidents.read"},
+			wantErr: true,
+			errMsg:  "invalid scope 'incidents.read' for Classic OAuth",
+		},
+		{
+			name:    "empty",
+			scopes:  []string{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateClassicScopes(tt.scopes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateClassicScopes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && err != nil {
+				if got := err.Error(); got != tt.errMsg {
+					// Check if errMsg is a prefix (the full error includes the hint)
+					if len(got) < len(tt.errMsg) || got[:len(tt.errMsg)] != tt.errMsg {
+						t.Errorf("ValidateClassicScopes() error = %q, should start with %q", got, tt.errMsg)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestValidateScopedOAuthScopes(t *testing.T) {
+	tests := []struct {
+		name    string
+		scopes  []string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid_granular_scope",
+			scopes:  []string{"incidents.read"},
+			wantErr: false,
+		},
+		{
+			name:    "valid_multiple_scopes",
+			scopes:  []string{"incidents.read", "services.write", "users.read"},
+			wantErr: false,
+		},
+		{
+			name:    "valid_with_account_scope",
+			scopes:  []string{"as_account-us.mycompany", "incidents.read"},
+			wantErr: false,
+		},
+		{
+			name:    "valid_subresource_scope",
+			scopes:  []string{"users:contact_methods.read"},
+			wantErr: false,
+		},
+		{
+			name:    "valid_openid",
+			scopes:  []string{"openid"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid_classic_read",
+			scopes:  []string{"read"},
+			wantErr: true,
+			errMsg:  "invalid scope 'read' for Scoped OAuth",
+		},
+		{
+			name:    "invalid_classic_write",
+			scopes:  []string{"write"},
+			wantErr: true,
+			errMsg:  "invalid scope 'write' for Scoped OAuth",
+		},
+		{
+			name:    "invalid_mixed_with_classic",
+			scopes:  []string{"incidents.read", "read"},
+			wantErr: true,
+			errMsg:  "invalid scope 'read' for Scoped OAuth",
+		},
+		{
+			name:    "invalid_format_no_dot",
+			scopes:  []string{"incidents"},
+			wantErr: true,
+			errMsg:  "invalid scope 'incidents' for Scoped OAuth",
+		},
+		{
+			name:    "empty",
+			scopes:  []string{},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateScopedOAuthScopes(tt.scopes)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateScopedOAuthScopes() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && err != nil {
+				if got := err.Error(); got != tt.errMsg {
+					// Check if errMsg is a prefix (the full error includes the hint)
+					if len(got) < len(tt.errMsg) || got[:len(tt.errMsg)] != tt.errMsg {
+						t.Errorf("ValidateScopedOAuthScopes() error = %q, should start with %q", got, tt.errMsg)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestInvalidScopeError_Error(t *testing.T) {
+	err := &InvalidScopeError{
+		Scope:     "incidents.read",
+		OAuthType: "Classic",
+		Hint:      "Classic OAuth only supports 'read' and 'write' scopes",
+	}
+
+	want := "invalid scope 'incidents.read' for Classic OAuth: Classic OAuth only supports 'read' and 'write' scopes"
+	if got := err.Error(); got != want {
+		t.Errorf("InvalidScopeError.Error() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
This patch implements full support for PagerDuty's OAuth authentication models, including both Classic (broad read/write) and Scoped (granular resource) OAuth.

A new `pd auth login` command facilitates the Authorization Code grant flow by starting a local callback server, launching the browser, and securely storing the resulting credentials. The CLI infrastructure has been updated to accept OAuth flags and transparently use the stored token with auto-refresh capabilities.

Example `.pd.yml` configuration:

```yaml
oauth_type: scoped
client_id: "your-client-id"
client_secret: "your-client-secret"
scopes:
  - incidents.read
  - services.write
token_file: "~/.pd-token.json"
```