### PR TITLE
Migrate from gopkg.in/yaml.v2 to gopkg.in/yaml.v3

### DIFF
--- a/command/addon_list.go
+++ b/command/addon_list.go
@@ -5,7 +5,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"strings"
 )
 

--- a/command/addon_show.go
+++ b/command/addon_show.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"strings"
 )
 

--- a/command/escalation_policy_list.go
+++ b/command/escalation_policy_list.go
@@ -5,7 +5,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"strings"
 )
 

--- a/command/escalation_policy_show.go
+++ b/command/escalation_policy_show.go
@@ -5,7 +5,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"strings"
 )
 

--- a/command/event_orchestration_list.go
+++ b/command/event_orchestration_list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type EventOrchestrationList struct {

--- a/command/event_orchestration_show.go
+++ b/command/event_orchestration_show.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type EventOrchestrationShow struct {

--- a/command/incident_list.go
+++ b/command/incident_list.go
@@ -5,7 +5,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"strings"
 )
 

--- a/command/maintenance_window_list.go
+++ b/command/maintenance_window_list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type MaintenanceWindowList struct {

--- a/command/maintenance_window_show.go
+++ b/command/maintenance_window_show.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type MaintenanceWindowShow struct {

--- a/command/meta.go
+++ b/command/meta.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type ArrayFlags []string

--- a/command/oncall_list.go
+++ b/command/oncall_list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type OncallList struct {

--- a/command/schedule_list.go
+++ b/command/schedule_list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	yaml "gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v3"
 
 	pagerduty "github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"

--- a/command/service_list.go
+++ b/command/service_list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type ServiceList struct {

--- a/command/service_rule_list.go
+++ b/command/service_rule_list.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type ServiceRuleList struct {

--- a/command/service_rule_show.go
+++ b/command/service_rule_show.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type ServiceRuleShow struct {

--- a/command/service_show.go
+++ b/command/service_show.go
@@ -5,7 +5,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"strings"
 )
 

--- a/command/standard_list.go
+++ b/command/standard_list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type StandardList struct {

--- a/command/standard_multi_resources_scores_list.go
+++ b/command/standard_multi_resources_scores_list.go
@@ -8,7 +8,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type StandardListMultiResourcesScores struct {

--- a/command/standard_resource_scores_list.go
+++ b/command/standard_resource_scores_list.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type StandardListResourceScores struct {

--- a/command/team_list.go
+++ b/command/team_list.go
@@ -5,7 +5,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"strings"
 )
 

--- a/command/team_show.go
+++ b/command/team_show.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"strings"
 )
 

--- a/command/user_list.go
+++ b/command/user_list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type UserList struct {

--- a/command/vendor_list.go
+++ b/command/vendor_list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/mitchellh/cli"
 	log "github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type VendorList struct {

--- a/command/vendor_show.go
+++ b/command/vendor_show.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
 	"github.com/mitchellh/cli"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	"strings"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sirupsen/logrus v1.9.3
 	golang.org/x/oauth2 v0.15.0
-	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -37,4 +36,5 @@ require (
 	golang.org/x/sys v0.15.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -141,8 +141,8 @@ google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqw
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Summary

Migrate all usages of `gopkg.in/yaml.v2` to `gopkg.in/yaml.v3`.

## Motivation

The [go-yaml/yaml](https://github.com/go-yaml/yaml) repository has been archived and the maintainer has declared it unmaintained. `yaml.v3` is the maintained successor.

## Changes

- Updated all import paths from `gopkg.in/yaml.v2` to `gopkg.in/yaml.v3` across 24 files in `command/`
- Ran `go mod tidy` to update `go.mod` and `go.sum`

## Compatibility

This project only uses `yaml.Marshal` and `yaml.Unmarshal`, which have the same API in v3. No code changes beyond the import path were needed. All existing tests pass.