### PR TITLE
docs: fix 15 typos in Go doc comments and variable names

### DIFF
--- a/alert_grouping_setting.go
+++ b/alert_grouping_setting.go
@@ -8,13 +8,13 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-// AlertGroupingSettingConfigTime is the configuration content for a
+// AlertGroupingSettingConfigTime is the configuration content for an
 // AlertGroupingSetting of type "time"
 type AlertGroupingSettingConfigTime struct {
 	Timeout uint `json:"timeout"`
 }
 
-// AlertGroupingSettingConfigIntelligent is the configuration content for a
+// AlertGroupingSettingConfigIntelligent is the configuration content for an
 // AlertGroupingSetting of type "intelligent"
 type AlertGroupingSettingConfigIntelligent struct {
 	TimeWindow            uint     `json:"time_window"`
@@ -22,7 +22,7 @@ type AlertGroupingSettingConfigIntelligent struct {
 	IagFields             []string `json:"iag_fields"`
 }
 
-// AlertGroupingSettingConfigContentBased is the configuration content for a
+// AlertGroupingSettingConfigContentBased is the configuration content for an
 // AlertGroupingSetting of type "content_based" or "content_based_intelligent"
 type AlertGroupingSettingConfigContentBased struct {
 	TimeWindow            uint     `json:"time_window"`
@@ -140,7 +140,7 @@ func (c *Client) ListAlertGroupingSettings(ctx context.Context, o ListAlertGroup
 	return result, nil
 }
 
-// GetAlertGroupingSetting get an existing Alert Grouping Setting.
+// GetAlertGroupingSetting gets an existing Alert Grouping Setting.
 func (c *Client) GetAlertGroupingSetting(ctx context.Context, id string) (*AlertGroupingSetting, error) {
 	resp, err := c.get(ctx, "/alert_grouping_settings/"+id, nil)
 	if err != nil {
@@ -191,7 +191,7 @@ type alertGroupingSettingRaw struct {
 	Config json.RawMessage `json:"config,omitempty"`
 }
 
-// getAlertGroupingSettingFromRaw transform the content of a Alert Grouping
+// getAlertGroupingSettingFromRaw transforms the content of an Alert Grouping
 // Setting "config" field from a json raw message into the data structure
 // corresponding to its "type".
 func getAlertGroupingSettingFromRaw(raw alertGroupingSettingRaw) (*AlertGroupingSetting, error) {

--- a/audit.go
+++ b/audit.go
@@ -34,7 +34,7 @@ type ListAuditRecordsResponse struct {
 	// into a JSON.
 	ResponseMetaData *ResponseMetadata `json:"response_metadata,omitempty"`
 	Limit            uint              `json:"limit,omitempty"`
-	// NextCursor is an  opaque string that will deliver the next set of results
+	// NextCursor is an opaque string that will deliver the next set of results
 	// when provided as the cursor parameter in a subsequent request.
 	// A null value for this field indicates that there are no additional results.
 	// We use a pointer here to marshall the string value into null
@@ -42,7 +42,7 @@ type ListAuditRecordsResponse struct {
 	NextCursor *string `json:"next_cursor"`
 }
 
-// AuditRecord is a audit trail record that matches the query criteria.
+// AuditRecord is an audit trail record that matches the query criteria.
 type AuditRecord struct {
 	ID               string           `json:"id,omitempty"`
 	Self             string           `json:"self,omitempty"`
@@ -100,7 +100,7 @@ type Reference struct {
 	Removed     []APIObject `json:"removed,omitempty"`
 }
 
-// ListAuditRecords lists audit trial records matching provided query params
+// ListAuditRecords lists audit trail records matching provided query params
 // or default criteria.
 func (c *Client) ListAuditRecords(ctx context.Context, o ListAuditRecordsOptions) (ListAuditRecordsResponse, error) {
 	v, err := query.Values(o)
@@ -122,7 +122,7 @@ func (c *Client) ListAuditRecords(ctx context.Context, o ListAuditRecordsOptions
 	return result, nil
 }
 
-// ListAuditRecordsPaginated lists audit trial records matching provided query
+// ListAuditRecordsPaginated lists audit trail records matching provided query
 // params or default criteria, processing paginated responses. The include
 // function decides whether or not to include a specific AuditRecord in
 // the final result. If the include function is nil, all audit records from

--- a/business_service.go
+++ b/business_service.go
@@ -82,7 +82,7 @@ func (c *Client) ListBusinessServices(o ListBusinessServiceOptions) (*ListBusine
 // ListBusinessServicesPaginated lists existing business services, automatically
 // handling pagination and returning the full collection.
 func (c *Client) ListBusinessServicesPaginated(ctx context.Context, o ListBusinessServiceOptions) ([]*BusinessService, error) {
-	queryParms, err := query.Values(o)
+	queryParams, err := query.Values(o)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (c *Client) ListBusinessServicesPaginated(ctx context.Context, o ListBusine
 	}
 
 	// Make call to get all pages associated with the base endpoint.
-	if err := c.pagedGet(ctx, "/business_services?"+queryParms.Encode(), responseHandler); err != nil {
+	if err := c.pagedGet(ctx, "/business_services?"+queryParams.Encode(), responseHandler); err != nil {
 		return nil, err
 	}
 

--- a/extension.go
+++ b/extension.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-// Extension represents a single PagerDuty extension. These are addtional
+// Extension represents a single PagerDuty extension. These are additional
 // features to be used as part of the incident management process.
 type Extension struct {
 	APIObject

--- a/maintenance_window.go
+++ b/maintenance_window.go
@@ -20,7 +20,7 @@ type MaintenanceWindow struct {
 	CreatedBy      *APIObject  `json:"created_by,omitempty"`
 }
 
-// ListMaintenanceWindowsResponse is the data structur returned from calling the ListMaintenanceWindows API endpoint.
+// ListMaintenanceWindowsResponse is the data structure returned from calling the ListMaintenanceWindows API endpoint.
 type ListMaintenanceWindowsResponse struct {
 	APIListObject
 	MaintenanceWindows []MaintenanceWindow `json:"maintenance_windows"`
@@ -120,7 +120,7 @@ func (c *Client) CreateMaintenanceWindows(o MaintenanceWindow) (*MaintenanceWind
 }
 
 // DeleteMaintenanceWindow deletes an existing maintenance window if it's in the
-// future, or ends it if it's currently on-going.
+// future, or ends it if it's currently ongoing.
 //
 // Deprecated: Use DeleteMaintenanceWindowWithContext instead.
 func (c *Client) DeleteMaintenanceWindow(id string) error {
@@ -128,7 +128,7 @@ func (c *Client) DeleteMaintenanceWindow(id string) error {
 }
 
 // DeleteMaintenanceWindowWithContext deletes an existing maintenance window if it's in the
-// future, or ends it if it's currently on-going.
+// future, or ends it if it's currently ongoing.
 func (c *Client) DeleteMaintenanceWindowWithContext(ctx context.Context, id string) error {
 	_, err := c.delete(ctx, "/maintenance_windows/"+id)
 	return err


### PR DESCRIPTION
## Summary

Fix 15 typos and grammar issues across 5 files:

- **alert_grouping_setting.go**: fix "a AlertGroupingSetting" → "an" (3 instances), update Go doc verbs "get" → "gets" and "transform" → "transforms", fix "a Alert" → "an Alert"
- **business_service.go**: rename local variable `queryParms` → `queryParams` (not exported, safe to rename)
- **maintenance_window.go**: fix "structur" → "structure", "on-going" → "ongoing" (2 instances)
- **extension.go**: fix "addtional" → "additional"
- **audit.go**: fix "a audit" → "an audit", "audit trial" → "audit trail" (2 instances), remove extra space in "an  opaque"

The `queryParams` rename is a local variable only — not exported and not part of any public API. All other changes are in comments/documentation.