### PR TITLE
feat: add v3 Schedules API support

### DIFF
--- a/schedule_v3.go
+++ b/schedule_v3.go
@@ -1,0 +1,323 @@
+package pagerduty
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/google/go-querystring/query"
+)
+
+// scheduleV3Headers returns the HTTP headers required by PagerDuty's v3 Schedules API.
+// The v3 API requires Accept: application/json and the flexible-schedules early access header.
+// The early access value can be overridden via PAGERDUTY_SCHEDULE_V3_EARLY_ACCESS env var.
+func scheduleV3Headers() map[string]string {
+	earlyAccessVal := "flexible-schedules-early-access"
+	if val := os.Getenv("PAGERDUTY_SCHEDULE_V3_EARLY_ACCESS"); val != "" {
+		earlyAccessVal = val
+	}
+	return map[string]string{
+		"Accept":         "application/json",
+		"X-Early-Access": earlyAccessVal,
+	}
+}
+
+// ScheduleV3 represents a schedule in PagerDuty's v3 API.
+type ScheduleV3 struct {
+	ID                 string       `json:"id,omitempty"`
+	Type               string       `json:"type,omitempty"`
+	Name               string       `json:"name"`
+	TimeZone           string       `json:"time_zone"`
+	Description        string       `json:"description,omitempty"`
+	EscalationPolicies []string     `json:"escalation_policies,omitempty"`
+	Rotations          []RotationV3 `json:"rotations,omitempty"`
+}
+
+// RotationV3 represents a rotation within a v3 schedule.
+type RotationV3 struct {
+	ID     string    `json:"id,omitempty"`
+	Type   string    `json:"type,omitempty"`
+	Events []EventV3 `json:"events,omitempty"`
+}
+
+// EventTimeV3 represents a time field in a v3 schedule event.
+// The v3 API uses an object {"date_time": "...", "time_zone": "..."} rather than a plain string.
+type EventTimeV3 struct {
+	DateTime string `json:"date_time"`
+	TimeZone string `json:"time_zone,omitempty"`
+}
+
+// EventV3 represents an on-call event configuration within a rotation.
+type EventV3 struct {
+	ID                 string               `json:"id,omitempty"`
+	Type               string               `json:"type,omitempty"`
+	Name               string               `json:"name"`
+	StartTime          EventTimeV3          `json:"start_time"`
+	EndTime            EventTimeV3          `json:"end_time"`
+	EffectiveSince     string               `json:"effective_since"`
+	EffectiveUntil     *string              `json:"effective_until"`
+	Recurrence         []string             `json:"recurrence"`
+	AssignmentStrategy AssignmentStrategyV3 `json:"assignment_strategy"`
+}
+
+// AssignmentStrategyV3 defines how on-call responsibility is assigned within an event.
+type AssignmentStrategyV3 struct {
+	Type    string     `json:"type"`
+	Members []MemberV3 `json:"members"`
+}
+
+// MemberV3 represents a member in an assignment strategy.
+type MemberV3 struct {
+	Type   string  `json:"type"`
+	UserID *string `json:"user_id,omitempty"`
+}
+
+// ScheduleV3Input contains the mutable fields for creating or updating a v3 schedule.
+type ScheduleV3Input struct {
+	Name        string `json:"name"`
+	TimeZone    string `json:"time_zone"`
+	Description string `json:"description,omitempty"`
+}
+
+// scheduleV3Payload is the request body shape for v3 schedule create/update.
+// The rotations field must be present (even as []) per the v3 API validation.
+type scheduleV3Payload struct {
+	Name        string       `json:"name"`
+	TimeZone    string       `json:"time_zone"`
+	Description string       `json:"description,omitempty"`
+	Rotations   []RotationV3 `json:"rotations"`
+}
+
+type createScheduleV3Request struct {
+	Schedule scheduleV3Payload `json:"schedule"`
+}
+
+type updateScheduleV3Request struct {
+	Schedule scheduleV3Payload `json:"schedule"`
+}
+
+type scheduleV3Response struct {
+	Schedule ScheduleV3 `json:"schedule"`
+}
+
+// ListSchedulesV3Response is the response for listing v3 schedules.
+type ListSchedulesV3Response struct {
+	Schedules []ScheduleV3Reference `json:"schedules"`
+}
+
+// ScheduleV3Reference is a lightweight reference returned in v3 list responses.
+type ScheduleV3Reference struct {
+	ID      string `json:"id"`
+	Type    string `json:"type"`
+	Summary string `json:"summary"`
+	Self    string `json:"self"`
+	HTMLURL string `json:"html_url"`
+}
+
+// ListSchedulesV3Options are query parameters for listing v3 schedules.
+type ListSchedulesV3Options struct {
+	Query  string `url:"query,omitempty"`
+	Limit  int    `url:"limit,omitempty"`
+	Offset int    `url:"offset,omitempty"`
+}
+
+type rotationV3Response struct {
+	Rotation RotationV3 `json:"rotation"`
+}
+
+// eventV3Response wraps the v3 API event response. The v3 API uses "schedule_event" as the key.
+type eventV3Response struct {
+	Event EventV3 `json:"schedule_event"`
+}
+
+// ListSchedulesV3 retrieves a paginated list of v3 schedules.
+func (c *Client) ListSchedulesV3(ctx context.Context, o ListSchedulesV3Options) (*ListSchedulesV3Response, error) {
+	v, err := query.Values(o)
+	if err != nil {
+		return nil, err
+	}
+
+	path := "/v3/schedules"
+	if encoded := v.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+
+	resp, err := c.get(ctx, path, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result ListSchedulesV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// GetScheduleV3 retrieves a v3 schedule by ID, including its rotations and events.
+func (c *Client) GetScheduleV3(ctx context.Context, id string) (*ScheduleV3, error) {
+	resp, err := c.get(ctx, "/v3/schedules/"+id, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result scheduleV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Schedule, nil
+}
+
+// CreateScheduleV3 creates a new v3 schedule with metadata only.
+// Rotations and events must be added via separate API calls.
+func (c *Client) CreateScheduleV3(ctx context.Context, s ScheduleV3Input) (*ScheduleV3, error) {
+	d := createScheduleV3Request{Schedule: scheduleV3Payload{
+		Name:        s.Name,
+		TimeZone:    s.TimeZone,
+		Description: s.Description,
+		Rotations:   []RotationV3{},
+	}}
+
+	resp, err := c.post(ctx, "/v3/schedules", d, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create v3 schedule, HTTP status code: %d", resp.StatusCode)
+	}
+
+	var result scheduleV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Schedule, nil
+}
+
+// UpdateScheduleV3 updates a v3 schedule's metadata (name, time_zone, description).
+func (c *Client) UpdateScheduleV3(ctx context.Context, id string, s ScheduleV3Input) (*ScheduleV3, error) {
+	d := updateScheduleV3Request{Schedule: scheduleV3Payload{
+		Name:        s.Name,
+		TimeZone:    s.TimeZone,
+		Description: s.Description,
+		Rotations:   []RotationV3{},
+	}}
+
+	resp, err := c.put(ctx, "/v3/schedules/"+id, d, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result scheduleV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Schedule, nil
+}
+
+// DeleteScheduleV3 soft-deletes a v3 schedule and all its rotations and events.
+func (c *Client) DeleteScheduleV3(ctx context.Context, id string) error {
+	// Use do() directly since delete() does not accept custom headers
+	resp, err := c.do(ctx, http.MethodDelete, "/v3/schedules/"+id, nil, scheduleV3Headers())
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// CreateRotationV3 creates a new empty rotation for a v3 schedule.
+// Events are added to the rotation via CreateEventV3.
+func (c *Client) CreateRotationV3(ctx context.Context, scheduleID string) (*RotationV3, error) {
+	resp, err := c.post(ctx, "/v3/schedules/"+scheduleID+"/rotations", map[string]interface{}{}, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create v3 rotation, HTTP status code: %d", resp.StatusCode)
+	}
+
+	var result rotationV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Rotation, nil
+}
+
+// GetRotationV3 retrieves a rotation by ID for a given schedule.
+func (c *Client) GetRotationV3(ctx context.Context, scheduleID, rotationID string) (*RotationV3, error) {
+	resp, err := c.get(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result rotationV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Rotation, nil
+}
+
+// DeleteRotationV3 soft-deletes a rotation from a v3 schedule.
+func (c *Client) DeleteRotationV3(ctx context.Context, scheduleID, rotationID string) error {
+	// Use do() directly since delete() does not accept custom headers
+	resp, err := c.do(ctx, http.MethodDelete, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID, nil, scheduleV3Headers())
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// CreateEventV3 creates a new event within a v3 rotation.
+func (c *Client) CreateEventV3(ctx context.Context, scheduleID, rotationID string, e EventV3) (*EventV3, error) {
+	resp, err := c.post(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events", e, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create v3 event, HTTP status code: %d", resp.StatusCode)
+	}
+
+	var result eventV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Event, nil
+}
+
+// UpdateEventV3 updates an event within a v3 rotation.
+func (c *Client) UpdateEventV3(ctx context.Context, scheduleID, rotationID, eventID string, e EventV3) (*EventV3, error) {
+	resp, err := c.put(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events/"+eventID, e, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result eventV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Event, nil
+}
+
+// DeleteEventV3 deletes an event from a v3 rotation.
+func (c *Client) DeleteEventV3(ctx context.Context, scheduleID, rotationID, eventID string) error {
+	// Use do() directly since delete() does not accept custom headers
+	resp, err := c.do(ctx, http.MethodDelete, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events/"+eventID, nil, scheduleV3Headers())
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/schedule_v3.go
+++ b/schedule_v3.go
@@ -103,16 +103,7 @@ type scheduleV3Response struct {
 
 // ListSchedulesV3Response is the response for listing v3 schedules.
 type ListSchedulesV3Response struct {
-	Schedules []ScheduleV3Reference `json:"schedules"`
-}
-
-// ScheduleV3Reference is a lightweight reference returned in v3 list responses.
-type ScheduleV3Reference struct {
-	ID      string `json:"id"`
-	Type    string `json:"type"`
-	Summary string `json:"summary"`
-	Self    string `json:"self"`
-	HTMLURL string `json:"html_url"`
+	Schedules []APIObject `json:"schedules"`
 }
 
 // ListSchedulesV3Options are query parameters for listing v3 schedules.

--- a/schedule_v3.go
+++ b/schedule_v3.go
@@ -25,13 +25,14 @@ func scheduleV3Headers() map[string]string {
 
 // ScheduleV3 represents a schedule in PagerDuty's v3 API.
 type ScheduleV3 struct {
-	ID                 string       `json:"id,omitempty"`
-	Type               string       `json:"type,omitempty"`
-	Name               string       `json:"name"`
-	TimeZone           string       `json:"time_zone"`
-	Description        string       `json:"description,omitempty"`
-	EscalationPolicies []string     `json:"escalation_policies,omitempty"`
-	Rotations          []RotationV3 `json:"rotations,omitempty"`
+	ID                 string             `json:"id,omitempty"`
+	Type               string             `json:"type,omitempty"`
+	Name               string             `json:"name"`
+	TimeZone           string             `json:"time_zone"`
+	Description        string             `json:"description,omitempty"`
+	EscalationPolicies []string           `json:"escalation_policies,omitempty"`
+	Teams              []TeamReferenceV3  `json:"teams,omitempty"`
+	Rotations          []RotationV3       `json:"rotations,omitempty"`
 }
 
 // RotationV3 represents a rotation within a v3 schedule.
@@ -63,8 +64,15 @@ type EventV3 struct {
 
 // AssignmentStrategyV3 defines how on-call responsibility is assigned within an event.
 type AssignmentStrategyV3 struct {
-	Type    string     `json:"type"`
-	Members []MemberV3 `json:"members"`
+	Type            string     `json:"type"`
+	ShiftsPerMember *int       `json:"shifts_per_member,omitempty"`
+	Members         []MemberV3 `json:"members"`
+}
+
+// TeamReferenceV3 represents a team associated with a v3 schedule.
+type TeamReferenceV3 struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
 }
 
 // MemberV3 represents a member in an assignment strategy.
@@ -75,18 +83,20 @@ type MemberV3 struct {
 
 // ScheduleV3Input contains the mutable fields for creating or updating a v3 schedule.
 type ScheduleV3Input struct {
-	Name        string `json:"name"`
-	TimeZone    string `json:"time_zone"`
-	Description string `json:"description,omitempty"`
+	Name        string             `json:"name"`
+	TimeZone    string             `json:"time_zone"`
+	Description string             `json:"description,omitempty"`
+	Teams       []TeamReferenceV3  `json:"teams,omitempty"`
 }
 
 // scheduleV3Payload is the request body shape for v3 schedule create/update.
 // The rotations field must be present (even as []) per the v3 API validation.
 type scheduleV3Payload struct {
-	Name        string       `json:"name"`
-	TimeZone    string       `json:"time_zone"`
-	Description string       `json:"description,omitempty"`
-	Rotations   []RotationV3 `json:"rotations"`
+	Name        string             `json:"name"`
+	TimeZone    string             `json:"time_zone"`
+	Description string             `json:"description,omitempty"`
+	Teams       []TeamReferenceV3  `json:"teams,omitempty"`
+	Rotations   []RotationV3       `json:"rotations"`
 }
 
 type createScheduleV3Request struct {
@@ -117,9 +127,16 @@ type rotationV3Response struct {
 	Rotation RotationV3 `json:"rotation"`
 }
 
-// eventV3Response wraps the v3 API event response. The v3 API uses "schedule_event" as the key.
 type eventV3Response struct {
-	Event EventV3 `json:"schedule_event"`
+	Event EventV3 `json:"event"`
+}
+
+type createEventV3Request struct {
+	Event EventV3 `json:"event"`
+}
+
+type updateEventV3Request struct {
+	Event EventV3 `json:"event"`
 }
 
 // ListSchedulesV3 retrieves a paginated list of v3 schedules.
@@ -169,6 +186,7 @@ func (c *Client) CreateScheduleV3(ctx context.Context, s ScheduleV3Input) (*Sche
 		Name:        s.Name,
 		TimeZone:    s.TimeZone,
 		Description: s.Description,
+		Teams:       s.Teams,
 		Rotations:   []RotationV3{},
 	}}
 
@@ -195,6 +213,7 @@ func (c *Client) UpdateScheduleV3(ctx context.Context, id string, s ScheduleV3In
 		Name:        s.Name,
 		TimeZone:    s.TimeZone,
 		Description: s.Description,
+		Teams:       s.Teams,
 		Rotations:   []RotationV3{},
 	}}
 
@@ -257,6 +276,21 @@ func (c *Client) GetRotationV3(ctx context.Context, scheduleID, rotationID strin
 	return &result.Rotation, nil
 }
 
+// GetEventV3 retrieves a single event from a v3 rotation.
+func (c *Client) GetEventV3(ctx context.Context, scheduleID, rotationID, eventID string) (*EventV3, error) {
+	resp, err := c.get(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events/"+eventID, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result eventV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Event, nil
+}
+
 // DeleteRotationV3 soft-deletes a rotation from a v3 schedule.
 func (c *Client) DeleteRotationV3(ctx context.Context, scheduleID, rotationID string) error {
 	// Use do() directly since delete() does not accept custom headers
@@ -270,7 +304,7 @@ func (c *Client) DeleteRotationV3(ctx context.Context, scheduleID, rotationID st
 
 // CreateEventV3 creates a new event within a v3 rotation.
 func (c *Client) CreateEventV3(ctx context.Context, scheduleID, rotationID string, e EventV3) (*EventV3, error) {
-	resp, err := c.post(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events", e, scheduleV3Headers())
+	resp, err := c.post(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events", createEventV3Request{Event: e}, scheduleV3Headers())
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +323,7 @@ func (c *Client) CreateEventV3(ctx context.Context, scheduleID, rotationID strin
 
 // UpdateEventV3 updates an event within a v3 rotation.
 func (c *Client) UpdateEventV3(ctx context.Context, scheduleID, rotationID, eventID string, e EventV3) (*EventV3, error) {
-	resp, err := c.put(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events/"+eventID, e, scheduleV3Headers())
+	resp, err := c.put(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events/"+eventID, updateEventV3Request{Event: e}, scheduleV3Headers())
 	if err != nil {
 		return nil, err
 	}

--- a/schedule_v3.go
+++ b/schedule_v3.go
@@ -4,32 +4,26 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/google/go-querystring/query"
 )
 
 // scheduleV3Headers returns the HTTP headers required by PagerDuty's v3 Schedules API.
-// The v3 API requires Accept: application/json and the flexible-schedules early access header.
-// The early access value can be overridden via PAGERDUTY_SCHEDULE_V3_EARLY_ACCESS env var.
 func scheduleV3Headers() map[string]string {
-	earlyAccessVal := "flexible-schedules-early-access"
-	if val := os.Getenv("PAGERDUTY_SCHEDULE_V3_EARLY_ACCESS"); val != "" {
-		earlyAccessVal = val
-	}
 	return map[string]string{
-		"Accept":         "application/json",
-		"X-Early-Access": earlyAccessVal,
+		"Accept": "application/json",
+		// The v3 API requires Accept: application/json and the flexible-schedules early access header.
+		"X-Early-Access": "flexible-schedules-early-access",
 	}
 }
 
 // ScheduleV3 represents a schedule in PagerDuty's v3 API.
 type ScheduleV3 struct {
-	ID                 string           `json:"id,omitempty"`
-	Type               string           `json:"type,omitempty"`
-	Name               string           `json:"name"`
-	TimeZone           string           `json:"time_zone"`
-	Description        string           `json:"description,omitempty"`
+	ID                 string            `json:"id,omitempty"`
+	Type               string            `json:"type,omitempty"`
+	Name               string            `json:"name"`
+	TimeZone           string            `json:"time_zone"`
+	Description        string            `json:"description,omitempty"`
 	EscalationPolicies []APIObject       `json:"escalation_policies,omitempty"`
 	Teams              []TeamReferenceV3 `json:"teams,omitempty"`
 	Users              []APIObject       `json:"users,omitempty"`

--- a/schedule_v3.go
+++ b/schedule_v3.go
@@ -25,21 +25,29 @@ func scheduleV3Headers() map[string]string {
 
 // ScheduleV3 represents a schedule in PagerDuty's v3 API.
 type ScheduleV3 struct {
-	ID                 string             `json:"id,omitempty"`
-	Type               string             `json:"type,omitempty"`
-	Name               string             `json:"name"`
-	TimeZone           string             `json:"time_zone"`
-	Description        string             `json:"description,omitempty"`
-	EscalationPolicies []string           `json:"escalation_policies,omitempty"`
-	Teams              []TeamReferenceV3  `json:"teams,omitempty"`
-	Rotations          []RotationV3       `json:"rotations,omitempty"`
+	ID                 string           `json:"id,omitempty"`
+	Type               string           `json:"type,omitempty"`
+	Name               string           `json:"name"`
+	TimeZone           string           `json:"time_zone"`
+	Description        string           `json:"description,omitempty"`
+	EscalationPolicies []APIObject       `json:"escalation_policies,omitempty"`
+	Teams              []TeamReferenceV3 `json:"teams,omitempty"`
+	Users              []APIObject       `json:"users,omitempty"`
+	Rotations          []RotationV3      `json:"rotations,omitempty"`
+	FinalSchedule      *FinalScheduleV3  `json:"final_schedule,omitempty"`
+	HTTPCalURL         string            `json:"http_cal_url,omitempty"`
+	WebCalURL          string            `json:"web_cal_url,omitempty"`
+	Self               string            `json:"self,omitempty"`
+	HTMLURL            string            `json:"html_url,omitempty"`
 }
 
 // RotationV3 represents a rotation within a v3 schedule.
 type RotationV3 struct {
-	ID     string    `json:"id,omitempty"`
-	Type   string    `json:"type,omitempty"`
-	Events []EventV3 `json:"events,omitempty"`
+	ID      string    `json:"id,omitempty"`
+	Type    string    `json:"type,omitempty"`
+	Events  []EventV3 `json:"events,omitempty"`
+	Self    string    `json:"self,omitempty"`
+	HTMLURL string    `json:"html_url,omitempty"`
 }
 
 // EventTimeV3 represents a time field in a v3 schedule event.
@@ -60,6 +68,8 @@ type EventV3 struct {
 	EffectiveUntil     *string              `json:"effective_until"`
 	Recurrence         []string             `json:"recurrence"`
 	AssignmentStrategy AssignmentStrategyV3 `json:"assignment_strategy"`
+	Self               string               `json:"self,omitempty"`
+	HTMLURL            string               `json:"html_url,omitempty"`
 }
 
 // AssignmentStrategyV3 defines how on-call responsibility is assigned within an event.
@@ -75,28 +85,118 @@ type TeamReferenceV3 struct {
 	Type string `json:"type"`
 }
 
-// MemberV3 represents a member in an assignment strategy.
+// MemberV3 represents a member in an assignment strategy or shift.
 type MemberV3 struct {
 	Type   string  `json:"type"`
 	UserID *string `json:"user_id,omitempty"`
 }
 
+// FinalScheduleV3 holds computed on-call assignments for a requested time range.
+// Only present when include[]=final_schedule is passed to GetScheduleV3 with since/until.
+type FinalScheduleV3 struct {
+	Type                       string                      `json:"type"`
+	RenderedCoveragePercentage float64                     `json:"rendered_coverage_percentage"`
+	ComputedShiftAssignments   []ComputedShiftAssignmentV3 `json:"computed_shift_assignments"`
+}
+
+// ComputedShiftAssignmentV3 represents a single computed on-call interval within a FinalScheduleV3.
+type ComputedShiftAssignmentV3 struct {
+	Type      string        `json:"type"`
+	StartTime string        `json:"start_time"`
+	EndTime   string        `json:"end_time"`
+	Member    MemberV3      `json:"member"`
+	Source    ShiftSourceV3 `json:"source"`
+}
+
+// ShiftSourceV3 identifies where a computed shift assignment originated.
+type ShiftSourceV3 struct {
+	Type       string `json:"type"`
+	RotationID string `json:"rotation_id,omitempty"`
+	ShiftID    string `json:"shift_id,omitempty"`
+	OverrideID string `json:"override_id,omitempty"`
+}
+
+// ShiftAssignmentV3 assigns a member to a custom shift slot (response form includes an ID).
+type ShiftAssignmentV3 struct {
+	ID     string   `json:"id,omitempty"`
+	Type   string   `json:"type"`
+	Member MemberV3 `json:"member"`
+}
+
+// CustomShiftV3 represents an ad-hoc one-off shift outside of rotation events.
+type CustomShiftV3 struct {
+	ID          string              `json:"id,omitempty"`
+	Type        string              `json:"type,omitempty"`
+	StartTime   string              `json:"start_time"`
+	EndTime     string              `json:"end_time"`
+	Assignments []ShiftAssignmentV3 `json:"assignments"`
+	Self        string              `json:"self,omitempty"`
+	HTMLURL     string              `json:"html_url,omitempty"`
+}
+
+// CustomShiftInputV3 is the creation payload for a single custom shift.
+type CustomShiftInputV3 struct {
+	Type        string              `json:"type"`
+	StartTime   string              `json:"start_time"`
+	EndTime     string              `json:"end_time"`
+	Assignments []ShiftAssignmentV3 `json:"assignments"`
+}
+
+// CustomShiftUpdateV3 is the update payload for a custom shift (all fields optional).
+type CustomShiftUpdateV3 struct {
+	StartTime   string              `json:"start_time,omitempty"`
+	EndTime     string              `json:"end_time,omitempty"`
+	Assignments []ShiftAssignmentV3 `json:"assignments,omitempty"`
+}
+
+// OverrideShiftV3 temporarily replaces a scheduled on-call member for a specific time period.
+type OverrideShiftV3 struct {
+	ID               string   `json:"id,omitempty"`
+	Type             string   `json:"type,omitempty"`
+	RotationID       string   `json:"rotation_id,omitempty"`
+	CustomShiftID    string   `json:"custom_shift_id,omitempty"`
+	StartTime        string   `json:"start_time"`
+	EndTime          string   `json:"end_time"`
+	OverriddenMember MemberV3 `json:"overridden_member"`
+	OverridingMember MemberV3 `json:"overriding_member"`
+	Self             string   `json:"self,omitempty"`
+	HTMLURL          string   `json:"html_url,omitempty"`
+}
+
+// OverrideShiftInputV3 is the creation payload for a single override.
+type OverrideShiftInputV3 struct {
+	Type             string   `json:"type"`
+	RotationID       string   `json:"rotation_id,omitempty"`
+	CustomShiftID    string   `json:"custom_shift_id,omitempty"`
+	StartTime        string   `json:"start_time"`
+	EndTime          string   `json:"end_time"`
+	OverriddenMember MemberV3 `json:"overridden_member"`
+	OverridingMember MemberV3 `json:"overriding_member"`
+}
+
+// OverrideShiftUpdateV3 is the update payload for an override (all fields optional).
+type OverrideShiftUpdateV3 struct {
+	StartTime        string    `json:"start_time,omitempty"`
+	EndTime          string    `json:"end_time,omitempty"`
+	OverridingMember *MemberV3 `json:"overriding_member,omitempty"`
+}
+
 // ScheduleV3Input contains the mutable fields for creating or updating a v3 schedule.
 type ScheduleV3Input struct {
-	Name        string             `json:"name"`
-	TimeZone    string             `json:"time_zone"`
-	Description string             `json:"description,omitempty"`
-	Teams       []TeamReferenceV3  `json:"teams,omitempty"`
+	Name        string            `json:"name"`
+	TimeZone    string            `json:"time_zone"`
+	Description string            `json:"description,omitempty"`
+	Teams       []TeamReferenceV3 `json:"teams,omitempty"`
 }
 
 // scheduleV3Payload is the request body shape for v3 schedule create/update.
 // The rotations field must be present (even as []) per the v3 API validation.
 type scheduleV3Payload struct {
-	Name        string             `json:"name"`
-	TimeZone    string             `json:"time_zone"`
-	Description string             `json:"description,omitempty"`
-	Teams       []TeamReferenceV3  `json:"teams,omitempty"`
-	Rotations   []RotationV3       `json:"rotations"`
+	Name        string            `json:"name"`
+	TimeZone    string            `json:"time_zone"`
+	Description string            `json:"description,omitempty"`
+	Teams       []TeamReferenceV3 `json:"teams,omitempty"`
+	Rotations   []RotationV3      `json:"rotations"`
 }
 
 type createScheduleV3Request struct {
@@ -114,6 +214,9 @@ type scheduleV3Response struct {
 // ListSchedulesV3Response is the response for listing v3 schedules.
 type ListSchedulesV3Response struct {
 	Schedules []APIObject `json:"schedules"`
+	Limit     int         `json:"limit,omitempty"`
+	Offset    int         `json:"offset,omitempty"`
+	More      bool        `json:"more,omitempty"`
 }
 
 // ListSchedulesV3Options are query parameters for listing v3 schedules.
@@ -121,6 +224,62 @@ type ListSchedulesV3Options struct {
 	Query  string `url:"query,omitempty"`
 	Limit  int    `url:"limit,omitempty"`
 	Offset int    `url:"offset,omitempty"`
+}
+
+// GetScheduleV3Options are optional query parameters for GetScheduleV3.
+// Pass include[]=final_schedule with Since/Until to retrieve computed on-call assignments.
+type GetScheduleV3Options struct {
+	Since    string   `url:"since,omitempty"`
+	Until    string   `url:"until,omitempty"`
+	TimeZone string   `url:"time_zone,omitempty"`
+	Overflow string   `url:"overflow,omitempty"`
+	Include  []string `url:"include,omitempty,brackets"`
+}
+
+// GetRotationV3Options are optional query parameters for GetRotationV3.
+type GetRotationV3Options struct {
+	Since string `url:"since,omitempty"`
+	Until string `url:"until,omitempty"`
+}
+
+// GetEventV3Options are optional query parameters for GetEventV3.
+type GetEventV3Options struct {
+	Since string `url:"since,omitempty"`
+	Until string `url:"until,omitempty"`
+}
+
+// ListRotationsV3Options are query parameters for listing rotations.
+type ListRotationsV3Options struct {
+	Limit  int `url:"limit,omitempty"`
+	Offset int `url:"offset,omitempty"`
+}
+
+// ListEventsV3Options are query parameters for listing events within a rotation.
+type ListEventsV3Options struct {
+	Limit  int `url:"limit,omitempty"`
+	Offset int `url:"offset,omitempty"`
+}
+
+// ListCustomShiftsV3Options are query parameters for listing custom shifts.
+// Since and Until are required by the API.
+type ListCustomShiftsV3Options struct {
+	Since    string `url:"since"`
+	Until    string `url:"until"`
+	TimeZone string `url:"time_zone,omitempty"`
+	Overflow string `url:"overflow,omitempty"`
+	Limit    int    `url:"limit,omitempty"`
+	Offset   int    `url:"offset,omitempty"`
+}
+
+// ListOverridesV3Options are query parameters for listing overrides.
+// Since and Until are required by the API.
+type ListOverridesV3Options struct {
+	Since    string `url:"since"`
+	Until    string `url:"until"`
+	TimeZone string `url:"time_zone,omitempty"`
+	Overflow string `url:"overflow,omitempty"`
+	Limit    int    `url:"limit,omitempty"`
+	Offset   int    `url:"offset,omitempty"`
 }
 
 type rotationV3Response struct {
@@ -139,16 +298,87 @@ type updateEventV3Request struct {
 	Event EventV3 `json:"event"`
 }
 
+// ListRotationsV3Response is the response for listing rotations.
+type ListRotationsV3Response struct {
+	Rotations []RotationV3 `json:"rotations"`
+	Limit     int          `json:"limit,omitempty"`
+	Offset    int          `json:"offset,omitempty"`
+	More      bool         `json:"more,omitempty"`
+}
+
+// ListEventsV3Response is the response for listing events within a rotation.
+type ListEventsV3Response struct {
+	Events []EventV3 `json:"events"`
+	Limit  int       `json:"limit,omitempty"`
+	Offset int       `json:"offset,omitempty"`
+	More   bool      `json:"more,omitempty"`
+}
+
+// ListCustomShiftsV3Response is the response for listing custom shifts.
+type ListCustomShiftsV3Response struct {
+	CustomShifts []CustomShiftV3 `json:"custom_shifts"`
+	Limit        int             `json:"limit,omitempty"`
+	Offset       int             `json:"offset,omitempty"`
+	More         bool            `json:"more,omitempty"`
+}
+
+type createCustomShiftsV3Request struct {
+	CustomShifts []CustomShiftInputV3 `json:"custom_shifts"`
+}
+
+type createCustomShiftsV3Response struct {
+	CustomShifts []CustomShiftV3 `json:"custom_shifts"`
+}
+
+type customShiftV3Response struct {
+	CustomShift CustomShiftV3 `json:"custom_shift"`
+}
+
+type updateCustomShiftV3Request struct {
+	CustomShift CustomShiftUpdateV3 `json:"custom_shift"`
+}
+
+// ListOverridesV3Response is the response for listing overrides.
+type ListOverridesV3Response struct {
+	Overrides []OverrideShiftV3 `json:"overrides"`
+	Limit     int               `json:"limit,omitempty"`
+	Offset    int               `json:"offset,omitempty"`
+	More      bool              `json:"more,omitempty"`
+}
+
+type createOverridesV3Request struct {
+	Overrides []OverrideShiftInputV3 `json:"overrides"`
+}
+
+type createOverridesV3Response struct {
+	Overrides []OverrideShiftV3 `json:"overrides"`
+}
+
+type overrideShiftV3Response struct {
+	Override OverrideShiftV3 `json:"override"`
+}
+
+type updateOverrideV3Request struct {
+	Override OverrideShiftUpdateV3 `json:"override"`
+}
+
+// buildPath appends non-empty query string to path.
+func buildV3Path(base string, v interface{}) (string, error) {
+	vals, err := query.Values(v)
+	if err != nil {
+		return "", err
+	}
+	if encoded := vals.Encode(); encoded != "" {
+		return base + "?" + encoded, nil
+	}
+	return base, nil
+}
+
 // ListSchedulesV3 retrieves a paginated list of v3 schedules.
 func (c *Client) ListSchedulesV3(ctx context.Context, o ListSchedulesV3Options) (*ListSchedulesV3Response, error) {
-	v, err := query.Values(o)
+	path, err := buildV3Path("/v3/schedules", o)
 	if err != nil {
 		return nil, err
-	}
-
-	path := "/v3/schedules"
-	if encoded := v.Encode(); encoded != "" {
-		path += "?" + encoded
 	}
 
 	resp, err := c.get(ctx, path, scheduleV3Headers())
@@ -165,8 +395,19 @@ func (c *Client) ListSchedulesV3(ctx context.Context, o ListSchedulesV3Options) 
 }
 
 // GetScheduleV3 retrieves a v3 schedule by ID, including its rotations and events.
-func (c *Client) GetScheduleV3(ctx context.Context, id string) (*ScheduleV3, error) {
-	resp, err := c.get(ctx, "/v3/schedules/"+id, scheduleV3Headers())
+// Optionally pass GetScheduleV3Options with Include: []string{"final_schedule"} and Since/Until
+// to also receive computed on-call assignments.
+func (c *Client) GetScheduleV3(ctx context.Context, id string, opts ...GetScheduleV3Options) (*ScheduleV3, error) {
+	var o GetScheduleV3Options
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	path, err := buildV3Path("/v3/schedules/"+id, o)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.get(ctx, path, scheduleV3Headers())
 	if err != nil {
 		return nil, err
 	}
@@ -241,6 +482,26 @@ func (c *Client) DeleteScheduleV3(ctx context.Context, id string) error {
 	return nil
 }
 
+// ListRotationsV3 retrieves all rotations for a v3 schedule.
+func (c *Client) ListRotationsV3(ctx context.Context, scheduleID string, o ListRotationsV3Options) (*ListRotationsV3Response, error) {
+	path, err := buildV3Path("/v3/schedules/"+scheduleID+"/rotations", o)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.get(ctx, path, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result ListRotationsV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
 // CreateRotationV3 creates a new empty rotation for a v3 schedule.
 // Events are added to the rotation via CreateEventV3.
 func (c *Client) CreateRotationV3(ctx context.Context, scheduleID string) (*RotationV3, error) {
@@ -262,8 +523,18 @@ func (c *Client) CreateRotationV3(ctx context.Context, scheduleID string) (*Rota
 }
 
 // GetRotationV3 retrieves a rotation by ID for a given schedule.
-func (c *Client) GetRotationV3(ctx context.Context, scheduleID, rotationID string) (*RotationV3, error) {
-	resp, err := c.get(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID, scheduleV3Headers())
+// Optionally pass GetRotationV3Options with Since/Until to filter the events returned.
+func (c *Client) GetRotationV3(ctx context.Context, scheduleID, rotationID string, opts ...GetRotationV3Options) (*RotationV3, error) {
+	var o GetRotationV3Options
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	path, err := buildV3Path("/v3/schedules/"+scheduleID+"/rotations/"+rotationID, o)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.get(ctx, path, scheduleV3Headers())
 	if err != nil {
 		return nil, err
 	}
@@ -274,21 +545,6 @@ func (c *Client) GetRotationV3(ctx context.Context, scheduleID, rotationID strin
 	}
 
 	return &result.Rotation, nil
-}
-
-// GetEventV3 retrieves a single event from a v3 rotation.
-func (c *Client) GetEventV3(ctx context.Context, scheduleID, rotationID, eventID string) (*EventV3, error) {
-	resp, err := c.get(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events/"+eventID, scheduleV3Headers())
-	if err != nil {
-		return nil, err
-	}
-
-	var result eventV3Response
-	if err = c.decodeJSON(resp, &result); err != nil {
-		return nil, err
-	}
-
-	return &result.Event, nil
 }
 
 // DeleteRotationV3 soft-deletes a rotation from a v3 schedule.
@@ -302,6 +558,26 @@ func (c *Client) DeleteRotationV3(ctx context.Context, scheduleID, rotationID st
 	return nil
 }
 
+// ListEventsV3 retrieves all events for a v3 rotation, ordered by start time.
+func (c *Client) ListEventsV3(ctx context.Context, scheduleID, rotationID string, o ListEventsV3Options) (*ListEventsV3Response, error) {
+	path, err := buildV3Path("/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events", o)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.get(ctx, path, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result ListEventsV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
 // CreateEventV3 creates a new event within a v3 rotation.
 func (c *Client) CreateEventV3(ctx context.Context, scheduleID, rotationID string, e EventV3) (*EventV3, error) {
 	resp, err := c.post(ctx, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events", createEventV3Request{Event: e}, scheduleV3Headers())
@@ -311,6 +587,31 @@ func (c *Client) CreateEventV3(ctx context.Context, scheduleID, rotationID strin
 
 	if resp.StatusCode != http.StatusCreated {
 		return nil, fmt.Errorf("failed to create v3 event, HTTP status code: %d", resp.StatusCode)
+	}
+
+	var result eventV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Event, nil
+}
+
+// GetEventV3 retrieves a single event from a v3 rotation.
+// Optionally pass GetEventV3Options with Since/Until to filter the event's computed data.
+func (c *Client) GetEventV3(ctx context.Context, scheduleID, rotationID, eventID string, opts ...GetEventV3Options) (*EventV3, error) {
+	var o GetEventV3Options
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+	path, err := buildV3Path("/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events/"+eventID, o)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.get(ctx, path, scheduleV3Headers())
+	if err != nil {
+		return nil, err
 	}
 
 	var result eventV3Response
@@ -340,6 +641,168 @@ func (c *Client) UpdateEventV3(ctx context.Context, scheduleID, rotationID, even
 func (c *Client) DeleteEventV3(ctx context.Context, scheduleID, rotationID, eventID string) error {
 	// Use do() directly since delete() does not accept custom headers
 	resp, err := c.do(ctx, http.MethodDelete, "/v3/schedules/"+scheduleID+"/rotations/"+rotationID+"/events/"+eventID, nil, scheduleV3Headers())
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// ListCustomShiftsV3 retrieves custom shifts for a schedule within the given time range.
+// Since and Until in the options are required by the API.
+func (c *Client) ListCustomShiftsV3(ctx context.Context, scheduleID string, o ListCustomShiftsV3Options) (*ListCustomShiftsV3Response, error) {
+	path, err := buildV3Path("/v3/schedules/"+scheduleID+"/custom_shifts", o)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.get(ctx, path, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result ListCustomShiftsV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// CreateCustomShiftsV3 creates one or more ad-hoc custom shifts for a schedule.
+func (c *Client) CreateCustomShiftsV3(ctx context.Context, scheduleID string, shifts []CustomShiftInputV3) ([]CustomShiftV3, error) {
+	resp, err := c.post(ctx, "/v3/schedules/"+scheduleID+"/custom_shifts", createCustomShiftsV3Request{CustomShifts: shifts}, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create v3 custom shifts, HTTP status code: %d", resp.StatusCode)
+	}
+
+	var result createCustomShiftsV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result.CustomShifts, nil
+}
+
+// GetCustomShiftV3 retrieves a single custom shift by ID.
+func (c *Client) GetCustomShiftV3(ctx context.Context, scheduleID, customShiftID string) (*CustomShiftV3, error) {
+	resp, err := c.get(ctx, "/v3/schedules/"+scheduleID+"/custom_shifts/"+customShiftID, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result customShiftV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.CustomShift, nil
+}
+
+// UpdateCustomShiftV3 updates an existing custom shift.
+// If the shift has already started, only EndTime can be modified.
+func (c *Client) UpdateCustomShiftV3(ctx context.Context, scheduleID, customShiftID string, update CustomShiftUpdateV3) (*CustomShiftV3, error) {
+	resp, err := c.put(ctx, "/v3/schedules/"+scheduleID+"/custom_shifts/"+customShiftID, updateCustomShiftV3Request{CustomShift: update}, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result customShiftV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.CustomShift, nil
+}
+
+// DeleteCustomShiftV3 deletes a custom shift by ID.
+func (c *Client) DeleteCustomShiftV3(ctx context.Context, scheduleID, customShiftID string) error {
+	resp, err := c.do(ctx, http.MethodDelete, "/v3/schedules/"+scheduleID+"/custom_shifts/"+customShiftID, nil, scheduleV3Headers())
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// ListOverridesV3 retrieves overrides for a schedule within the given time range.
+// Since and Until in the options are required by the API.
+func (c *Client) ListOverridesV3(ctx context.Context, scheduleID string, o ListOverridesV3Options) (*ListOverridesV3Response, error) {
+	path, err := buildV3Path("/v3/schedules/"+scheduleID+"/overrides", o)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.get(ctx, path, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result ListOverridesV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// CreateOverridesV3 creates one or more overrides that temporarily replace scheduled on-call members.
+// Each override must reference either a RotationID or a CustomShiftID (not both).
+func (c *Client) CreateOverridesV3(ctx context.Context, scheduleID string, overrides []OverrideShiftInputV3) ([]OverrideShiftV3, error) {
+	resp, err := c.post(ctx, "/v3/schedules/"+scheduleID+"/overrides", createOverridesV3Request{Overrides: overrides}, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, fmt.Errorf("failed to create v3 overrides, HTTP status code: %d", resp.StatusCode)
+	}
+
+	var result createOverridesV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return result.Overrides, nil
+}
+
+// GetOverrideV3 retrieves a single override by ID.
+func (c *Client) GetOverrideV3(ctx context.Context, scheduleID, overrideID string) (*OverrideShiftV3, error) {
+	resp, err := c.get(ctx, "/v3/schedules/"+scheduleID+"/overrides/"+overrideID, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result overrideShiftV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Override, nil
+}
+
+// UpdateOverrideV3 updates an existing override.
+func (c *Client) UpdateOverrideV3(ctx context.Context, scheduleID, overrideID string, update OverrideShiftUpdateV3) (*OverrideShiftV3, error) {
+	resp, err := c.put(ctx, "/v3/schedules/"+scheduleID+"/overrides/"+overrideID, updateOverrideV3Request{Override: update}, scheduleV3Headers())
+	if err != nil {
+		return nil, err
+	}
+
+	var result overrideShiftV3Response
+	if err = c.decodeJSON(resp, &result); err != nil {
+		return nil, err
+	}
+
+	return &result.Override, nil
+}
+
+// DeleteOverrideV3 deletes an override by ID.
+func (c *Client) DeleteOverrideV3(ctx context.Context, scheduleID, overrideID string) error {
+	resp, err := c.do(ctx, http.MethodDelete, "/v3/schedules/"+scheduleID+"/overrides/"+overrideID, nil, scheduleV3Headers())
 	if err != nil {
 		return err
 	}

--- a/schedule_v3_test.go
+++ b/schedule_v3_test.go
@@ -160,7 +160,7 @@ func TestScheduleV3_List(t *testing.T) {
 	}
 
 	want := &ListSchedulesV3Response{
-		Schedules: []ScheduleV3Reference{
+		Schedules: []APIObject{
 			{
 				ID:      testScheduleV3ID,
 				Type:    "schedule_reference",
@@ -192,7 +192,7 @@ func TestScheduleV3_ListWithQuery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	want := &ListSchedulesV3Response{Schedules: []ScheduleV3Reference{}}
+	want := &ListSchedulesV3Response{Schedules: []APIObject{}}
 	testEqual(t, want, res)
 }
 

--- a/schedule_v3_test.go
+++ b/schedule_v3_test.go
@@ -1,0 +1,781 @@
+package pagerduty
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+var (
+	testScheduleV3ID = "SCHED01"
+	testRotationV3ID = "ROT01"
+	testEventV3ID    = "EVT01"
+)
+
+const (
+	mockScheduleV3ListResponse = `{
+		"schedules": [
+			{
+				"id": "SCHED01",
+				"type": "schedule_reference",
+				"summary": "On-Call Schedule",
+				"self": "https://api.pagerduty.com/v3/schedules/SCHED01",
+				"html_url": "https://example.pagerduty.com/schedules/SCHED01"
+			}
+		]
+	}`
+
+	mockScheduleV3ListEmptyResponse = `{"schedules": []}`
+
+	// No "events" key in rotation — Go decodes Events as nil.
+	mockScheduleV3GetResponse = `{
+		"schedule": {
+			"id": "SCHED01",
+			"type": "schedule",
+			"name": "On-Call Schedule",
+			"time_zone": "UTC",
+			"description": "Test schedule",
+			"rotations": [
+				{"id": "ROT01", "type": "rotation"}
+			]
+		}
+	}`
+
+	// No rotations — used for create / update responses.
+	mockScheduleV3MutateResponse = `{
+		"schedule": {
+			"id": "SCHED01",
+			"type": "schedule",
+			"name": "On-Call Schedule",
+			"time_zone": "UTC",
+			"description": "Test schedule"
+		}
+	}`
+
+	// "events": [] — Go decodes Events as []EventV3{} (non-nil empty slice).
+	mockRotationV3Response = `{
+		"rotation": {
+			"id": "ROT01",
+			"type": "rotation",
+			"events": []
+		}
+	}`
+
+	mockEventV3Response = `{
+		"schedule_event": {
+			"id": "EVT01",
+			"type": "schedule_event",
+			"name": "On-Call Event",
+			"start_time": {"date_time": "2026-02-21T09:00:00Z"},
+			"end_time":   {"date_time": "2026-02-21T17:00:00Z"},
+			"effective_since": "2026-02-21T09:00:00Z",
+			"effective_until": null,
+			"recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"],
+			"assignment_strategy": {
+				"type": "user_assignment_strategy",
+				"members": [
+					{"type": "user_member", "user_id": "USER01"}
+				]
+			}
+		}
+	}`
+
+	mockScheduleV3Error400 = `{
+		"error": {
+			"code": 2001,
+			"message": "Invalid Input Provided",
+			"errors": ["name is required"]
+		}
+	}`
+
+	mockScheduleV3Error404 = `{
+		"error": {
+			"code": 2100,
+			"message": "Not Found",
+			"errors": ["The specified resource does not exist"]
+		}
+	}`
+
+	mockScheduleV3Error500 = `{
+		"error": {
+			"code": 3001,
+			"message": "Internal Server Error",
+			"errors": ["An unexpected error occurred"]
+		}
+	}`
+)
+
+// testV3EarlyAccessHeader verifies the X-Early-Access header required by
+// every v3 endpoint is present on the outgoing request.
+func testV3EarlyAccessHeader(t *testing.T, r *http.Request) {
+	t.Helper()
+	if got := r.Header.Get("X-Early-Access"); got == "" {
+		t.Error("X-Early-Access header is missing from v3 request")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// unmarshalApiErrorObject — v3 map[string][]string error format
+// ---------------------------------------------------------------------------
+
+func TestUnmarshalApiErrorObject_V3MapFormat(t *testing.T) {
+	data := []byte(`{"code":2001,"message":"Unprocessable Entity","errors":{"name":["can't be blank"]}}`)
+	aeo, err := unmarshalApiErrorObject(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if aeo.Code != 2001 {
+		t.Errorf("Code = %d, want 2001", aeo.Code)
+	}
+	if aeo.Message != "Unprocessable Entity" {
+		t.Errorf("Message = %q, want %q", aeo.Message, "Unprocessable Entity")
+	}
+	if len(aeo.Errors) != 1 {
+		t.Fatalf("len(Errors) = %d, want 1", len(aeo.Errors))
+	}
+	if aeo.Errors[0] != "name: can't be blank" {
+		t.Errorf("Errors[0] = %q, want %q", aeo.Errors[0], "name: can't be blank")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListSchedulesV3
+// ---------------------------------------------------------------------------
+
+func TestScheduleV3_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockScheduleV3ListResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListSchedulesV3(context.Background(), ListSchedulesV3Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListSchedulesV3Response{
+		Schedules: []ScheduleV3Reference{
+			{
+				ID:      testScheduleV3ID,
+				Type:    "schedule_reference",
+				Summary: "On-Call Schedule",
+				Self:    "https://api.pagerduty.com/v3/schedules/SCHED01",
+				HTMLURL: "https://example.pagerduty.com/schedules/SCHED01",
+			},
+		},
+	}
+	testEqual(t, want, res)
+}
+
+func TestScheduleV3_ListWithQuery(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if got := r.URL.Query().Get("query"); got != "on-call" {
+			t.Errorf("query param = %q, want %q", got, "on-call")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockScheduleV3ListEmptyResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListSchedulesV3(context.Background(), ListSchedulesV3Options{Query: "on-call"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListSchedulesV3Response{Schedules: []ScheduleV3Reference{}}
+	testEqual(t, want, res)
+}
+
+func TestScheduleV3_List500Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(mockScheduleV3Error500))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.ListSchedulesV3(context.Background(), ListSchedulesV3Options{})
+	if !testErrCheck(t, "ListSchedulesV3", "status code 500", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetScheduleV3
+// ---------------------------------------------------------------------------
+
+func TestScheduleV3_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockScheduleV3GetResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.GetScheduleV3(context.Background(), testScheduleV3ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ScheduleV3{
+		ID:          testScheduleV3ID,
+		Type:        "schedule",
+		Name:        "On-Call Schedule",
+		TimeZone:    "UTC",
+		Description: "Test schedule",
+		// Events key absent in JSON → nil slice
+		Rotations: []RotationV3{
+			{ID: testRotationV3ID, Type: "rotation"},
+		},
+	}
+	testEqual(t, want, res)
+}
+
+func TestScheduleV3_Get404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.GetScheduleV3(context.Background(), testScheduleV3ID)
+	if !testErrCheck(t, "GetScheduleV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateScheduleV3
+// ---------------------------------------------------------------------------
+
+func TestScheduleV3_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(mockScheduleV3MutateResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.CreateScheduleV3(context.Background(), ScheduleV3Input{
+		Name:        "On-Call Schedule",
+		TimeZone:    "UTC",
+		Description: "Test schedule",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ScheduleV3{
+		ID:          testScheduleV3ID,
+		Type:        "schedule",
+		Name:        "On-Call Schedule",
+		TimeZone:    "UTC",
+		Description: "Test schedule",
+	}
+	testEqual(t, want, res)
+}
+
+func TestScheduleV3_Create400Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(mockScheduleV3Error400))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.CreateScheduleV3(context.Background(), ScheduleV3Input{})
+	if !testErrCheck(t, "CreateScheduleV3", "Invalid Input", err) {
+		return
+	}
+}
+
+// The v3 API must respond 201; any other 2xx is treated as an error.
+func TestScheduleV3_CreateNon201Status(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK) // 200 instead of 201
+		_, _ = w.Write([]byte(mockScheduleV3MutateResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.CreateScheduleV3(context.Background(), ScheduleV3Input{Name: "Test", TimeZone: "UTC"})
+	if !testErrCheck(t, "CreateScheduleV3", "failed to create v3 schedule", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateScheduleV3
+// ---------------------------------------------------------------------------
+
+func TestScheduleV3_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockScheduleV3MutateResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.UpdateScheduleV3(context.Background(), testScheduleV3ID, ScheduleV3Input{
+		Name:        "On-Call Schedule",
+		TimeZone:    "UTC",
+		Description: "Test schedule",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ScheduleV3{
+		ID:          testScheduleV3ID,
+		Type:        "schedule",
+		Name:        "On-Call Schedule",
+		TimeZone:    "UTC",
+		Description: "Test schedule",
+	}
+	testEqual(t, want, res)
+}
+
+func TestScheduleV3_Update404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateScheduleV3(context.Background(), testScheduleV3ID, ScheduleV3Input{})
+	if !testErrCheck(t, "UpdateScheduleV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeleteScheduleV3
+// ---------------------------------------------------------------------------
+
+func TestScheduleV3_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testV3EarlyAccessHeader(t, r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	err := client.DeleteScheduleV3(context.Background(), testScheduleV3ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScheduleV3_Delete404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	err := client.DeleteScheduleV3(context.Background(), testScheduleV3ID)
+	if !testErrCheck(t, "DeleteScheduleV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateRotationV3
+// ---------------------------------------------------------------------------
+
+func TestRotationV3_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(mockRotationV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.CreateRotationV3(context.Background(), testScheduleV3ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &RotationV3{
+		ID:     testRotationV3ID,
+		Type:   "rotation",
+		Events: []EventV3{},
+	}
+	testEqual(t, want, res)
+}
+
+func TestRotationV3_CreateNon201Status(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK) // 200 instead of 201
+		_, _ = w.Write([]byte(mockRotationV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.CreateRotationV3(context.Background(), testScheduleV3ID)
+	if !testErrCheck(t, "CreateRotationV3", "failed to create v3 rotation", err) {
+		return
+	}
+}
+
+func TestRotationV3_Create404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.CreateRotationV3(context.Background(), testScheduleV3ID)
+	if !testErrCheck(t, "CreateRotationV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetRotationV3
+// ---------------------------------------------------------------------------
+
+func TestRotationV3_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockRotationV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.GetRotationV3(context.Background(), testScheduleV3ID, testRotationV3ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &RotationV3{
+		ID:     testRotationV3ID,
+		Type:   "rotation",
+		Events: []EventV3{},
+	}
+	testEqual(t, want, res)
+}
+
+func TestRotationV3_Get404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.GetRotationV3(context.Background(), testScheduleV3ID, testRotationV3ID)
+	if !testErrCheck(t, "GetRotationV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeleteRotationV3
+// ---------------------------------------------------------------------------
+
+func TestRotationV3_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testV3EarlyAccessHeader(t, r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	err := client.DeleteRotationV3(context.Background(), testScheduleV3ID, testRotationV3ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRotationV3_Delete404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	err := client.DeleteRotationV3(context.Background(), testScheduleV3ID, testRotationV3ID)
+	if !testErrCheck(t, "DeleteRotationV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateEventV3
+// ---------------------------------------------------------------------------
+
+func TestEventV3_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(mockEventV3Response))
+	})
+
+	userID := "USER01"
+	input := EventV3{
+		Name:           "On-Call Event",
+		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z"},
+		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z"},
+		EffectiveSince: "2026-02-21T09:00:00Z",
+		Recurrence:     []string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
+		AssignmentStrategy: AssignmentStrategyV3{
+			Type:    "user_assignment_strategy",
+			Members: []MemberV3{{Type: "user_member", UserID: &userID}},
+		},
+	}
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.CreateEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &EventV3{
+		ID:             testEventV3ID,
+		Type:           "schedule_event",
+		Name:           "On-Call Event",
+		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z"},
+		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z"},
+		EffectiveSince: "2026-02-21T09:00:00Z",
+		EffectiveUntil: nil,
+		Recurrence:     []string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
+		AssignmentStrategy: AssignmentStrategyV3{
+			Type:    "user_assignment_strategy",
+			Members: []MemberV3{{Type: "user_member", UserID: &userID}},
+		},
+	}
+	testEqual(t, want, res)
+}
+
+func TestEventV3_CreateNon201Status(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK) // 200 instead of 201
+		_, _ = w.Write([]byte(mockEventV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.CreateEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, EventV3{})
+	if !testErrCheck(t, "CreateEventV3", "failed to create v3 event", err) {
+		return
+	}
+}
+
+func TestEventV3_Create400Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(mockScheduleV3Error400))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.CreateEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, EventV3{})
+	if !testErrCheck(t, "CreateEventV3", "Invalid Input", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateEventV3
+// ---------------------------------------------------------------------------
+
+func TestEventV3_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events/"+testEventV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockEventV3Response))
+	})
+
+	userID := "USER01"
+	input := EventV3{
+		Name:           "On-Call Event",
+		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z"},
+		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z"},
+		EffectiveSince: "2026-02-21T09:00:00Z",
+		Recurrence:     []string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
+		AssignmentStrategy: AssignmentStrategyV3{
+			Type:    "user_assignment_strategy",
+			Members: []MemberV3{{Type: "user_member", UserID: &userID}},
+		},
+	}
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.UpdateEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, testEventV3ID, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &EventV3{
+		ID:             testEventV3ID,
+		Type:           "schedule_event",
+		Name:           "On-Call Event",
+		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z"},
+		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z"},
+		EffectiveSince: "2026-02-21T09:00:00Z",
+		EffectiveUntil: nil,
+		Recurrence:     []string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
+		AssignmentStrategy: AssignmentStrategyV3{
+			Type:    "user_assignment_strategy",
+			Members: []MemberV3{{Type: "user_member", UserID: &userID}},
+		},
+	}
+	testEqual(t, want, res)
+}
+
+func TestEventV3_Update404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events/"+testEventV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, testEventV3ID, EventV3{})
+	if !testErrCheck(t, "UpdateEventV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeleteEventV3
+// ---------------------------------------------------------------------------
+
+func TestEventV3_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events/"+testEventV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testV3EarlyAccessHeader(t, r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	err := client.DeleteEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, testEventV3ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEventV3_Delete404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events/"+testEventV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	err := client.DeleteEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, testEventV3ID)
+	if !testErrCheck(t, "DeleteEventV3", "Not Found", err) {
+		return
+	}
+}

--- a/schedule_v3_test.go
+++ b/schedule_v3_test.go
@@ -2,9 +2,18 @@ package pagerduty
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 )
+
+// testBodyContains decodes the request body JSON into dest and calls t.Fatal on error.
+func testBodyContains(t *testing.T, r *http.Request, dest interface{}) {
+	t.Helper()
+	if err := json.NewDecoder(r.Body).Decode(dest); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
+}
 
 var (
 	testScheduleV3ID = "SCHED01"
@@ -48,7 +57,10 @@ const (
 			"type": "schedule",
 			"name": "On-Call Schedule",
 			"time_zone": "UTC",
-			"description": "Test schedule"
+			"description": "Test schedule",
+			"teams": [
+				{"id": "TEAM01", "type": "team_reference"}
+			]
 		}
 	}`
 
@@ -62,17 +74,18 @@ const (
 	}`
 
 	mockEventV3Response = `{
-		"schedule_event": {
+		"event": {
 			"id": "EVT01",
 			"type": "schedule_event",
 			"name": "On-Call Event",
-			"start_time": {"date_time": "2026-02-21T09:00:00Z"},
-			"end_time":   {"date_time": "2026-02-21T17:00:00Z"},
+			"start_time": {"date_time": "2026-02-21T09:00:00Z", "time_zone": "America/New_York"},
+			"end_time":   {"date_time": "2026-02-21T17:00:00Z", "time_zone": "America/New_York"},
 			"effective_since": "2026-02-21T09:00:00Z",
 			"effective_until": null,
 			"recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"],
 			"assignment_strategy": {
-				"type": "user_assignment_strategy",
+				"type": "rotating_member_assignment_strategy",
+				"shifts_per_member": 1,
 				"members": [
 					{"type": "user_member", "user_id": "USER01"}
 				]
@@ -278,6 +291,12 @@ func TestScheduleV3_Create(t *testing.T) {
 	mux.HandleFunc("/v3/schedules", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testV3EarlyAccessHeader(t, r)
+		// Verify teams are forwarded in the request payload.
+		var body createScheduleV3Request
+		testBodyContains(t, r, &body)
+		if len(body.Schedule.Teams) != 1 || body.Schedule.Teams[0].ID != "TEAM01" {
+			t.Errorf("request teams = %v, want [{TEAM01 team_reference}]", body.Schedule.Teams)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte(mockScheduleV3MutateResponse))
@@ -288,6 +307,7 @@ func TestScheduleV3_Create(t *testing.T) {
 		Name:        "On-Call Schedule",
 		TimeZone:    "UTC",
 		Description: "Test schedule",
+		Teams:       []TeamReferenceV3{{ID: "TEAM01", Type: "team_reference"}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -299,6 +319,7 @@ func TestScheduleV3_Create(t *testing.T) {
 		Name:        "On-Call Schedule",
 		TimeZone:    "UTC",
 		Description: "Test schedule",
+		Teams:       []TeamReferenceV3{{ID: "TEAM01", Type: "team_reference"}},
 	}
 	testEqual(t, want, res)
 }
@@ -351,6 +372,12 @@ func TestScheduleV3_Update(t *testing.T) {
 	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testV3EarlyAccessHeader(t, r)
+		// Verify teams are forwarded in the request payload.
+		var body updateScheduleV3Request
+		testBodyContains(t, r, &body)
+		if len(body.Schedule.Teams) != 1 || body.Schedule.Teams[0].ID != "TEAM01" {
+			t.Errorf("request teams = %v, want [{TEAM01 team_reference}]", body.Schedule.Teams)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(mockScheduleV3MutateResponse))
 	})
@@ -360,6 +387,7 @@ func TestScheduleV3_Update(t *testing.T) {
 		Name:        "On-Call Schedule",
 		TimeZone:    "UTC",
 		Description: "Test schedule",
+		Teams:       []TeamReferenceV3{{ID: "TEAM01", Type: "team_reference"}},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -371,6 +399,7 @@ func TestScheduleV3_Update(t *testing.T) {
 		Name:        "On-Call Schedule",
 		TimeZone:    "UTC",
 		Description: "Test schedule",
+		Teams:       []TeamReferenceV3{{ID: "TEAM01", Type: "team_reference"}},
 	}
 	testEqual(t, want, res)
 }
@@ -595,21 +624,31 @@ func TestEventV3_Create(t *testing.T) {
 	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		testV3EarlyAccessHeader(t, r)
+		// Verify the request body is wrapped under "event" key.
+		var body struct {
+			Event EventV3 `json:"event"`
+		}
+		testBodyContains(t, r, &body)
+		if body.Event.Name != "On-Call Event" {
+			t.Errorf("request body event.name = %q, want %q", body.Event.Name, "On-Call Event")
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		_, _ = w.Write([]byte(mockEventV3Response))
 	})
 
+	shiftsPerMember := 1
 	userID := "USER01"
 	input := EventV3{
 		Name:           "On-Call Event",
-		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z"},
-		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z"},
+		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z", TimeZone: "America/New_York"},
+		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z", TimeZone: "America/New_York"},
 		EffectiveSince: "2026-02-21T09:00:00Z",
 		Recurrence:     []string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
 		AssignmentStrategy: AssignmentStrategyV3{
-			Type:    "user_assignment_strategy",
-			Members: []MemberV3{{Type: "user_member", UserID: &userID}},
+			Type:            "rotating_member_assignment_strategy",
+			ShiftsPerMember: &shiftsPerMember,
+			Members:         []MemberV3{{Type: "user_member", UserID: &userID}},
 		},
 	}
 
@@ -623,14 +662,15 @@ func TestEventV3_Create(t *testing.T) {
 		ID:             testEventV3ID,
 		Type:           "schedule_event",
 		Name:           "On-Call Event",
-		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z"},
-		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z"},
+		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z", TimeZone: "America/New_York"},
+		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z", TimeZone: "America/New_York"},
 		EffectiveSince: "2026-02-21T09:00:00Z",
 		EffectiveUntil: nil,
 		Recurrence:     []string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
 		AssignmentStrategy: AssignmentStrategyV3{
-			Type:    "user_assignment_strategy",
-			Members: []MemberV3{{Type: "user_member", UserID: &userID}},
+			Type:            "rotating_member_assignment_strategy",
+			ShiftsPerMember: &shiftsPerMember,
+			Members:         []MemberV3{{Type: "user_member", UserID: &userID}},
 		},
 	}
 	testEqual(t, want, res)
@@ -683,20 +723,30 @@ func TestEventV3_Update(t *testing.T) {
 	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events/"+testEventV3ID, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		testV3EarlyAccessHeader(t, r)
+		// Verify the request body is wrapped under "event" key.
+		var body struct {
+			Event EventV3 `json:"event"`
+		}
+		testBodyContains(t, r, &body)
+		if body.Event.Name != "On-Call Event" {
+			t.Errorf("request body event.name = %q, want %q", body.Event.Name, "On-Call Event")
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(mockEventV3Response))
 	})
 
+	shiftsPerMember := 1
 	userID := "USER01"
 	input := EventV3{
 		Name:           "On-Call Event",
-		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z"},
-		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z"},
+		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z", TimeZone: "America/New_York"},
+		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z", TimeZone: "America/New_York"},
 		EffectiveSince: "2026-02-21T09:00:00Z",
 		Recurrence:     []string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
 		AssignmentStrategy: AssignmentStrategyV3{
-			Type:    "user_assignment_strategy",
-			Members: []MemberV3{{Type: "user_member", UserID: &userID}},
+			Type:            "rotating_member_assignment_strategy",
+			ShiftsPerMember: &shiftsPerMember,
+			Members:         []MemberV3{{Type: "user_member", UserID: &userID}},
 		},
 	}
 
@@ -710,14 +760,15 @@ func TestEventV3_Update(t *testing.T) {
 		ID:             testEventV3ID,
 		Type:           "schedule_event",
 		Name:           "On-Call Event",
-		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z"},
-		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z"},
+		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z", TimeZone: "America/New_York"},
+		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z", TimeZone: "America/New_York"},
 		EffectiveSince: "2026-02-21T09:00:00Z",
 		EffectiveUntil: nil,
 		Recurrence:     []string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
 		AssignmentStrategy: AssignmentStrategyV3{
-			Type:    "user_assignment_strategy",
-			Members: []MemberV3{{Type: "user_member", UserID: &userID}},
+			Type:            "rotating_member_assignment_strategy",
+			ShiftsPerMember: &shiftsPerMember,
+			Members:         []MemberV3{{Type: "user_member", UserID: &userID}},
 		},
 	}
 	testEqual(t, want, res)
@@ -776,6 +827,65 @@ func TestEventV3_Delete404Error(t *testing.T) {
 	client := defaultTestClient(server.URL, "foo")
 	err := client.DeleteEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, testEventV3ID)
 	if !testErrCheck(t, "DeleteEventV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetEventV3
+// ---------------------------------------------------------------------------
+
+func TestEventV3_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events/"+testEventV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockEventV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.GetEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, testEventV3ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shiftsPerMember := 1
+	userID := "USER01"
+	want := &EventV3{
+		ID:             testEventV3ID,
+		Type:           "schedule_event",
+		Name:           "On-Call Event",
+		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z", TimeZone: "America/New_York"},
+		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z", TimeZone: "America/New_York"},
+		EffectiveSince: "2026-02-21T09:00:00Z",
+		EffectiveUntil: nil,
+		Recurrence:     []string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
+		AssignmentStrategy: AssignmentStrategyV3{
+			Type:            "rotating_member_assignment_strategy",
+			ShiftsPerMember: &shiftsPerMember,
+			Members:         []MemberV3{{Type: "user_member", UserID: &userID}},
+		},
+	}
+	testEqual(t, want, res)
+}
+
+func TestEventV3_Get404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events/"+testEventV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.GetEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, testEventV3ID)
+	if !testErrCheck(t, "GetEventV3", "Not Found", err) {
 		return
 	}
 }

--- a/schedule_v3_test.go
+++ b/schedule_v3_test.go
@@ -16,9 +16,11 @@ func testBodyContains(t *testing.T, r *http.Request, dest interface{}) {
 }
 
 var (
-	testScheduleV3ID = "SCHED01"
-	testRotationV3ID = "ROT01"
-	testEventV3ID    = "EVT01"
+	testScheduleV3ID   = "SCHED01"
+	testRotationV3ID   = "ROT01"
+	testEventV3ID      = "EVT01"
+	testCustomShiftID  = "CSH01"
+	testOverrideV3ID   = "OVR01"
 )
 
 const (
@@ -50,6 +52,50 @@ const (
 		}
 	}`
 
+	// Reproduces the real API response shape for a schedule associated with an
+	// escalation policy. Prior to the fix, this caused:
+	// "json: cannot unmarshal object into Go struct field
+	//  ScheduleV3.schedule.escalation_policies of type string"
+	mockScheduleV3GetWithEscalationPoliciesResponse = `{
+		"schedule": {
+			"id": "SCHED01",
+			"type": "schedule",
+			"name": "On-Call Schedule",
+			"time_zone": "UTC",
+			"escalation_policies": [
+				{
+					"id": "EP01",
+					"type": "escalation_policy",
+					"summary": "Default EP",
+					"self": "https://api.pagerduty.com/escalation_policies/EP01",
+					"html_url": "https://app.pagerduty.com/escalation_policies/EP01"
+				}
+			]
+		}
+	}`
+
+	mockScheduleV3GetWithFinalResponse = `{
+		"schedule": {
+			"id": "SCHED01",
+			"type": "schedule",
+			"name": "On-Call Schedule",
+			"time_zone": "UTC",
+			"final_schedule": {
+				"type": "final_schedule",
+				"rendered_coverage_percentage": 100,
+				"computed_shift_assignments": [
+					{
+						"type": "computed_shift_assignment",
+						"start_time": "2026-03-01T09:00:00Z",
+						"end_time": "2026-03-08T09:00:00Z",
+						"member": {"type": "user_member", "user_id": "USER01"},
+						"source": {"type": "schedule_rotation", "rotation_id": "ROT01"}
+					}
+				]
+			}
+		}
+	}`
+
 	// No rotations — used for create / update responses.
 	mockScheduleV3MutateResponse = `{
 		"schedule": {
@@ -73,6 +119,40 @@ const (
 		}
 	}`
 
+	mockListRotationsV3Response = `{
+		"rotations": [
+			{"id": "ROT01", "type": "rotation"}
+		],
+		"limit": 25,
+		"offset": 0,
+		"more": false
+	}`
+
+	mockListEventsV3Response = `{
+		"events": [
+			{
+				"id": "EVT01",
+				"type": "schedule_event",
+				"name": "On-Call Event",
+				"start_time": {"date_time": "2026-02-21T09:00:00Z", "time_zone": "America/New_York"},
+				"end_time":   {"date_time": "2026-02-21T17:00:00Z", "time_zone": "America/New_York"},
+				"effective_since": "2026-02-21T09:00:00Z",
+				"effective_until": null,
+				"recurrence": ["RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"],
+				"assignment_strategy": {
+					"type": "rotating_member_assignment_strategy",
+					"shifts_per_member": 1,
+					"members": [
+						{"type": "user_member", "user_id": "USER01"}
+					]
+				}
+			}
+		],
+		"limit": 25,
+		"offset": 0,
+		"more": false
+	}`
+
 	mockEventV3Response = `{
 		"event": {
 			"id": "EVT01",
@@ -91,6 +171,92 @@ const (
 				]
 			}
 		}
+	}`
+
+	mockCustomShiftV3Response = `{
+		"custom_shift": {
+			"id": "CSH01",
+			"type": "custom_shift",
+			"start_time": "2026-03-15T09:00:00Z",
+			"end_time":   "2026-03-15T17:00:00Z",
+			"assignments": [
+				{"id": "ASN01", "type": "shift_assignment", "member": {"type": "user_member", "user_id": "USER01"}}
+			]
+		}
+	}`
+
+	mockListCustomShiftsV3Response = `{
+		"custom_shifts": [
+			{
+				"id": "CSH01",
+				"type": "custom_shift",
+				"start_time": "2026-03-15T09:00:00Z",
+				"end_time":   "2026-03-15T17:00:00Z",
+				"assignments": [
+					{"id": "ASN01", "type": "shift_assignment", "member": {"type": "user_member", "user_id": "USER01"}}
+				]
+			}
+		],
+		"limit": 25,
+		"offset": 0,
+		"more": false
+	}`
+
+	mockCreateCustomShiftsV3Response = `{
+		"custom_shifts": [
+			{
+				"id": "CSH01",
+				"type": "custom_shift",
+				"start_time": "2026-03-15T09:00:00Z",
+				"end_time":   "2026-03-15T17:00:00Z",
+				"assignments": [
+					{"id": "ASN01", "type": "shift_assignment", "member": {"type": "user_member", "user_id": "USER01"}}
+				]
+			}
+		]
+	}`
+
+	mockOverrideShiftV3Response = `{
+		"override": {
+			"id": "OVR01",
+			"type": "override_shift",
+			"rotation_id": "ROT01",
+			"start_time": "2026-03-15T09:00:00Z",
+			"end_time":   "2026-03-15T17:00:00Z",
+			"overridden_member": {"type": "user_member", "user_id": "USER01"},
+			"overriding_member": {"type": "user_member", "user_id": "USER02"}
+		}
+	}`
+
+	mockListOverridesV3Response = `{
+		"overrides": [
+			{
+				"id": "OVR01",
+				"type": "override_shift",
+				"rotation_id": "ROT01",
+				"start_time": "2026-03-15T09:00:00Z",
+				"end_time":   "2026-03-15T17:00:00Z",
+				"overridden_member": {"type": "user_member", "user_id": "USER01"},
+				"overriding_member": {"type": "user_member", "user_id": "USER02"}
+			}
+		],
+		"limit": 25,
+		"offset": 0,
+		"more": false
+	}`
+
+	mockCreateOverridesV3Response = `{
+		"overrides": [
+			{
+				"id": "OVR01",
+				"type": "override_shift",
+				"rotation_id": "ROT01",
+				"start_time": "2026-03-15T09:00:00Z",
+				"end_time":   "2026-03-15T17:00:00Z",
+				"overridden_member": {"type": "user_member", "user_id": "USER01"},
+				"overriding_member": {"type": "user_member", "user_id": "USER02"}
+			}
+		]
 	}`
 
 	mockScheduleV3Error400 = `{
@@ -243,7 +409,7 @@ func TestScheduleV3_Get(t *testing.T) {
 	})
 
 	client := defaultTestClient(server.URL, "foo")
-	res, err := client.GetScheduleV3(context.Background(), testScheduleV3ID)
+	res, err := client.GetScheduleV3(context.Background(), testScheduleV3ID, GetScheduleV3Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,6 +428,44 @@ func TestScheduleV3_Get(t *testing.T) {
 	testEqual(t, want, res)
 }
 
+func TestScheduleV3_GetWithFinalSchedule(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		if got := r.URL.Query().Get("since"); got == "" {
+			t.Error("expected since query param")
+		}
+		if got := r.URL.Query().Get("until"); got == "" {
+			t.Error("expected until query param")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockScheduleV3GetWithFinalResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.GetScheduleV3(context.Background(), testScheduleV3ID, GetScheduleV3Options{
+		Since:   "2026-03-01T00:00:00Z",
+		Until:   "2026-03-08T00:00:00Z",
+		Include: []string{"final_schedule"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.FinalSchedule == nil {
+		t.Fatal("expected FinalSchedule to be non-nil")
+	}
+	if res.FinalSchedule.RenderedCoveragePercentage != 100 {
+		t.Errorf("RenderedCoveragePercentage = %v, want 100", res.FinalSchedule.RenderedCoveragePercentage)
+	}
+	if len(res.FinalSchedule.ComputedShiftAssignments) != 1 {
+		t.Fatalf("len(ComputedShiftAssignments) = %d, want 1", len(res.FinalSchedule.ComputedShiftAssignments))
+	}
+}
+
 func TestScheduleV3_Get404Error(t *testing.T) {
 	setup()
 	defer teardown()
@@ -274,9 +478,37 @@ func TestScheduleV3_Get404Error(t *testing.T) {
 	})
 
 	client := defaultTestClient(server.URL, "foo")
-	_, err := client.GetScheduleV3(context.Background(), testScheduleV3ID)
+	_, err := client.GetScheduleV3(context.Background(), testScheduleV3ID, GetScheduleV3Options{})
 	if !testErrCheck(t, "GetScheduleV3", "Not Found", err) {
 		return
+	}
+}
+
+func TestScheduleV3_GetWithEscalationPolicies(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockScheduleV3GetWithEscalationPoliciesResponse))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.GetScheduleV3(context.Background(), testScheduleV3ID)
+	if err != nil {
+		t.Fatalf("GetScheduleV3 returned error: %v", err)
+	}
+
+	if len(res.EscalationPolicies) != 1 {
+		t.Fatalf("len(EscalationPolicies) = %d, want 1", len(res.EscalationPolicies))
+	}
+	if got := res.EscalationPolicies[0].ID; got != "EP01" {
+		t.Errorf("EscalationPolicies[0].ID = %q, want %q", got, "EP01")
+	}
+	if got := res.EscalationPolicies[0].Type; got != "escalation_policy" {
+		t.Errorf("EscalationPolicies[0].Type = %q, want %q", got, "escalation_policy")
 	}
 }
 
@@ -462,6 +694,56 @@ func TestScheduleV3_Delete404Error(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// ListRotationsV3
+// ---------------------------------------------------------------------------
+
+func TestRotationV3_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockListRotationsV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListRotationsV3(context.Background(), testScheduleV3ID, ListRotationsV3Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &ListRotationsV3Response{
+		Rotations: []RotationV3{
+			{ID: testRotationV3ID, Type: "rotation"},
+		},
+		Limit:  25,
+		Offset: 0,
+		More:   false,
+	}
+	testEqual(t, want, res)
+}
+
+func TestRotationV3_List404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.ListRotationsV3(context.Background(), testScheduleV3ID, ListRotationsV3Options{})
+	if !testErrCheck(t, "ListRotationsV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
 // CreateRotationV3
 // ---------------------------------------------------------------------------
 
@@ -543,7 +825,7 @@ func TestRotationV3_Get(t *testing.T) {
 	})
 
 	client := defaultTestClient(server.URL, "foo")
-	res, err := client.GetRotationV3(context.Background(), testScheduleV3ID, testRotationV3ID)
+	res, err := client.GetRotationV3(context.Background(), testScheduleV3ID, testRotationV3ID, GetRotationV3Options{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -554,6 +836,32 @@ func TestRotationV3_Get(t *testing.T) {
 		Events: []EventV3{},
 	}
 	testEqual(t, want, res)
+}
+
+func TestRotationV3_GetWithTimeRange(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if got := r.URL.Query().Get("since"); got != "2026-03-01T00:00:00Z" {
+			t.Errorf("since = %q, want %q", got, "2026-03-01T00:00:00Z")
+		}
+		if got := r.URL.Query().Get("until"); got != "2026-03-08T00:00:00Z" {
+			t.Errorf("until = %q, want %q", got, "2026-03-08T00:00:00Z")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockRotationV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.GetRotationV3(context.Background(), testScheduleV3ID, testRotationV3ID, GetRotationV3Options{
+		Since: "2026-03-01T00:00:00Z",
+		Until: "2026-03-08T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestRotationV3_Get404Error(t *testing.T) {
@@ -568,7 +876,7 @@ func TestRotationV3_Get404Error(t *testing.T) {
 	})
 
 	client := defaultTestClient(server.URL, "foo")
-	_, err := client.GetRotationV3(context.Background(), testScheduleV3ID, testRotationV3ID)
+	_, err := client.GetRotationV3(context.Background(), testScheduleV3ID, testRotationV3ID, GetRotationV3Options{})
 	if !testErrCheck(t, "GetRotationV3", "Not Found", err) {
 		return
 	}
@@ -609,6 +917,56 @@ func TestRotationV3_Delete404Error(t *testing.T) {
 	client := defaultTestClient(server.URL, "foo")
 	err := client.DeleteRotationV3(context.Background(), testScheduleV3ID, testRotationV3ID)
 	if !testErrCheck(t, "DeleteRotationV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListEventsV3
+// ---------------------------------------------------------------------------
+
+func TestEventV3_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockListEventsV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListEventsV3(context.Background(), testScheduleV3ID, testRotationV3ID, ListEventsV3Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res.Events) != 1 {
+		t.Fatalf("len(Events) = %d, want 1", len(res.Events))
+	}
+	if res.Events[0].ID != testEventV3ID {
+		t.Errorf("Events[0].ID = %q, want %q", res.Events[0].ID, testEventV3ID)
+	}
+	if res.Limit != 25 {
+		t.Errorf("Limit = %d, want 25", res.Limit)
+	}
+}
+
+func TestEventV3_List404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.ListEventsV3(context.Background(), testScheduleV3ID, testRotationV3ID, ListEventsV3Options{})
+	if !testErrCheck(t, "ListEventsV3", "Not Found", err) {
 		return
 	}
 }
@@ -708,6 +1066,65 @@ func TestEventV3_Create400Error(t *testing.T) {
 	client := defaultTestClient(server.URL, "foo")
 	_, err := client.CreateEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, EventV3{})
 	if !testErrCheck(t, "CreateEventV3", "Invalid Input", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetEventV3
+// ---------------------------------------------------------------------------
+
+func TestEventV3_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events/"+testEventV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockEventV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.GetEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, testEventV3ID, GetEventV3Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	shiftsPerMember := 1
+	userID := "USER01"
+	want := &EventV3{
+		ID:             testEventV3ID,
+		Type:           "schedule_event",
+		Name:           "On-Call Event",
+		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z", TimeZone: "America/New_York"},
+		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z", TimeZone: "America/New_York"},
+		EffectiveSince: "2026-02-21T09:00:00Z",
+		EffectiveUntil: nil,
+		Recurrence:     []string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
+		AssignmentStrategy: AssignmentStrategyV3{
+			Type:            "rotating_member_assignment_strategy",
+			ShiftsPerMember: &shiftsPerMember,
+			Members:         []MemberV3{{Type: "user_member", UserID: &userID}},
+		},
+	}
+	testEqual(t, want, res)
+}
+
+func TestEventV3_Get404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events/"+testEventV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.GetEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, testEventV3ID, GetEventV3Options{})
+	if !testErrCheck(t, "GetEventV3", "Not Found", err) {
 		return
 	}
 }
@@ -832,51 +1249,48 @@ func TestEventV3_Delete404Error(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// GetEventV3
+// ListCustomShiftsV3
 // ---------------------------------------------------------------------------
 
-func TestEventV3_Get(t *testing.T) {
+func TestCustomShiftV3_List(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events/"+testEventV3ID, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/custom_shifts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testV3EarlyAccessHeader(t, r)
+		if got := r.URL.Query().Get("since"); got == "" {
+			t.Error("expected since query param")
+		}
+		if got := r.URL.Query().Get("until"); got == "" {
+			t.Error("expected until query param")
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(mockEventV3Response))
+		_, _ = w.Write([]byte(mockListCustomShiftsV3Response))
 	})
 
 	client := defaultTestClient(server.URL, "foo")
-	res, err := client.GetEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, testEventV3ID)
+	res, err := client.ListCustomShiftsV3(context.Background(), testScheduleV3ID, ListCustomShiftsV3Options{
+		Since: "2026-03-01T00:00:00Z",
+		Until: "2026-03-31T00:00:00Z",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	shiftsPerMember := 1
-	userID := "USER01"
-	want := &EventV3{
-		ID:             testEventV3ID,
-		Type:           "schedule_event",
-		Name:           "On-Call Event",
-		StartTime:      EventTimeV3{DateTime: "2026-02-21T09:00:00Z", TimeZone: "America/New_York"},
-		EndTime:        EventTimeV3{DateTime: "2026-02-21T17:00:00Z", TimeZone: "America/New_York"},
-		EffectiveSince: "2026-02-21T09:00:00Z",
-		EffectiveUntil: nil,
-		Recurrence:     []string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"},
-		AssignmentStrategy: AssignmentStrategyV3{
-			Type:            "rotating_member_assignment_strategy",
-			ShiftsPerMember: &shiftsPerMember,
-			Members:         []MemberV3{{Type: "user_member", UserID: &userID}},
-		},
+	if len(res.CustomShifts) != 1 {
+		t.Fatalf("len(CustomShifts) = %d, want 1", len(res.CustomShifts))
 	}
-	testEqual(t, want, res)
+	if res.CustomShifts[0].ID != testCustomShiftID {
+		t.Errorf("CustomShifts[0].ID = %q, want %q", res.CustomShifts[0].ID, testCustomShiftID)
+	}
 }
 
-func TestEventV3_Get404Error(t *testing.T) {
+func TestCustomShiftV3_List404Error(t *testing.T) {
 	setup()
 	defer teardown()
 
-	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/rotations/"+testRotationV3ID+"/events/"+testEventV3ID, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/custom_shifts", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
@@ -884,8 +1298,492 @@ func TestEventV3_Get404Error(t *testing.T) {
 	})
 
 	client := defaultTestClient(server.URL, "foo")
-	_, err := client.GetEventV3(context.Background(), testScheduleV3ID, testRotationV3ID, testEventV3ID)
-	if !testErrCheck(t, "GetEventV3", "Not Found", err) {
+	_, err := client.ListCustomShiftsV3(context.Background(), testScheduleV3ID, ListCustomShiftsV3Options{
+		Since: "2026-03-01T00:00:00Z",
+		Until: "2026-03-31T00:00:00Z",
+	})
+	if !testErrCheck(t, "ListCustomShiftsV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateCustomShiftsV3
+// ---------------------------------------------------------------------------
+
+func TestCustomShiftV3_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/custom_shifts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testV3EarlyAccessHeader(t, r)
+		var body createCustomShiftsV3Request
+		testBodyContains(t, r, &body)
+		if len(body.CustomShifts) != 1 {
+			t.Fatalf("len(custom_shifts) = %d, want 1", len(body.CustomShifts))
+		}
+		if body.CustomShifts[0].StartTime != "2026-03-15T09:00:00Z" {
+			t.Errorf("start_time = %q, want %q", body.CustomShifts[0].StartTime, "2026-03-15T09:00:00Z")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(mockCreateCustomShiftsV3Response))
+	})
+
+	userID := "USER01"
+	input := []CustomShiftInputV3{
+		{
+			Type:      "custom_shift",
+			StartTime: "2026-03-15T09:00:00Z",
+			EndTime:   "2026-03-15T17:00:00Z",
+			Assignments: []ShiftAssignmentV3{
+				{Type: "shift_assignment", Member: MemberV3{Type: "user_member", UserID: &userID}},
+			},
+		},
+	}
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.CreateCustomShiftsV3(context.Background(), testScheduleV3ID, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(res))
+	}
+	if res[0].ID != testCustomShiftID {
+		t.Errorf("ID = %q, want %q", res[0].ID, testCustomShiftID)
+	}
+}
+
+func TestCustomShiftV3_CreateNon201Status(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/custom_shifts", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK) // 200 instead of 201
+		_, _ = w.Write([]byte(mockCreateCustomShiftsV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.CreateCustomShiftsV3(context.Background(), testScheduleV3ID, []CustomShiftInputV3{})
+	if !testErrCheck(t, "CreateCustomShiftsV3", "failed to create v3 custom shifts", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetCustomShiftV3
+// ---------------------------------------------------------------------------
+
+func TestCustomShiftV3_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/custom_shifts/"+testCustomShiftID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockCustomShiftV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.GetCustomShiftV3(context.Background(), testScheduleV3ID, testCustomShiftID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userID := "USER01"
+	want := &CustomShiftV3{
+		ID:        testCustomShiftID,
+		Type:      "custom_shift",
+		StartTime: "2026-03-15T09:00:00Z",
+		EndTime:   "2026-03-15T17:00:00Z",
+		Assignments: []ShiftAssignmentV3{
+			{ID: "ASN01", Type: "shift_assignment", Member: MemberV3{Type: "user_member", UserID: &userID}},
+		},
+	}
+	testEqual(t, want, res)
+}
+
+func TestCustomShiftV3_Get404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/custom_shifts/"+testCustomShiftID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.GetCustomShiftV3(context.Background(), testScheduleV3ID, testCustomShiftID)
+	if !testErrCheck(t, "GetCustomShiftV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateCustomShiftV3
+// ---------------------------------------------------------------------------
+
+func TestCustomShiftV3_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/custom_shifts/"+testCustomShiftID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testV3EarlyAccessHeader(t, r)
+		var body updateCustomShiftV3Request
+		testBodyContains(t, r, &body)
+		if body.CustomShift.EndTime != "2026-03-15T18:00:00Z" {
+			t.Errorf("end_time = %q, want %q", body.CustomShift.EndTime, "2026-03-15T18:00:00Z")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockCustomShiftV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.UpdateCustomShiftV3(context.Background(), testScheduleV3ID, testCustomShiftID, CustomShiftUpdateV3{
+		EndTime: "2026-03-15T18:00:00Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.ID != testCustomShiftID {
+		t.Errorf("ID = %q, want %q", res.ID, testCustomShiftID)
+	}
+}
+
+func TestCustomShiftV3_Update404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/custom_shifts/"+testCustomShiftID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateCustomShiftV3(context.Background(), testScheduleV3ID, testCustomShiftID, CustomShiftUpdateV3{})
+	if !testErrCheck(t, "UpdateCustomShiftV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeleteCustomShiftV3
+// ---------------------------------------------------------------------------
+
+func TestCustomShiftV3_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/custom_shifts/"+testCustomShiftID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testV3EarlyAccessHeader(t, r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	err := client.DeleteCustomShiftV3(context.Background(), testScheduleV3ID, testCustomShiftID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCustomShiftV3_Delete404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/custom_shifts/"+testCustomShiftID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	err := client.DeleteCustomShiftV3(context.Background(), testScheduleV3ID, testCustomShiftID)
+	if !testErrCheck(t, "DeleteCustomShiftV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ListOverridesV3
+// ---------------------------------------------------------------------------
+
+func TestOverrideV3_List(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/overrides", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		if got := r.URL.Query().Get("since"); got == "" {
+			t.Error("expected since query param")
+		}
+		if got := r.URL.Query().Get("until"); got == "" {
+			t.Error("expected until query param")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockListOverridesV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.ListOverridesV3(context.Background(), testScheduleV3ID, ListOverridesV3Options{
+		Since: "2026-03-01T00:00:00Z",
+		Until: "2026-03-31T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res.Overrides) != 1 {
+		t.Fatalf("len(Overrides) = %d, want 1", len(res.Overrides))
+	}
+	if res.Overrides[0].ID != testOverrideV3ID {
+		t.Errorf("Overrides[0].ID = %q, want %q", res.Overrides[0].ID, testOverrideV3ID)
+	}
+}
+
+func TestOverrideV3_List404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/overrides", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.ListOverridesV3(context.Background(), testScheduleV3ID, ListOverridesV3Options{
+		Since: "2026-03-01T00:00:00Z",
+		Until: "2026-03-31T00:00:00Z",
+	})
+	if !testErrCheck(t, "ListOverridesV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CreateOverridesV3
+// ---------------------------------------------------------------------------
+
+func TestOverrideV3_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/overrides", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testV3EarlyAccessHeader(t, r)
+		var body createOverridesV3Request
+		testBodyContains(t, r, &body)
+		if len(body.Overrides) != 1 {
+			t.Fatalf("len(overrides) = %d, want 1", len(body.Overrides))
+		}
+		if body.Overrides[0].RotationID != "ROT01" {
+			t.Errorf("rotation_id = %q, want %q", body.Overrides[0].RotationID, "ROT01")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(mockCreateOverridesV3Response))
+	})
+
+	user1 := "USER01"
+	user2 := "USER02"
+	input := []OverrideShiftInputV3{
+		{
+			Type:             "override_shift",
+			RotationID:       "ROT01",
+			StartTime:        "2026-03-15T09:00:00Z",
+			EndTime:          "2026-03-15T17:00:00Z",
+			OverriddenMember: MemberV3{Type: "user_member", UserID: &user1},
+			OverridingMember: MemberV3{Type: "user_member", UserID: &user2},
+		},
+	}
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.CreateOverridesV3(context.Background(), testScheduleV3ID, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res) != 1 {
+		t.Fatalf("len(result) = %d, want 1", len(res))
+	}
+	if res[0].ID != testOverrideV3ID {
+		t.Errorf("ID = %q, want %q", res[0].ID, testOverrideV3ID)
+	}
+}
+
+func TestOverrideV3_CreateNon201Status(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/overrides", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK) // 200 instead of 201
+		_, _ = w.Write([]byte(mockCreateOverridesV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.CreateOverridesV3(context.Background(), testScheduleV3ID, []OverrideShiftInputV3{})
+	if !testErrCheck(t, "CreateOverridesV3", "failed to create v3 overrides", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetOverrideV3
+// ---------------------------------------------------------------------------
+
+func TestOverrideV3_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/overrides/"+testOverrideV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testV3EarlyAccessHeader(t, r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockOverrideShiftV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.GetOverrideV3(context.Background(), testScheduleV3ID, testOverrideV3ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	user1 := "USER01"
+	user2 := "USER02"
+	want := &OverrideShiftV3{
+		ID:               testOverrideV3ID,
+		Type:             "override_shift",
+		RotationID:       "ROT01",
+		StartTime:        "2026-03-15T09:00:00Z",
+		EndTime:          "2026-03-15T17:00:00Z",
+		OverriddenMember: MemberV3{Type: "user_member", UserID: &user1},
+		OverridingMember: MemberV3{Type: "user_member", UserID: &user2},
+	}
+	testEqual(t, want, res)
+}
+
+func TestOverrideV3_Get404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/overrides/"+testOverrideV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.GetOverrideV3(context.Background(), testScheduleV3ID, testOverrideV3ID)
+	if !testErrCheck(t, "GetOverrideV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// UpdateOverrideV3
+// ---------------------------------------------------------------------------
+
+func TestOverrideV3_Update(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/overrides/"+testOverrideV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		testV3EarlyAccessHeader(t, r)
+		var body updateOverrideV3Request
+		testBodyContains(t, r, &body)
+		if body.Override.EndTime != "2026-03-15T18:00:00Z" {
+			t.Errorf("end_time = %q, want %q", body.Override.EndTime, "2026-03-15T18:00:00Z")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(mockOverrideShiftV3Response))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	res, err := client.UpdateOverrideV3(context.Background(), testScheduleV3ID, testOverrideV3ID, OverrideShiftUpdateV3{
+		EndTime: "2026-03-15T18:00:00Z",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.ID != testOverrideV3ID {
+		t.Errorf("ID = %q, want %q", res.ID, testOverrideV3ID)
+	}
+}
+
+func TestOverrideV3_Update404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/overrides/"+testOverrideV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	_, err := client.UpdateOverrideV3(context.Background(), testScheduleV3ID, testOverrideV3ID, OverrideShiftUpdateV3{})
+	if !testErrCheck(t, "UpdateOverrideV3", "Not Found", err) {
+		return
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeleteOverrideV3
+// ---------------------------------------------------------------------------
+
+func TestOverrideV3_Delete(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/overrides/"+testOverrideV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		testV3EarlyAccessHeader(t, r)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	err := client.DeleteOverrideV3(context.Background(), testScheduleV3ID, testOverrideV3ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOverrideV3_Delete404Error(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v3/schedules/"+testScheduleV3ID+"/overrides/"+testOverrideV3ID, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(mockScheduleV3Error404))
+	})
+
+	client := defaultTestClient(server.URL, "foo")
+	err := client.DeleteOverrideV3(context.Background(), testScheduleV3ID, testOverrideV3ID)
+	if !testErrCheck(t, "DeleteOverrideV3", "Not Found", err) {
 		return
 	}
 }


### PR DESCRIPTION
## Summary

Adds full CRUD client support for the PagerDuty [v3 Schedules API](https://developer.pagerduty.com/api-reference/d90c4c94e3ce2-create-a-schedule) (`/v3/schedules`) in `schedule_v3.go`.

## Changes

### New types
- `TeamReferenceV3` — team association for schedules (`id`, `type`)

### Updated types
- `ScheduleV3` — added `Teams []TeamReferenceV3`
- `ScheduleV3Input` — added `Teams []TeamReferenceV3`
- `scheduleV3Payload` — added `Teams []TeamReferenceV3`
- `AssignmentStrategyV3` — added `ShiftsPerMember *int` (required by API for `rotating_member_assignment_strategy`)

### Request/response envelope fixes
- `eventV3Response` — corrected JSON key from `"schedule_event"` → `"event"` (new API spec)
- Added `createEventV3Request` wrapper (`{"event": {...}}`) — the API requires this envelope on POST
- Added `updateEventV3Request` wrapper (`{"event": {...}}`) — the API requires this envelope on PUT
- `CreateEventV3` and `UpdateEventV3` now use the correct request wrappers

### New methods
- `GetEventV3` — retrieve a single event by ID

### Propagate teams
- `CreateScheduleV3` and `UpdateScheduleV3` now pass `Teams` through to the payload